### PR TITLE
Add missing global stylesheet

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,46 @@
+/* src/index.css */
+
+/* CSS Reset */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+body {
+  min-height: 100vh;
+  text-rendering: optimizeSpeed;
+  line-height: 1.5;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  background-color: #f9fafb;
+  color: #1f2937;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+img, picture {
+  max-width: 100%;
+  display: block;
+}
+
+button {
+  font: inherit;
+}
+
+input, textarea, select {
+  font: inherit;
+}
+
+#root {
+  min-height: 100vh;
+}


### PR DESCRIPTION
## Summary
- add the missing global stylesheet imported by main.tsx to restore the build
- include a light reset and base typography/background styles for the app

## Testing
- `npm run build` *(fails: existing TypeScript error in src/components/portfolio-editor.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cc718e89d0832f8d9f5313a477ca0e