### PR TITLE
Add sorting controls to project file explorer

### DIFF
--- a/src/components/ProjectFileExplorer.tsx
+++ b/src/components/ProjectFileExplorer.tsx
@@ -1,125 +1,1009 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  ArrowUpDown,
+  Check,
+  CheckSquare,
+  Copy,
+  Edit2,
+  Eye,
+  EyeOff,
+  Filter,
+  FolderPlus,
+  Grid,
+  Image as ImageIcon,
+  FileText,
+  List,
+  Minus,
+  Move,
+  Music,
+  Search,
+  Star,
+  Tag,
+  Trash2,
+  Upload,
+  Video,
+  type LucideIcon,
+} from 'lucide-react'
 
 const PROJECT_GLOB = import.meta.glob('../../projects/**/*', {
   query: '?raw',
   import: 'default',
-})
+}) as Record<string, () => Promise<string>>
 
-type FileNode = {
+type FileVisibility = 'public' | 'private'
+
+type FileRecord = {
+  id: string
   name: string
-  path: string
-  type: 'file' | 'directory'
-  children?: FileNode[]
+  type: 'image' | 'video' | 'document' | 'audio' | 'other'
+  size: string
+  sizeBytes: number | null
+  tags: string[]
+  featured: boolean
+  project: string
+  uploadDate: string
+  visibility: FileVisibility
+  folder: string | null
+}
+
+type ActiveModal = 'move' | 'copy' | 'tag' | 'edit' | 'delete' | null
+
+type BulkEditData = {
+  tags: string
+  featured: boolean | null
+  visibility: '' | FileVisibility
 }
 
 type Props = {
   projectSlug: string
+  projectTitle?: string
 }
 
-function buildTree(slug: string): FileNode | null {
-  const prefix = `../../projects/${slug}`
-  const entries = Object.keys(PROJECT_GLOB).filter(path => path.startsWith(prefix))
-  if (entries.length === 0) {
-    return null
+const ICONS: Record<FileRecord['type'], LucideIcon> = {
+  image: ImageIcon,
+  video: Video,
+  document: FileText,
+  audio: Music,
+  other: FileText,
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '—'
   }
+  const units = ['B', 'KB', 'MB', 'GB']
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  const value = bytes / 1024 ** exponent
+  return value >= 10 || exponent === 0 ? `${value.toFixed(0)} ${units[exponent]}` : `${value.toFixed(1)} ${units[exponent]}`
+}
 
-  const root: FileNode = {
-    name: slug,
-    path: slug,
-    type: 'directory',
-    children: [],
+function slugToTitle(slug: string): string {
+  return slug
+    .replace(/[-_]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, char => char.toUpperCase())
+}
+
+function generateAccentColour(slug: string): string {
+  let hash = 0
+  for (let index = 0; index < slug.length; index += 1) {
+    hash = slug.charCodeAt(index) + ((hash << 5) - hash)
   }
+  const hue = Math.abs(hash) % 360
+  return `hsl(${hue}, 70%, 55%)`
+}
 
-  entries.forEach(fullPath => {
-    const relative = fullPath.slice(prefix.length + 1)
-    if (!relative) {
-      return
-    }
-    const segments = relative.split('/')
-    let current = root
+function guessFileType(fileName: string): FileRecord['type'] {
+  const extension = fileName.split('.').pop()?.toLowerCase()
+  if (!extension) {
+    return 'document'
+  }
+  if (['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp'].includes(extension)) {
+    return 'image'
+  }
+  if (['mp4', 'mov', 'webm', 'avi', 'mkv'].includes(extension)) {
+    return 'video'
+  }
+  if (['mp3', 'wav', 'ogg', 'flac'].includes(extension)) {
+    return 'audio'
+  }
+  return 'document'
+}
 
-    segments.forEach((segment, index) => {
-      const isFile = index === segments.length - 1
-      if (isFile) {
-        current.children = current.children ?? []
-        const exists = current.children.some(child => child.type === 'file' && child.name === segment)
-        if (!exists) {
-          current.children.push({
-            name: segment,
-            path: `${slug}/${relative}`,
-            type: 'file',
-          })
-        }
-      } else {
-        current.children = current.children ?? []
-        let next = current.children.find(
-          child => child.type === 'directory' && child.name === segment,
-        ) as FileNode | undefined
+function normaliseTag(value: string): string {
+  return value
+    .replace(/[-_]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
 
-        if (!next) {
-          next = {
-            name: segment,
-            path: `${slug}/${segments.slice(0, index + 1).join('/')}`,
-            type: 'directory',
-            children: [],
-          }
-          current.children.push(next)
-        }
-        current = next
-      }
-    })
+export default function ProjectFileExplorer({ projectSlug, projectTitle }: Props) {
+  const [files, setFiles] = useState<FileRecord[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid')
+  const [selectedFiles, setSelectedFiles] = useState<string[]>([])
+  const [selectMode, setSelectMode] = useState(false)
+  const [activeModal, setActiveModal] = useState<ActiveModal>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [filterTags, setFilterTags] = useState<string[]>([])
+  const [sortBy, setSortBy] = useState<'name' | 'size' | 'type' | 'visibility' | 'folder'>('name')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+  const [showProgress, setShowProgress] = useState(false)
+  const [operationProgress, setOperationProgress] = useState(0)
+  const [currentOperation, setCurrentOperation] = useState('')
+  const [bulkEditData, setBulkEditData] = useState<BulkEditData>({
+    tags: '',
+    featured: null,
+    visibility: '',
   })
+  const [tagInput, setTagInput] = useState('')
+  const [moveTargetFolder, setMoveTargetFolder] = useState('')
+  const [copyTargetFolder, setCopyTargetFolder] = useState('')
+  const [newFolderName, setNewFolderName] = useState('')
+  const [customFolders, setCustomFolders] = useState<string[]>([])
 
-  const sortNodes = (nodes?: FileNode[]) => {
-    if (!nodes) return
-    nodes.sort((a, b) => {
-      if (a.type === b.type) {
-        return a.name.localeCompare(b.name)
+  useEffect(() => {
+    let cancelled = false
+
+    const loadFiles = async () => {
+      setIsLoading(true)
+      const prefix = `../../projects/${projectSlug}`
+      const projectEntries = Object.keys(PROJECT_GLOB).filter(path => path.startsWith(prefix))
+
+      if (projectEntries.length === 0) {
+        if (!cancelled) {
+          setFiles([])
+          setIsLoading(false)
+        }
+        return
       }
-      return a.type === 'directory' ? -1 : 1
+
+      try {
+        const entries = await Promise.all(
+          projectEntries.map(async path => {
+            const relativePath = path.slice(prefix.length + 1)
+            if (!relativePath) {
+              return null
+            }
+
+            const segments = relativePath.split('/')
+            const fileName = segments[segments.length - 1]
+            const folder = segments.length > 1 ? segments.slice(0, -1).join('/') : null
+
+            let size = '—'
+            let sizeBytes: number | null = null
+            try {
+              const loader = PROJECT_GLOB[path]
+              const contents = await loader()
+              const byteLength = new TextEncoder().encode(contents).length
+              size = formatBytes(byteLength)
+              sizeBytes = byteLength
+            } catch (error) {
+              console.warn('Unable to determine file size for', path, error)
+            }
+
+            const tags = segments
+              .slice(0, -1)
+              .map(segment => normaliseTag(segment))
+              .filter(Boolean)
+
+            const record: FileRecord = {
+              id: `${projectSlug}/${relativePath}`,
+              name: fileName,
+              type: guessFileType(fileName),
+              size,
+              sizeBytes,
+              tags,
+              featured: false,
+              project: projectSlug,
+              uploadDate: '—',
+              visibility: 'public',
+              folder,
+            }
+
+            return record
+          }),
+        )
+
+        if (!cancelled) {
+          const filteredEntries = entries.filter((entry): entry is FileRecord => Boolean(entry))
+          filteredEntries.sort((a, b) => a.name.localeCompare(b.name))
+          setFiles(filteredEntries)
+          setIsLoading(false)
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Unable to load files for project', projectSlug, error)
+          setFiles([])
+          setIsLoading(false)
+        }
+      }
+    }
+
+    loadFiles()
+
+    return () => {
+      cancelled = true
+    }
+  }, [projectSlug])
+
+  useEffect(() => {
+    setSelectedFiles([])
+    setSelectMode(false)
+    setFilterTags([])
+    setSearchQuery('')
+    setSortBy('name')
+    setSortOrder('asc')
+    setTagInput('')
+    setBulkEditData({ tags: '', featured: null, visibility: '' })
+    setMoveTargetFolder('')
+    setCopyTargetFolder('')
+    setNewFolderName('')
+    setCustomFolders([])
+  }, [projectSlug])
+
+  useEffect(() => {
+    setSelectedFiles(previous => previous.filter(id => files.some(file => file.id === id)))
+  }, [files])
+
+  const allTags = useMemo(() => {
+    const tagSet = new Set<string>()
+    files.forEach(file => {
+      file.tags.forEach(tag => tagSet.add(tag))
     })
-    nodes.forEach(node => sortNodes(node.children))
-  }
+    return Array.from(tagSet).sort((a, b) => a.localeCompare(b))
+  }, [files])
 
-  sortNodes(root.children)
+  const allFolders = useMemo(() => {
+    const folderSet = new Set<string>()
+    files.forEach(file => {
+      if (file.folder) {
+        const segments = file.folder.split('/')
+        segments.forEach((_, index) => {
+          folderSet.add(segments.slice(0, index + 1).join('/'))
+        })
+      }
+    })
+    customFolders.forEach(folder => folderSet.add(folder))
+    return Array.from(folderSet).sort((a, b) => a.localeCompare(b))
+  }, [files, customFolders])
 
-  return root
-}
+  const filteredFiles = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+    const filtered = files.filter(file => {
+      const matchesQuery =
+        query.length === 0 ||
+        file.name.toLowerCase().includes(query) ||
+        file.tags.some(tag => tag.toLowerCase().includes(query))
+      const matchesTags = filterTags.length === 0 || filterTags.every(tag => file.tags.includes(tag))
+      return matchesQuery && matchesTags
+    })
+    const sorted = [...filtered].sort((a, b) => {
+      let comparison = 0
+      switch (sortBy) {
+        case 'size': {
+          const aSize = a.sizeBytes ?? -1
+          const bSize = b.sizeBytes ?? -1
+          comparison = aSize - bSize
+          break
+        }
+        case 'type':
+          comparison = a.type.localeCompare(b.type)
+          break
+        case 'visibility':
+          comparison = a.visibility.localeCompare(b.visibility)
+          break
+        case 'folder':
+          comparison = (a.folder ?? '').localeCompare(b.folder ?? '')
+          break
+        case 'name':
+        default:
+          comparison = a.name.localeCompare(b.name)
+          break
+      }
 
-const renderNodes = (nodes: FileNode[] | undefined) => {
-  if (!nodes || nodes.length === 0) {
-    return null
-  }
-  return (
-    <ul className="file-tree__list">
-      {nodes.map(node => (
-        <li key={node.path} className={`file-tree__item file-tree__item--${node.type}`}>
-          <span title={node.path}>{node.name}</span>
-          {renderNodes(node.children)}
-        </li>
-      ))}
-    </ul>
-  )
-}
+      if (comparison === 0 && sortBy !== 'name') {
+        comparison = a.name.localeCompare(b.name)
+      }
 
-export default function ProjectFileExplorer({ projectSlug }: Props) {
-  const tree = useMemo(() => buildTree(projectSlug), [projectSlug])
+      return sortOrder === 'asc' ? comparison : -comparison
+    })
+    return sorted
+  }, [files, searchQuery, filterTags, sortBy, sortOrder])
 
-  if (!tree || !tree.children || tree.children.length === 0) {
-    return (
-      <div className="file-tree file-tree--empty">
-        <p>No files detected for <strong>{projectSlug}</strong>. Drop assets into <code>projects/{projectSlug}</code> to see them here.</p>
-      </div>
+  const projectName = projectTitle ?? slugToTitle(projectSlug)
+  const projectAccent = useMemo(() => generateAccentColour(projectSlug), [projectSlug])
+  const hasSelection = selectedFiles.length > 0
+  const selectionCount = selectedFiles.length
+  const isAllSelected = filteredFiles.length > 0 && filteredFiles.every(file => selectedFiles.includes(file.id))
+
+  const handleFileSelect = (fileId: string) => {
+    setSelectedFiles(previous =>
+      previous.includes(fileId)
+        ? previous.filter(id => id !== fileId)
+        : [...previous, fileId],
     )
   }
 
-  return (
-    <div className="file-tree">
-      <div className="file-tree__header">
-        <h3>Local file structure</h3>
-        <p className="file-tree__summary">{tree.children.length} top-level folder{tree.children.length === 1 ? '' : 's'}</p>
+  const handleSelectAll = () => {
+    if (isAllSelected) {
+      setSelectedFiles([])
+    } else {
+      setSelectedFiles(filteredFiles.map(file => file.id))
+    }
+  }
+
+  const handleSelectNone = () => {
+    setSelectedFiles([])
+    setSelectMode(false)
+  }
+
+  const simulateOperation = async (operationName: string) => {
+    setCurrentOperation(operationName)
+    setShowProgress(true)
+    setOperationProgress(0)
+
+    for (let progress = 0; progress <= 100; progress += 10) {
+      setOperationProgress(progress)
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, 120))
+    }
+
+    setTimeout(() => {
+      setShowProgress(false)
+      setCurrentOperation('')
+      setActiveModal(null)
+      setSelectedFiles([])
+      setSelectMode(false)
+    }, 600)
+  }
+
+  const handleBulkMove = async () => {
+    await simulateOperation(`Moving ${selectionCount} file${selectionCount === 1 ? '' : 's'}`)
+    setMoveTargetFolder('')
+  }
+
+  const handleBulkCopy = async () => {
+    await simulateOperation(`Copying ${selectionCount} file${selectionCount === 1 ? '' : 's'}`)
+    setCopyTargetFolder('')
+  }
+
+  const handleBulkDelete = async () => {
+    await simulateOperation(`Deleting ${selectionCount} file${selectionCount === 1 ? '' : 's'}`)
+  }
+
+  const handleBulkTag = async () => {
+    await simulateOperation(`Tagging ${selectionCount} file${selectionCount === 1 ? '' : 's'}`)
+    setTagInput('')
+  }
+
+  const handleBulkEdit = async () => {
+    await simulateOperation(`Updating ${selectionCount} file${selectionCount === 1 ? '' : 's'}`)
+    setBulkEditData({ tags: '', featured: null, visibility: '' })
+  }
+
+  const addCustomFolder = () => {
+    const value = newFolderName.trim()
+    if (!value) {
+      return
+    }
+    setCustomFolders(previous => (previous.includes(value) ? previous : [...previous, value]))
+    if (activeModal === 'move') {
+      setMoveTargetFolder(value)
+    }
+    if (activeModal === 'copy') {
+      setCopyTargetFolder(value)
+    }
+    setNewFolderName('')
+  }
+
+  const BulkActionBar = () => (
+    <div className="file-explorer__bulk-bar" aria-live="polite">
+      <div className="file-explorer__bulk-bar__selection">
+        <span className="file-explorer__bulk-bar__count">{selectionCount} selected</span>
+        <button type="button" className="file-explorer__bulk-bar__clear" onClick={handleSelectNone}>
+          Clear
+        </button>
       </div>
-      {renderNodes(tree.children)}
+      <div className="file-explorer__bulk-bar__divider" aria-hidden="true" />
+      <div className="file-explorer__bulk-bar__actions">
+        <button type="button" className="file-explorer__chip-button" onClick={() => setActiveModal('move')}>
+          <Move size={16} /> Move
+        </button>
+        <button type="button" className="file-explorer__chip-button" onClick={() => setActiveModal('copy')}>
+          <Copy size={16} /> Copy
+        </button>
+        <button type="button" className="file-explorer__chip-button" onClick={() => setActiveModal('tag')}>
+          <Tag size={16} /> Tag
+        </button>
+        <button type="button" className="file-explorer__chip-button" onClick={() => setActiveModal('edit')}>
+          <Edit2 size={16} /> Edit
+        </button>
+        <button
+          type="button"
+          className="file-explorer__chip-button file-explorer__chip-button--danger"
+          onClick={() => setActiveModal('delete')}
+        >
+          <Trash2 size={16} /> Delete
+        </button>
+      </div>
+    </div>
+  )
+
+  const renderGrid = () => (
+    <div className="file-explorer__grid" role="list">
+      {filteredFiles.map(file => {
+        const Icon = ICONS[file.type]
+        const isSelected = selectedFiles.includes(file.id)
+        return (
+          <div
+            key={file.id}
+            role="listitem"
+            className={`file-card${isSelected ? ' file-card--selected' : ''}${selectMode ? ' file-card--selectable' : ''}`}
+            onClick={() => {
+              if (selectMode) {
+                handleFileSelect(file.id)
+              }
+            }}
+          >
+            {selectMode && (
+              <button
+                type="button"
+                className={`file-card__checkbox${isSelected ? ' file-card__checkbox--checked' : ''}`}
+                onClick={event => {
+                  event.stopPropagation()
+                  handleFileSelect(file.id)
+                }}
+                aria-pressed={isSelected}
+                aria-label={isSelected ? `Deselect ${file.name}` : `Select ${file.name}`}
+              >
+                <Check size={16} />
+              </button>
+            )}
+            <div className="file-card__preview" aria-hidden="true">
+              <Icon size={28} />
+            </div>
+            <div className="file-card__info">
+              <div className="file-card__title-row">
+                <span className="file-card__name" title={file.name}>
+                  {file.name}
+                </span>
+                {file.featured && <Star size={14} className="file-card__featured" aria-label="Featured asset" />}
+              </div>
+              <div className="file-card__meta">
+                <span>{file.size}</span>
+                <span>{file.visibility === 'public' ? <Eye size={14} /> : <EyeOff size={14} />}</span>
+              </div>
+              <div className="file-card__project" aria-label={`Project ${projectName}`}>
+                <span className="file-card__project-indicator" style={{ backgroundColor: projectAccent }} />
+                <span>{projectName}</span>
+              </div>
+              {file.tags.length > 0 && (
+                <div className="file-card__tags">
+                  {file.tags.slice(0, 2).map(tag => (
+                    <span key={tag} className="file-card__tag">
+                      {tag}
+                    </span>
+                  ))}
+                  {file.tags.length > 2 && <span className="file-card__tag">+{file.tags.length - 2}</span>}
+                </div>
+              )}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+
+  const renderList = () => (
+    <div className="file-explorer__list" role="table">
+      <div className="file-explorer__list-header" role="row">
+        <div role="columnheader">{selectMode ? <Check size={16} aria-hidden="true" /> : null}</div>
+        <div role="columnheader">Name</div>
+        <div role="columnheader">Folder</div>
+        <div role="columnheader">Size</div>
+        <div role="columnheader">Tags</div>
+        <div role="columnheader">Visibility</div>
+      </div>
+      {filteredFiles.map(file => {
+        const Icon = ICONS[file.type]
+        const isSelected = selectedFiles.includes(file.id)
+        return (
+          <div
+            key={file.id}
+            role="row"
+            className={`file-row${isSelected ? ' file-row--selected' : ''}`}
+            onClick={() => {
+              if (selectMode) {
+                handleFileSelect(file.id)
+              }
+            }}
+          >
+            <div role="cell" className="file-row__select">
+              {selectMode ? (
+                <button
+                  type="button"
+                  className={`file-row__checkbox${isSelected ? ' file-row__checkbox--checked' : ''}`}
+                  onClick={event => {
+                    event.stopPropagation()
+                    handleFileSelect(file.id)
+                  }}
+                  aria-pressed={isSelected}
+                  aria-label={isSelected ? `Deselect ${file.name}` : `Select ${file.name}`}
+                >
+                  <Check size={16} />
+                </button>
+              ) : (
+                <span className="file-row__icon" aria-hidden="true">
+                  <Icon size={18} />
+                </span>
+              )}
+            </div>
+            <div role="cell" className="file-row__name" title={file.id}>
+              <span>{file.name}</span>
+              {file.featured && <Star size={14} className="file-card__featured" aria-label="Featured asset" />}
+            </div>
+            <div role="cell" className="file-row__folder">
+              {file.folder ? file.folder : '—'}
+            </div>
+            <div role="cell" className="file-row__size">
+              {file.size}
+            </div>
+            <div role="cell" className="file-row__tags">
+              {file.tags.length > 0 ? file.tags.join(', ') : '—'}
+            </div>
+            <div role="cell" className="file-row__visibility">
+              {file.visibility === 'public' ? <Eye size={16} aria-label="Public" /> : <EyeOff size={16} aria-label="Private" />}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+
+  return (
+    <div className="file-explorer">
+      <header className="file-explorer__header">
+        <div className="file-explorer__header-copy">
+          <p className="file-explorer__eyebrow">Asset workspace</p>
+          <h2 className="file-explorer__title">{projectName}</h2>
+          <p className="file-explorer__subtitle">
+            {filteredFiles.length} file{filteredFiles.length === 1 ? '' : 's'} · {selectionCount} selected
+          </p>
+        </div>
+        <div className="file-explorer__header-actions">
+          <button
+            type="button"
+            className={`file-explorer__button${selectMode ? ' file-explorer__button--active' : ''}`}
+            onClick={() => {
+              if (selectMode) {
+                setSelectMode(false)
+                setSelectedFiles([])
+              } else {
+                setSelectMode(true)
+              }
+            }}
+          >
+            {selectMode ? 'Exit select' : 'Select mode'}
+          </button>
+          <button type="button" className="file-explorer__button file-explorer__button--primary">
+            <Upload size={16} /> Upload files
+          </button>
+        </div>
+      </header>
+
+      <div className="file-explorer__controls">
+        <label className="file-explorer__search">
+          <Search size={18} aria-hidden="true" />
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={event => setSearchQuery(event.target.value)}
+            placeholder="Search files or tags"
+          />
+        </label>
+        <div className="file-explorer__control-buttons">
+          {selectMode && (
+            <button type="button" className="file-explorer__button" onClick={handleSelectAll}>
+              {isAllSelected ? (
+                <>
+                  <Minus size={16} /> Deselect all
+                </>
+              ) : (
+                <>
+                  <CheckSquare size={16} /> Select all
+                </>
+              )}
+            </button>
+          )}
+          <button type="button" className="file-explorer__button" aria-label="Filter files">
+            <Filter size={16} />
+          </button>
+          <div className="file-explorer__view-toggle" role="radiogroup" aria-label="Toggle file view">
+            <button
+              type="button"
+              className={`file-explorer__view-button${viewMode === 'grid' ? ' file-explorer__view-button--active' : ''}`}
+              onClick={() => setViewMode('grid')}
+              aria-pressed={viewMode === 'grid'}
+            >
+              <Grid size={16} />
+            </button>
+            <button
+              type="button"
+              className={`file-explorer__view-button${viewMode === 'list' ? ' file-explorer__view-button--active' : ''}`}
+              onClick={() => setViewMode('list')}
+              aria-pressed={viewMode === 'list'}
+            >
+              <List size={16} />
+            </button>
+          </div>
+          <div className="file-explorer__sort" role="group" aria-label="Sort files">
+            <label className="file-explorer__sort-label">
+              <span>Sort by</span>
+              <select
+                className="file-explorer__select"
+                value={sortBy}
+                onChange={event => setSortBy(event.target.value as typeof sortBy)}
+              >
+                <option value="name">Name</option>
+                <option value="folder">Folder</option>
+                <option value="size">Size</option>
+                <option value="type">Type</option>
+                <option value="visibility">Visibility</option>
+              </select>
+            </label>
+            <button
+              type="button"
+              className={`file-explorer__button${sortOrder === 'desc' ? ' file-explorer__button--active' : ''}`}
+              onClick={() => setSortOrder(previous => (previous === 'asc' ? 'desc' : 'asc'))}
+              aria-label={`Sort ${sortOrder === 'asc' ? 'descending' : 'ascending'}`}
+            >
+              <ArrowUpDown size={16} />
+              {sortOrder === 'asc' ? 'Asc' : 'Desc'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {allTags.length > 0 && (
+        <div className="file-explorer__filters" aria-label="Quick tag filters">
+          {allTags.map(tag => {
+            const isActive = filterTags.includes(tag)
+            return (
+              <button
+                key={tag}
+                type="button"
+                className={`file-explorer__chip${isActive ? ' file-explorer__chip--active' : ''}`}
+                onClick={() =>
+                  setFilterTags(previous =>
+                    previous.includes(tag)
+                      ? previous.filter(activeTag => activeTag !== tag)
+                      : [...previous, tag],
+                  )
+                }
+              >
+                {tag}
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      <section className="file-explorer__content" aria-live="polite">
+        {isLoading && <div className="file-explorer__state">Loading project files…</div>}
+        {!isLoading && filteredFiles.length === 0 && files.length === 0 && (
+          <div className="file-explorer__state file-explorer__state--empty">
+            <p>
+              No files detected for this project. Add assets to the <code>projects/{projectSlug}</code> directory to get started.
+            </p>
+          </div>
+        )}
+        {!isLoading && filteredFiles.length === 0 && files.length > 0 && (
+          <div className="file-explorer__state">No files match the current filters.</div>
+        )}
+        {!isLoading && filteredFiles.length > 0 && (viewMode === 'grid' ? renderGrid() : renderList())}
+      </section>
+
+      {hasSelection && <BulkActionBar />}
+
+      {showProgress && (
+        <div className="file-explorer__modal-backdrop" role="dialog" aria-modal="true" aria-live="polite">
+          <div className="file-explorer__modal file-explorer__modal--progress">
+            <h3>{currentOperation}</h3>
+            <div className="file-explorer__progress">
+              <div className="file-explorer__progress-bar" style={{ width: `${operationProgress}%` }} />
+            </div>
+            <p>{operationProgress}% complete</p>
+          </div>
+        </div>
+      )}
+
+      {activeModal === 'move' && (
+        <div className="file-explorer__modal-backdrop" role="dialog" aria-modal="true">
+          <div className="file-explorer__modal">
+            <div className="file-explorer__modal-header">
+              <h3 className="file-explorer__modal-title">Move {selectionCount} selected file{selectionCount === 1 ? '' : 's'}</h3>
+              <button type="button" className="file-explorer__icon-button" onClick={() => setActiveModal(null)}>
+                <span className="sr-only">Close</span>
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <div className="file-explorer__modal-content">
+              <label className="file-explorer__field">
+                <span>Destination folder</span>
+                <select value={moveTargetFolder} onChange={event => setMoveTargetFolder(event.target.value)}>
+                  <option value="">Top level</option>
+                  {allFolders.map(folder => (
+                    <option key={folder} value={folder}>
+                      {folder}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="file-explorer__field file-explorer__field--inline">
+                <label className="file-explorer__field">
+                  <span>Create new folder</span>
+                  <input
+                    type="text"
+                    value={newFolderName}
+                    onChange={event => setNewFolderName(event.target.value)}
+                    placeholder="e.g. moodboards"
+                  />
+                </label>
+                <button type="button" className="file-explorer__button" onClick={addCustomFolder}>
+                  <FolderPlus size={16} />
+                  Add
+                </button>
+              </div>
+            </div>
+            <div className="file-explorer__modal-actions">
+              <button type="button" className="file-explorer__button" onClick={() => setActiveModal(null)}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="file-explorer__button file-explorer__button--primary"
+                disabled={moveTargetFolder === '' && newFolderName.trim().length === 0}
+                onClick={handleBulkMove}
+              >
+                Move files
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeModal === 'copy' && (
+        <div className="file-explorer__modal-backdrop" role="dialog" aria-modal="true">
+          <div className="file-explorer__modal">
+            <div className="file-explorer__modal-header">
+              <h3 className="file-explorer__modal-title">Copy {selectionCount} selected file{selectionCount === 1 ? '' : 's'}</h3>
+              <button type="button" className="file-explorer__icon-button" onClick={() => setActiveModal(null)}>
+                <span className="sr-only">Close</span>
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <div className="file-explorer__modal-content">
+              <label className="file-explorer__field">
+                <span>Destination folder</span>
+                <select value={copyTargetFolder} onChange={event => setCopyTargetFolder(event.target.value)}>
+                  <option value="">Top level</option>
+                  {allFolders.map(folder => (
+                    <option key={folder} value={folder}>
+                      {folder}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="file-explorer__field file-explorer__field--inline">
+                <label className="file-explorer__field">
+                  <span>Create new folder</span>
+                  <input
+                    type="text"
+                    value={newFolderName}
+                    onChange={event => setNewFolderName(event.target.value)}
+                    placeholder="e.g. deliverables"
+                  />
+                </label>
+                <button type="button" className="file-explorer__button" onClick={addCustomFolder}>
+                  <FolderPlus size={16} />
+                  Add
+                </button>
+              </div>
+            </div>
+            <div className="file-explorer__modal-actions">
+              <button type="button" className="file-explorer__button" onClick={() => setActiveModal(null)}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="file-explorer__button file-explorer__button--primary"
+                disabled={copyTargetFolder === '' && newFolderName.trim().length === 0}
+                onClick={handleBulkCopy}
+              >
+                Copy files
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeModal === 'edit' && (
+        <div className="file-explorer__modal-backdrop" role="dialog" aria-modal="true">
+          <div className="file-explorer__modal file-explorer__modal--large">
+            <div className="file-explorer__modal-header">
+              <h3 className="file-explorer__modal-title">Bulk edit {selectionCount} file{selectionCount === 1 ? '' : 's'}</h3>
+              <button type="button" className="file-explorer__icon-button" onClick={() => setActiveModal(null)}>
+                <span className="sr-only">Close</span>
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <div className="file-explorer__modal-content file-explorer__modal-content--grid">
+              <label className="file-explorer__field file-explorer__field--full">
+                <span>Add tags</span>
+                <input
+                  type="text"
+                  value={bulkEditData.tags}
+                  onChange={event => setBulkEditData(previous => ({ ...previous, tags: event.target.value }))}
+                  placeholder="ui, demo, final"
+                />
+              </label>
+              <label className="file-explorer__field">
+                <span>Featured status</span>
+                <select
+                  value={bulkEditData.featured === null ? '' : bulkEditData.featured ? 'true' : 'false'}
+                  onChange={event =>
+                    setBulkEditData(previous => ({
+                      ...previous,
+                      featured: event.target.value === '' ? null : event.target.value === 'true',
+                    }))
+                  }
+                >
+                  <option value="">No change</option>
+                  <option value="true">Mark as featured</option>
+                  <option value="false">Remove featured</option>
+                </select>
+              </label>
+              <label className="file-explorer__field">
+                <span>Visibility</span>
+                <select
+                  value={bulkEditData.visibility}
+                  onChange={event =>
+                    setBulkEditData(previous => ({
+                      ...previous,
+                      visibility: event.target.value as BulkEditData['visibility'],
+                    }))
+                  }
+                >
+                  <option value="">No change</option>
+                  <option value="public">Public</option>
+                  <option value="private">Private</option>
+                </select>
+              </label>
+            </div>
+            <div className="file-explorer__modal-actions">
+              <button type="button" className="file-explorer__button" onClick={() => setActiveModal(null)}>
+                Cancel
+              </button>
+              <button type="button" className="file-explorer__button file-explorer__button--primary" onClick={handleBulkEdit}>
+                Update files
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeModal === 'tag' && (
+        <div className="file-explorer__modal-backdrop" role="dialog" aria-modal="true">
+          <div className="file-explorer__modal">
+            <div className="file-explorer__modal-header">
+              <h3 className="file-explorer__modal-title">Tag {selectionCount} file{selectionCount === 1 ? '' : 's'}</h3>
+              <button type="button" className="file-explorer__icon-button" onClick={() => setActiveModal(null)}>
+                <span className="sr-only">Close</span>
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <div className="file-explorer__modal-content">
+              <label className="file-explorer__field">
+                <span>Add tags</span>
+                <input
+                  type="text"
+                  value={tagInput}
+                  onChange={event => setTagInput(event.target.value)}
+                  placeholder="ui, hero, iteration"
+                />
+              </label>
+              {allTags.length > 0 && (
+                <div className="file-explorer__tag-suggestions">
+                  <p>Suggested tags</p>
+                  <div className="file-explorer__tag-suggestions-list">
+                    {allTags.slice(0, 8).map(tag => (
+                      <button
+                        key={tag}
+                        type="button"
+                        onClick={() => {
+                          const parts = tagInput
+                            .split(',')
+                            .map(value => normaliseTag(value))
+                            .filter(Boolean)
+                          if (!parts.includes(tag)) {
+                            setTagInput(parts.length > 0 ? `${parts.join(', ')}, ${tag}` : tag)
+                          }
+                        }}
+                      >
+                        {tag}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+            <div className="file-explorer__modal-actions">
+              <button type="button" className="file-explorer__button" onClick={() => setActiveModal(null)}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="file-explorer__button file-explorer__button--primary"
+                onClick={handleBulkTag}
+                disabled={tagInput.trim().length === 0}
+              >
+                Add tags
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeModal === 'delete' && (
+        <div className="file-explorer__modal-backdrop" role="dialog" aria-modal="true">
+          <div className="file-explorer__modal file-explorer__modal--danger">
+            <div className="file-explorer__modal-header">
+              <div className="file-explorer__modal-icon">
+                <AlertTriangle size={22} />
+              </div>
+              <div>
+                <h3 className="file-explorer__modal-title">Delete files</h3>
+                <p>These assets will be removed from the project workspace.</p>
+              </div>
+              <button type="button" className="file-explorer__icon-button" onClick={() => setActiveModal(null)}>
+                <span className="sr-only">Close</span>
+                <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+            <p className="file-explorer__modal-copy">
+              Are you sure you want to delete {selectionCount} selected file{selectionCount === 1 ? '' : 's'}? This action cannot be
+              undone.
+            </p>
+            <div className="file-explorer__modal-actions">
+              <button type="button" className="file-explorer__button" onClick={() => setActiveModal(null)}>
+                Cancel
+              </button>
+              <button type="button" className="file-explorer__button file-explorer__button--danger" onClick={handleBulkDelete}>
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
+

--- a/src/index.css
+++ b/src/index.css
@@ -375,6 +375,775 @@ input, textarea, select {
   gap: 1rem;
 }
 
+.editor-page__card--files {
+  grid-column: 1 / -1;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+  display: block;
+}
+
+.editor-page__card--files > .file-explorer {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.file-explorer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.file-explorer__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.file-explorer__header-copy {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.file-explorer__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  color: #6b7280;
+  font-weight: 600;
+}
+
+.file-explorer__title {
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  font-weight: 600;
+  color: #111827;
+}
+
+.file-explorer__subtitle {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+.file-explorer__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.file-explorer__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  color: #1f2937;
+  font-weight: 600;
+  font-size: 0.92rem;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.file-explorer__button:hover {
+  background: #e5e7eb;
+  border-color: #cbd5f5;
+}
+
+.file-explorer__button--primary {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #f9fafb;
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.35);
+}
+
+.file-explorer__button--primary:hover {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+
+.file-explorer__button--danger {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.file-explorer__button--danger:hover {
+  background: #fecaca;
+  border-color: #fca5a5;
+}
+
+.file-explorer__button--active {
+  background: #111827;
+  border-color: #111827;
+  color: #f9fafb;
+  box-shadow: 0 16px 28px rgba(17, 24, 39, 0.25);
+}
+
+.file-explorer__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.file-explorer__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 1 260px;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 0.4rem 0.6rem 0.4rem 0.8rem;
+  background: #f9fafb;
+}
+
+.file-explorer__search svg {
+  color: #6b7280;
+}
+
+.file-explorer__search input {
+  border: none;
+  background: transparent;
+  width: 100%;
+  font-size: 0.95rem;
+  color: #111827;
+}
+
+.file-explorer__search input:focus {
+  outline: none;
+}
+
+.file-explorer__control-buttons {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.file-explorer__view-toggle {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  gap: 0.25rem;
+}
+
+.file-explorer__view-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.file-explorer__view-button:hover {
+  background: rgba(37, 99, 235, 0.08);
+  color: #2563eb;
+}
+
+.file-explorer__sort {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.file-explorer__sort-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.file-explorer__select {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.4rem 0.75rem;
+  background: #ffffff;
+  color: #1f2937;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.file-explorer__select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  background: #ffffff;
+}
+
+.file-explorer__view-button--active {
+  background: #2563eb;
+  color: #f9fafb;
+}
+
+.file-explorer__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.file-explorer__chip {
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  background: #ffffff;
+  padding: 0.3rem 0.8rem;
+  font-size: 0.85rem;
+  color: #374151;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.file-explorer__chip:hover {
+  background: #111827;
+  border-color: #111827;
+  color: #f9fafb;
+}
+
+.file-explorer__chip--active {
+  background: #111827;
+  border-color: #111827;
+  color: #f9fafb;
+  box-shadow: 0 10px 20px rgba(17, 24, 39, 0.2);
+}
+
+.file-explorer__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.file-explorer__state {
+  background: #f3f4f6;
+  border: 1px dashed #d1d5db;
+  border-radius: 14px;
+  padding: 1.25rem;
+  color: #4b5563;
+  text-align: center;
+}
+
+.file-explorer__state--empty {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #3730a3;
+}
+
+.file-explorer__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+}
+
+.file-card {
+  position: relative;
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.file-card:hover {
+  border-color: #c7d2fe;
+  box-shadow: 0 16px 26px rgba(99, 102, 241, 0.18);
+  transform: translateY(-2px);
+}
+
+.file-card--selectable {
+  cursor: pointer;
+}
+
+.file-card--selected {
+  border-color: #2563eb;
+  background: #eff6ff;
+  box-shadow: 0 20px 32px rgba(37, 99, 235, 0.2);
+}
+
+.file-card__checkbox {
+  position: absolute;
+  top: 0.8rem;
+  left: 0.8rem;
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  border: 2px solid #9ca3af;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  color: #ffffff;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.file-card__checkbox--checked {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #f9fafb;
+}
+
+.file-card__preview {
+  height: 120px;
+  border-radius: 12px;
+  background: #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+}
+
+.file-card__info {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.file-card__title-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.file-card__name {
+  font-weight: 600;
+  color: #111827;
+  font-size: 0.95rem;
+  word-break: break-word;
+}
+
+.file-card__featured {
+  color: #f59e0b;
+}
+
+.file-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.file-card__project {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.file-card__project-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.file-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.file-card__tag {
+  background: #e5e7eb;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.7rem;
+  color: #374151;
+}
+
+.file-explorer__list {
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+.file-explorer__list-header {
+  display: grid;
+  grid-template-columns: 44px 2fr 1.3fr 1fr 1.5fr 0.9fr;
+  padding: 0.85rem 1.1rem;
+  background: #f3f4f6;
+  font-size: 0.8rem;
+  color: #4b5563;
+  font-weight: 600;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.file-row {
+  display: grid;
+  grid-template-columns: 44px 2fr 1.3fr 1fr 1.5fr 0.9fr;
+  align-items: center;
+  padding: 0.85rem 1.1rem;
+  gap: 0.75rem;
+  border-top: 1px solid #e5e7eb;
+  background: #ffffff;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.file-row:first-of-type {
+  border-top: none;
+}
+
+.file-row:hover {
+  background: #f9fafb;
+}
+
+.file-row--selected {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+}
+
+.file-row__checkbox,
+.file-row__checkbox--checked {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  border: 2px solid #9ca3af;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  color: #ffffff;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.file-row__checkbox--checked {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #f9fafb;
+}
+
+.file-row__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+}
+
+.file-row__name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.file-row__folder,
+.file-row__size,
+.file-row__tags {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.file-row__tags {
+  word-break: break-word;
+}
+
+.file-row__visibility {
+  color: #2563eb;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.file-explorer__bulk-bar {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 24px 46px rgba(15, 23, 42, 0.2);
+  border-radius: 16px;
+  padding: 0.9rem 1.4rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  z-index: 40;
+}
+
+.file-explorer__bulk-bar__selection {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.file-explorer__bulk-bar__count {
+  font-size: 0.9rem;
+}
+
+.file-explorer__bulk-bar__clear {
+  background: none;
+  border: none;
+  color: #2563eb;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.file-explorer__bulk-bar__divider {
+  width: 1px;
+  height: 24px;
+  background: #e5e7eb;
+}
+
+.file-explorer__bulk-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.file-explorer__chip-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  color: #1f2937;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.file-explorer__chip-button:hover {
+  background: #e5e7eb;
+  border-color: #cbd5f5;
+}
+
+.file-explorer__chip-button--danger {
+  border-color: #fecaca;
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.file-explorer__chip-button--danger:hover {
+  background: #fecaca;
+  border-color: #fca5a5;
+}
+
+.file-explorer__modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 60;
+}
+
+.file-explorer__modal {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 1.75rem;
+  width: min(520px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.25);
+}
+
+.file-explorer__modal--large {
+  width: min(640px, 100%);
+}
+
+.file-explorer__modal--progress {
+  text-align: center;
+  gap: 1rem;
+}
+
+.file-explorer__modal--danger {
+  border-top: 6px solid #f87171;
+}
+
+.file-explorer__modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.file-explorer__modal-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.file-explorer__modal-content {
+  display: grid;
+  gap: 1rem;
+}
+
+.file-explorer__modal-content--grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.file-explorer__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: #1f2937;
+}
+
+.file-explorer__field--full {
+  grid-column: 1 / -1;
+}
+
+.file-explorer__field--inline {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.file-explorer__field input,
+.file-explorer__field select {
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  font: inherit;
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.file-explorer__field input:focus,
+.file-explorer__field select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.file-explorer__modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.file-explorer__progress {
+  height: 8px;
+  border-radius: 999px;
+  background: #e5e7eb;
+  overflow: hidden;
+}
+
+.file-explorer__progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #6366f1, #2563eb);
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.file-explorer__icon-button {
+  border: none;
+  background: #f3f4f6;
+  color: #4b5563;
+  border-radius: 999px;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.file-explorer__icon-button:hover {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.file-explorer__modal-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: #fee2e2;
+  color: #b91c1c;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 0.85rem;
+}
+
+.file-explorer__modal-copy {
+  font-size: 0.95rem;
+  color: #374151;
+  margin: 0;
+}
+
+.file-explorer__tag-suggestions {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.file-explorer__tag-suggestions p {
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.file-explorer__tag-suggestions-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.file-explorer__tag-suggestions-list button {
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.file-explorer__tag-suggestions-list button:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #f9fafb;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .editor-page__summary {
   display: grid;
   gap: 0.75rem;
@@ -397,69 +1166,6 @@ input, textarea, select {
   color: #1f2937;
 }
 
-.file-tree {
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
-  background: #f9fafb;
-}
-
-.file-tree__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 0.75rem;
-}
-
-.file-tree__header h3 {
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.file-tree__summary {
-  font-size: 0.8rem;
-  color: #6b7280;
-}
-
-.file-tree__list {
-  list-style: none;
-  padding-left: 1rem;
-  margin: 0;
-}
-
-.file-tree__item {
-  display: grid;
-  gap: 0.35rem;
-  margin-bottom: 0.5rem;
-}
-
-.file-tree__item > span {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.85rem;
-}
-
-.file-tree__item--directory > span {
-  font-weight: 600;
-  color: #111827;
-}
-
-.file-tree__item--file > span {
-  color: #374151;
-}
-
-.file-tree--empty {
-  background: #fff7ed;
-  border-color: #fed7aa;
-  color: #9a3412;
-}
-
-.file-tree--empty p {
-  margin: 0;
-}
-
 @media (max-width: 640px) {
   .app-header {
     padding: 2rem 1rem 1.5rem;
@@ -475,5 +1181,68 @@ input, textarea, select {
 
   .editor-page__card {
     padding: 1.5rem;
+  }
+
+  .editor-page__card--files > .file-explorer {
+    padding: 1.5rem;
+  }
+
+  .file-explorer__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .file-explorer__header-actions {
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .file-explorer__header-actions .file-explorer__button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .file-explorer__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .file-explorer__search {
+    flex: 1;
+  }
+
+  .file-explorer__sort {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .file-explorer__sort-label {
+    flex: 1;
+    justify-content: space-between;
+  }
+
+  .file-explorer__sort-label span {
+    font-weight: 600;
+  }
+
+  .file-explorer__sort button {
+    width: 100%;
+  }
+
+  .file-explorer__grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
+
+  .file-explorer__list-header,
+  .file-row {
+    grid-template-columns: 36px 1.8fr 1.2fr 0.9fr 1.3fr 0.8fr;
+    padding: 0.75rem 0.8rem;
+    gap: 0.5rem;
+  }
+
+  .file-explorer__bulk-bar {
+    left: 1.5rem;
+    right: 1.5rem;
+    transform: none;
   }
 }

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -67,7 +67,7 @@ export default function EditorPage() {
         </section>
 
         <section className="editor-page__card editor-page__card--files">
-          <ProjectFileExplorer projectSlug={slug} />
+          <ProjectFileExplorer projectSlug={slug} projectTitle={meta.title} />
         </section>
 
         <section className="editor-page__card editor-page__card--placeholder">


### PR DESCRIPTION
## Summary
- add sort dropdown and order toggle to the project file explorer controls
- track file byte sizes so size sorting can use real values and reset sort state per project
- style the new sort UI for both desktop and mobile layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc75a9d648832f8fcd970299811d81