### PR TITLE
Add portfolio case-study templates

### DIFF
--- a/docs/portfolio/TEMPLATE.DigitalWeb.md
+++ b/docs/portfolio/TEMPLATE.DigitalWeb.md
@@ -1,0 +1,35 @@
+# {{Creation Name}}
+
+**Category:** Digital / Web
+
+## Overview
+{{Short description of the digital project (website, CRM, customer portal, etc.).}}
+
+## Problem Statement
+{{What user or business challenge did the digital product solve?}}
+
+## Mold — Process & Steps
+- {{Planning & information architecture}}
+- {{Design & front-end development}}
+- {{Back-end / integration work}}
+- {{Testing & deployment}}
+
+## Casts — Outcomes & Impact
+- {{Usage metrics, conversions, performance gains}}
+- {{Client or stakeholder feedback}}
+
+## Media
+```markdown
+![Screenshot](path/to/image)
+[Live Site](https://example.com)
+[Repository](https://github.com/example)
+```
+
+## Skills Applied
+- {{Languages / frameworks}}
+- {{UX / UI design}}
+- {{DevOps or hosting tools}}
+
+## Reforging — Iteration Notes
+- {{Next features or optimizations}}
+- {{Technical debt or refactoring targets}}

--- a/docs/portfolio/TEMPLATE.InnovationTechnical.md
+++ b/docs/portfolio/TEMPLATE.InnovationTechnical.md
@@ -1,0 +1,34 @@
+# {{Creation Name}}
+
+**Category:** Innovation / Technical
+
+## Overview
+{{Summary of the exploratory project (AI, SaaS, 3D printing, drones, etc.).}}
+
+## Problem Statement
+{{What technical frontier or efficiency problem was targeted?}}
+
+## Mold — Process & Steps
+- {{Research & prototyping}}
+- {{Technology stack or hardware setup}}
+- {{Testing & iterations}}
+- {{Deployment or demonstration}}
+
+## Casts — Outcomes & Impact
+- {{Proof-of-concept results, benchmarks, or user feedback}}
+- {{Business or innovation implications}}
+
+## Media
+```markdown
+![Prototype or diagram](path/to/image)
+[Demo or repository link](https://example.com)
+```
+
+## Skills Applied
+- {{Programming languages / frameworks}}
+- {{Hardware / fabrication skills}}
+- {{Data analysis or AI tools}}
+
+## Reforging — Iteration Notes
+- {{Next experiments or scaling plans}}
+- {{Risks or challenges to address}}

--- a/docs/portfolio/TEMPLATE.Marketing.md
+++ b/docs/portfolio/TEMPLATE.Marketing.md
@@ -1,0 +1,34 @@
+# {{Creation Name}}
+
+**Category:** Marketing Campaign
+
+## Overview
+{{Summary of the campaign (social, email, catalog, etc.).}}
+
+## Problem Statement
+{{What audience or conversion challenge was addressed?}}
+
+## Mold — Process & Steps
+- {{Research & audience segmentation}}
+- {{Campaign strategy & creative development}}
+- {{Channel execution schedule}}
+- {{Tracking & optimization}}
+
+## Casts — Outcomes & Impact
+- {{Reach, engagement, or sales metrics}}
+- {{ROI or cost per acquisition}}
+
+## Media
+```markdown
+![Ad or creative](path/to/image)
+[Campaign landing page](https://example.com)
+```
+
+## Skills Applied
+- {{Copywriting / design}}
+- {{Marketing automation tools}}
+- {{Analytics}}
+
+## Reforging — Iteration Notes
+- {{What tests informed future campaigns?}}
+- {{Adjustments for next launch}}

--- a/docs/portfolio/TEMPLATE.Master.md
+++ b/docs/portfolio/TEMPLATE.Master.md
@@ -1,0 +1,32 @@
+# {{Creation Name}}
+
+**Category:** {{Project Category}}
+
+## Overview
+{{Short description of the project.}}
+
+## Problem Statement
+{{What challenge did this creation address?}}
+
+## Mold — Process & Steps
+- {{Tool / decision / step}}
+- {{Tool / decision / step}}
+
+## Casts — Outcomes & Impact
+- {{Result or metric}}
+- {{Result or metric}}
+
+## Media
+```markdown
+![Image description](path/to/image)
+[Video Link](https://example.com)
+[Downloadable Asset](path/to/file)
+```
+
+## Skills Applied
+- {{Tool, software, or skill}}
+- {{Tool, software, or skill}}
+
+## Reforging — Iteration Notes
+- {{What was learned?}}
+- {{What could be improved in the next version?}}

--- a/docs/portfolio/TEMPLATE.MediaCreative.md
+++ b/docs/portfolio/TEMPLATE.MediaCreative.md
@@ -1,0 +1,34 @@
+# {{Creation Name}}
+
+**Category:** Media / Creative
+
+## Overview
+{{Brief description of the media piece (video, animation, photography, audio, etc.).}}
+
+## Problem Statement
+{{What story or message needed to be conveyed?}}
+
+## Mold — Process & Steps
+- {{Concept development & scripting}}
+- {{Pre-production planning}}
+- {{Production}}
+- {{Post-production / editing}}
+
+## Casts — Outcomes & Impact
+- {{View counts, engagement, or distribution results}}
+- {{Awards or recognition}}
+
+## Media
+```markdown
+![Still frame](path/to/image)
+[Video or audio link](https://example.com)
+```
+
+## Skills Applied
+- {{Cinematography / animation / recording}}
+- {{Editing software}}
+- {{Sound design or color grading}}
+
+## Reforging — Iteration Notes
+- {{Feedback for future revisions}}
+- {{Technical or creative lessons}}

--- a/docs/portfolio/TEMPLATE.PrintStudio.md
+++ b/docs/portfolio/TEMPLATE.PrintStudio.md
@@ -1,0 +1,33 @@
+# {{Creation Name}}
+
+**Category:** Print Studio
+
+## Overview
+{{Brief summary of the print project (vehicle wrap, T-shirt, signage, banner, etc.).}}
+
+## Problem Statement
+{{What physical or branding challenge needed a printed solution?}}
+
+## Mold — Process & Steps
+- {{Design setup (dimensions, bleed, color profile)}}
+- {{Material selection & proofing}}
+- {{Production workflow}}
+
+## Casts — Outcomes & Impact
+- {{Quantity produced, installation notes, client feedback}}
+- {{Measured impact such as visibility or sales}}
+
+## Media
+```markdown
+![Finished piece](path/to/image)
+[Press-ready file](path/to/file)
+```
+
+## Skills Applied
+- {{Graphic design software}}
+- {{Printing / finishing techniques}}
+- {{Project management}}
+
+## Reforging — Iteration Notes
+- {{What would improve the next run?}}
+- {{Lessons learned about materials or vendors}}

--- a/docs/portfolio/TEMPLATE.ProcessTraining.md
+++ b/docs/portfolio/TEMPLATE.ProcessTraining.md
@@ -1,0 +1,34 @@
+# {{Creation Name}}
+
+**Category:** Process / Training
+
+## Overview
+{{Description of the workflow or training resource created.}}
+
+## Problem Statement
+{{What process gap or knowledge deficit needed addressing?}}
+
+## Mold — Process & Steps
+- {{Research current procedures}}
+- {{Draft documentation or training materials}}
+- {{Pilot with users / trainees}}
+- {{Refine based on feedback}}
+
+## Casts — Outcomes & Impact
+- {{Efficiency gains, reduced errors, or training completion metrics}}
+- {{Qualitative feedback from users}}
+
+## Media
+```markdown
+![Process diagram or slide](path/to/image)
+[Document or training link](path/to/file)
+```
+
+## Skills Applied
+- {{Technical writing / documentation}}
+- {{Instructional design tools}}
+- {{Change management}}
+
+## Reforging — Iteration Notes
+- {{Follow-up updates or revision schedule}}
+- {{Additional resources to develop}}


### PR DESCRIPTION
## Summary
- add generic case-study template using PortfolioForge's forge metaphor
- provide specialized templates for print, digital/web, marketing, media, innovation, and process/training projects

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3356b0fbc832f8721796bab09e3c6