### PR TITLE
Revamp intake form with multi-step upload flow

### DIFF
--- a/src/intake/IntakeForm.css
+++ b/src/intake/IntakeForm.css
@@ -1,0 +1,485 @@
+.upload-flow {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  color: #0f172a;
+}
+
+.upload-flow__header {
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 1.25rem;
+}
+
+.upload-flow__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.upload-flow__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+.upload-flow__icon-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: #6b7280;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.upload-flow__icon-button:not(:disabled):hover {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+  color: #111827;
+}
+
+.upload-flow__icon-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.upload-flow__steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.upload-flow__step {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.upload-flow__step-circle {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #e5e7eb;
+  color: #6b7280;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.upload-flow__step-circle--active,
+.upload-flow__step-circle--complete {
+  background: #7c3aed;
+  color: #ffffff;
+}
+
+.upload-flow__step-line {
+  height: 0.25rem;
+  border-radius: 999px;
+  background: #e5e7eb;
+  width: 100%;
+  transition: background 0.2s ease;
+}
+
+.upload-flow__step-line--complete {
+  background: #7c3aed;
+}
+
+.upload-flow__step-label {
+  grid-column: 1 / -1;
+  font-size: 0.85rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.upload-flow__main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.upload-flow__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.upload-flow__intro {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.upload-flow__intro h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.upload-flow__intro p {
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.upload-flow__intro--left {
+  text-align: left;
+}
+
+.upload-flow__dropzone {
+  border: 2px dashed #c4b5fd;
+  border-radius: 1.25rem;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  background: #f9fafb;
+  transition: border 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.upload-flow__dropzone--active {
+  border-color: #7c3aed;
+  background: #f5f3ff;
+  transform: translateY(-2px);
+}
+
+.upload-flow__dropzone h3 {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.upload-flow__dropzone p {
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.upload-flow__dropzone small {
+  color: #6b7280;
+}
+
+.upload-flow__dropzone-icon {
+  color: #7c3aed;
+}
+
+.upload-flow__file-input {
+  display: none;
+}
+
+.upload-flow__option-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.upload-flow__option-btn {
+  border: 1px solid #e5e7eb;
+  border-radius: 1rem;
+  padding: 1.25rem 1rem;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: #4338ca;
+  transition: border 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.upload-flow__option-btn:hover {
+  border-color: #a855f7;
+  background: #f5f3ff;
+  transform: translateY(-2px);
+}
+
+.upload-flow__file-card {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  border-radius: 1rem;
+  border: 1px solid #e5e7eb;
+  padding: 1rem 1.25rem;
+  background: #f9fafb;
+}
+
+.upload-flow__file-thumb {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.upload-flow__file-thumb--placeholder {
+  background: #ede9fe;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b21a8;
+}
+
+.upload-flow__file-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.upload-flow__file-meta strong {
+  color: #111827;
+}
+
+.upload-flow__project-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.upload-flow__project-btn {
+  border: 1px solid #e5e7eb;
+  border-radius: 1.1rem;
+  background: #ffffff;
+  padding: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.upload-flow__project-btn:hover {
+  border-color: #c4b5fd;
+  box-shadow: 0 12px 24px rgba(124, 58, 237, 0.08);
+  transform: translateY(-2px);
+}
+
+.upload-flow__project-btn--active {
+  border-color: #7c3aed;
+  box-shadow: 0 16px 32px rgba(124, 58, 237, 0.12);
+  background: #f5f3ff;
+}
+
+.upload-flow__project-btn--dashed {
+  border-style: dashed;
+}
+
+.upload-flow__project-body {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #4338ca;
+}
+
+.upload-flow__project-body p {
+  font-weight: 600;
+  color: #111827;
+}
+
+.upload-flow__project-body span {
+  display: block;
+  color: #6b7280;
+  font-size: 0.85rem;
+}
+
+.upload-flow__project-body--center {
+  justify-content: center;
+  color: #7c3aed;
+  font-weight: 600;
+}
+
+.upload-flow__project-indicator {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  border: 2px solid #d1d5db;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.upload-flow__project-indicator--active {
+  background: #7c3aed;
+  border-color: #7c3aed;
+}
+
+.upload-flow__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.upload-flow__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.upload-flow__field span {
+  font-weight: 600;
+  color: #1f2937;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.upload-flow__input,
+.upload-flow__textarea,
+.upload-flow__select {
+  border: 1px solid #d1d5db;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.upload-flow__textarea {
+  resize: vertical;
+  min-height: 7rem;
+}
+
+.upload-flow__input:focus,
+.upload-flow__textarea:focus,
+.upload-flow__select:focus {
+  outline: none;
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.18);
+}
+
+.upload-flow__field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+}
+
+.upload-flow__primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: #7c3aed;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.85rem;
+  padding: 0.85rem 1.25rem;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.upload-flow__primary-button--full {
+  width: 100%;
+}
+
+.upload-flow__primary-button:hover:not(:disabled) {
+  background: #6d28d9;
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(109, 40, 217, 0.28);
+}
+
+.upload-flow__primary-button:disabled {
+  background: #d1d5db;
+  color: #6b7280;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.upload-flow__secondary-button {
+  border: 1px solid #d1d5db;
+  border-radius: 0.85rem;
+  padding: 0.85rem 1.25rem;
+  font-weight: 600;
+  background: #ffffff;
+  color: #1f2937;
+  transition: background 0.2s ease, border 0.2s ease, transform 0.2s ease;
+}
+
+.upload-flow__secondary-button:hover {
+  background: #f9fafb;
+  border-color: #cbd5f5;
+  transform: translateY(-1px);
+}
+
+.upload-flow__action-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.upload-flow__review-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 1.25rem;
+  background: #ffffff;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.08);
+}
+
+.upload-flow__review-image {
+  border-radius: 1rem;
+  width: 100%;
+  height: 12rem;
+  object-fit: cover;
+}
+
+.upload-flow__review-headline h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 0.35rem;
+}
+
+.upload-flow__review-headline p {
+  color: #4b5563;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.upload-flow__review-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.upload-flow__review-list div {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.upload-flow__review-list dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+}
+
+.upload-flow__review-list dd {
+  margin: 0;
+  font-weight: 500;
+  color: #111827;
+}
+
+@media (max-width: 640px) {
+  .upload-flow__toolbar {
+    flex-wrap: wrap;
+  }
+
+  .upload-flow__icon-button {
+    order: -1;
+  }
+}

--- a/src/intake/IntakeForm.tsx
+++ b/src/intake/IntakeForm.tsx
@@ -1,100 +1,581 @@
-import React, { useState } from 'react'
-import { ProjectMeta, newProject, defaultTags } from './schema'
+import React, { useEffect, useRef, useState } from 'react'
+import {
+  ArrowLeft,
+  ArrowRight,
+  Calendar,
+  Check,
+  FileText,
+  Folder,
+  Globe,
+  Image,
+  Plus,
+  Tag,
+  Upload,
+  X,
+} from 'lucide-react'
+import { newProject, type ProjectMeta } from './schema'
+import './IntakeForm.css'
 
 type Props = { onComplete(meta: ProjectMeta): void }
 
-export default function IntakeForm({ onComplete }: Props) {
-  const [title, setTitle] = useState('')
-  const [problem, setProblem] = useState('')
-  const [solution, setSolution] = useState('')
-  const [outcomes, setOutcomes] = useState('')
-  const [tags, setTags] = useState<string[]>([])
+type UploadedFile = {
+  name: string
+  size: number
+  type: string
+  preview: string | null
+}
 
-  const toggleTag = (t: string) => {
-    setTags(prev => prev.includes(t) ? prev.filter(x => x !== t) : [...prev, t])
+const steps = ['Upload File', 'Choose Project', 'Fill Template', 'Review & Publish']
+
+const projectOptions = [
+  { id: 'web-dev', name: 'Web Development', count: 5 },
+  { id: 'design', name: 'UI/UX Design', count: 3 },
+  { id: 'mobile', name: 'Mobile Apps', count: 2 },
+]
+
+const categories = [
+  'Web Application',
+  'Mobile App',
+  'UI Design',
+  'Branding',
+  'Photography',
+  'Other',
+]
+
+const initialFormState = {
+  title: '',
+  description: '',
+  category: '',
+  dateCompleted: '',
+  clientName: '',
+  projectUrl: '',
+  technologies: '',
+}
+
+const parseList = (value: string) =>
+  value
+    .split(/[,;\n]+/)
+    .map(entry => entry.trim())
+    .filter(Boolean)
+
+export default function IntakeForm({ onComplete }: Props) {
+  const [currentStep, setCurrentStep] = useState(0)
+  const [dragOver, setDragOver] = useState(false)
+  const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(null)
+  const [selectedProject, setSelectedProject] = useState('')
+  const [formData, setFormData] = useState(initialFormState)
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (uploadedFile?.preview) {
+        URL.revokeObjectURL(uploadedFile.preview)
+      }
+    }
+  }, [uploadedFile])
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setDragOver(false)
+    const file = event.dataTransfer.files?.[0]
+    handleFileSelect(file)
   }
 
-  const submit = (e: React.FormEvent) => {
-    e.preventDefault()
-    const meta = newProject(title.trim())
-    meta.problem = problem.trim()
-    meta.solution = solution.trim()
-    meta.outcomes = outcomes.trim()
-    meta.tags = tags
+  const handleFileSelect = (file?: File) => {
+    if (!file) return
+
+    setUploadedFile(prev => {
+      if (prev?.preview) {
+        URL.revokeObjectURL(prev.preview)
+      }
+      return {
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+      }
+    })
+    setCurrentStep(1)
+  }
+
+  const handleInputChange = (field: keyof typeof initialFormState, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value,
+    }))
+  }
+
+  const nextStep = () => {
+    setCurrentStep(prev => (prev < steps.length - 1 ? prev + 1 : prev))
+  }
+
+  const prevStep = () => {
+    setCurrentStep(prev => (prev > 0 ? prev - 1 : prev))
+  }
+
+  const resetFlow = () => {
+    setCurrentStep(0)
+    setDragOver(false)
+    setUploadedFile(prev => {
+      if (prev?.preview) {
+        URL.revokeObjectURL(prev.preview)
+      }
+      return null
+    })
+    setSelectedProject('')
+    setFormData(initialFormState)
+  }
+
+  const formatFileSize = (bytes: number) => {
+    if (bytes === 0) return '0 Bytes'
+    const base = 1024
+    const units = ['Bytes', 'KB', 'MB', 'GB']
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(base)), units.length - 1)
+    const size = bytes / Math.pow(base, exponent)
+    return `${size.toFixed(size >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`
+  }
+
+  const getSelectedProjectName = () => {
+    if (!selectedProject) return ''
+    if (selectedProject === 'new') return 'New Project'
+    return projectOptions.find(option => option.id === selectedProject)?.name ?? ''
+  }
+
+  const handlePublish = () => {
+    const title = formData.title.trim()
+    if (!title) {
+      return
+    }
+
+    const meta = newProject(title)
+    meta.problem = formData.description.trim()
+
+    const solutionParts: string[] = []
+    const projectName = getSelectedProjectName()
+    if (projectName) {
+      solutionParts.push(`Project: ${projectName}`)
+    }
+    if (formData.clientName.trim()) {
+      solutionParts.push(`Client: ${formData.clientName.trim()}`)
+    }
+    if (formData.category.trim()) {
+      solutionParts.push(`Category: ${formData.category.trim()}`)
+    }
+    if (formData.projectUrl.trim()) {
+      solutionParts.push(formData.projectUrl.trim())
+    }
+    meta.solution = solutionParts.join(' • ')
+
+    const outcomes: string[] = []
+    if (formData.dateCompleted) {
+      const completedDate = new Date(`${formData.dateCompleted}-01`)
+      outcomes.push(
+        `Completed ${completedDate.toLocaleDateString(undefined, {
+          month: 'long',
+          year: 'numeric',
+        })}`,
+      )
+    }
+    if (uploadedFile) {
+      outcomes.push(`Primary asset: ${uploadedFile.name}`)
+    }
+    meta.outcomes = outcomes.join(' • ')
+
+    const tagSet = new Set<string>()
+    if (formData.category.trim()) {
+      tagSet.add(formData.category.trim())
+    }
+    if (projectName) {
+      tagSet.add(projectName)
+    }
+    const technologies = parseList(formData.technologies)
+    technologies.forEach(tagSet.add, tagSet)
+    if (tagSet.size > 0) {
+      meta.tags = Array.from(tagSet)
+    }
+    if (technologies.length > 0) {
+      meta.technologies = technologies
+    }
+
     onComplete(meta)
   }
 
   return (
-    <form onSubmit={submit} className="intake-form" autoComplete="off">
-      <div className="intake-form__heading">
-        <h1>Project intake</h1>
-        <p>Capture the essentials so we can build the story later.</p>
-      </div>
+    <div className="upload-flow">
+      <header className="upload-flow__header">
+        <div className="upload-flow__toolbar">
+          <button
+            type="button"
+            onClick={prevStep}
+            className="upload-flow__icon-button"
+            disabled={currentStep === 0}
+            aria-label="Previous step"
+          >
+            <ArrowLeft size={18} />
+          </button>
+          <h1 className="upload-flow__title">Add to Portfolio</h1>
+          <button
+            type="button"
+            onClick={resetFlow}
+            className="upload-flow__icon-button"
+            aria-label="Reset flow"
+          >
+            <X size={18} />
+          </button>
+        </div>
 
-      <div className="intake-form__grid">
-        <label className="intake-form__field">
-          <span>Project title</span>
-          <input
-            value={title}
-            onChange={e => setTitle(e.target.value)}
-            required
-            placeholder="Acme 2025 Launch"
-          />
-        </label>
-
-        <label className="intake-form__field">
-          <span>Problem identified</span>
-          <textarea
-            rows={3}
-            value={problem}
-            onChange={e => setProblem(e.target.value)}
-            placeholder="What wasn&apos;t working before you got involved?"
-          />
-        </label>
-
-        <label className="intake-form__field">
-          <span>Solution shipped</span>
-          <textarea
-            rows={3}
-            value={solution}
-            onChange={e => setSolution(e.target.value)}
-            placeholder="What did you design, build or deliver?"
-          />
-        </label>
-
-        <label className="intake-form__field">
-          <span>Outcomes / impact</span>
-          <textarea
-            rows={3}
-            value={outcomes}
-            onChange={e => setOutcomes(e.target.value)}
-            placeholder="Wins, metrics, reaction — the proof that it mattered."
-          />
-        </label>
-      </div>
-
-      <fieldset className="intake-form__tags">
-        <legend>Tag it so you can find it later</legend>
-        <div className="intake-form__tag-grid">
-          {defaultTags.map(t => {
-            const isActive = tags.includes(t)
+        <ol className="upload-flow__steps" aria-label="Progress">
+          {steps.map((step, index) => {
+            const isComplete = index < currentStep
+            const isActive = index === currentStep
             return (
-              <button
-                type="button"
-                key={t}
-                onClick={() => toggleTag(t)}
-                className={`intake-tag${isActive ? ' intake-tag--active' : ''}`}
-              >
-                {t}
-              </button>
+              <li key={step} className="upload-flow__step">
+                <span
+                  className={`upload-flow__step-circle${
+                    isComplete
+                      ? ' upload-flow__step-circle--complete'
+                      : isActive
+                        ? ' upload-flow__step-circle--active'
+                        : ''
+                  }`}
+                >
+                  {isComplete ? <Check size={14} /> : index + 1}
+                </span>
+                {index < steps.length - 1 && (
+                  <span
+                    className={`upload-flow__step-line${
+                      index < currentStep ? ' upload-flow__step-line--complete' : ''
+                    }`}
+                    aria-hidden="true"
+                  />
+                )}
+                <span className="upload-flow__step-label">{step}</span>
+              </li>
             )
           })}
-        </div>
-      </fieldset>
+        </ol>
+      </header>
 
-      <div className="intake-form__actions">
-        <button type="submit" className="button button--primary">Create project</button>
-      </div>
-    </form>
+      <main className="upload-flow__main">
+        {currentStep === 0 && (
+          <div className="upload-flow__section">
+            <div className="upload-flow__intro">
+              <h2>Upload your work</h2>
+              <p>Add images, documents, or motion assets that capture this project.</p>
+            </div>
+
+            <div
+              className={`upload-flow__dropzone${dragOver ? ' upload-flow__dropzone--active' : ''}`}
+              onDrop={handleDrop}
+              onDragOver={event => {
+                event.preventDefault()
+                setDragOver(true)
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload size={42} className="upload-flow__dropzone-icon" />
+              <h3>{dragOver ? 'Drop your file here' : 'Drag & drop or click to upload'}</h3>
+              <p>Supports JPG, PNG, PDF, MP4 and more.</p>
+              <small>Maximum file size: 50MB</small>
+            </div>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="upload-flow__file-input"
+              accept="image/*,video/*,.pdf,.doc,.docx"
+              onChange={event => handleFileSelect(event.target.files?.[0])}
+            />
+
+            <div className="upload-flow__option-grid">
+              <button type="button" className="upload-flow__option-btn" onClick={() => fileInputRef.current?.click()}>
+                <Image size={24} />
+                <span>Browse images</span>
+              </button>
+              <button type="button" className="upload-flow__option-btn" onClick={() => fileInputRef.current?.click()}>
+                <FileText size={24} />
+                <span>Browse documents</span>
+              </button>
+            </div>
+          </div>
+        )}
+
+        {currentStep === 1 && (
+          <div className="upload-flow__section">
+            {uploadedFile && (
+              <div className="upload-flow__file-card">
+                {uploadedFile.preview ? (
+                  <img src={uploadedFile.preview} alt="Preview" className="upload-flow__file-thumb" />
+                ) : (
+                  <div className="upload-flow__file-thumb upload-flow__file-thumb--placeholder">
+                    <FileText size={20} />
+                  </div>
+                )}
+                <div className="upload-flow__file-meta">
+                  <strong>{uploadedFile.name}</strong>
+                  <span>{formatFileSize(uploadedFile.size)}</span>
+                </div>
+              </div>
+            )}
+
+            <div className="upload-flow__intro upload-flow__intro--left">
+              <h2>Choose project</h2>
+              <p>Add this file to an existing project or start something new.</p>
+            </div>
+
+            <div className="upload-flow__project-list">
+              {projectOptions.map(option => {
+                const isActive = selectedProject === option.id
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => setSelectedProject(option.id)}
+                    className={`upload-flow__project-btn${isActive ? ' upload-flow__project-btn--active' : ''}`}
+                  >
+                    <div className="upload-flow__project-body">
+                      <Folder size={20} />
+                      <div>
+                        <p>{option.name}</p>
+                        <span>{option.count} items</span>
+                      </div>
+                    </div>
+                    <span
+                      className={`upload-flow__project-indicator${isActive ? ' upload-flow__project-indicator--active' : ''}`}
+                      aria-hidden="true"
+                    />
+                  </button>
+                )
+              })}
+
+              <button
+                type="button"
+                onClick={() => setSelectedProject('new')}
+                className={`upload-flow__project-btn upload-flow__project-btn--dashed${
+                  selectedProject === 'new' ? ' upload-flow__project-btn--active' : ''
+                }`}
+              >
+                <div className="upload-flow__project-body upload-flow__project-body--center">
+                  <Plus size={20} />
+                  <span>Create new project</span>
+                </div>
+                <span
+                  className={`upload-flow__project-indicator${
+                    selectedProject === 'new' ? ' upload-flow__project-indicator--active' : ''
+                  }`}
+                  aria-hidden="true"
+                />
+              </button>
+            </div>
+
+            <button
+              type="button"
+              onClick={nextStep}
+              disabled={!selectedProject}
+              className="upload-flow__primary-button upload-flow__primary-button--full"
+            >
+              Continue
+              <ArrowRight size={18} />
+            </button>
+          </div>
+        )}
+
+        {currentStep === 2 && (
+          <div className="upload-flow__section">
+            <div className="upload-flow__intro upload-flow__intro--left">
+              <h2>Project details</h2>
+              <p>Give us the essentials so you can publish with confidence.</p>
+            </div>
+
+            <div className="upload-flow__form">
+              <label className="upload-flow__field">
+                <span>Project title *</span>
+                <input
+                  type="text"
+                  value={formData.title}
+                  onChange={event => handleInputChange('title', event.target.value)}
+                  placeholder="E-commerce mobile app redesign"
+                  className="upload-flow__input"
+                  required
+                />
+              </label>
+
+              <label className="upload-flow__field">
+                <span>Description</span>
+                <textarea
+                  value={formData.description}
+                  onChange={event => handleInputChange('description', event.target.value)}
+                  placeholder="Describe the work, challenges, and impact."
+                  rows={4}
+                  className="upload-flow__textarea"
+                />
+              </label>
+
+              <label className="upload-flow__field">
+                <span>Category</span>
+                <select
+                  value={formData.category}
+                  onChange={event => handleInputChange('category', event.target.value)}
+                  className="upload-flow__select"
+                >
+                  <option value="">Select category</option>
+                  {categories.map(category => (
+                    <option key={category} value={category}>
+                      {category}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <div className="upload-flow__field-grid">
+                <label className="upload-flow__field">
+                  <span>
+                    <Calendar size={16} /> Completed
+                  </span>
+                  <input
+                    type="month"
+                    value={formData.dateCompleted}
+                    onChange={event => handleInputChange('dateCompleted', event.target.value)}
+                    className="upload-flow__input"
+                  />
+                </label>
+
+                <label className="upload-flow__field">
+                  <span>
+                    <Globe size={16} /> Live URL
+                  </span>
+                  <input
+                    type="url"
+                    value={formData.projectUrl}
+                    onChange={event => handleInputChange('projectUrl', event.target.value)}
+                    placeholder="https://..."
+                    className="upload-flow__input"
+                  />
+                </label>
+              </div>
+
+              <label className="upload-flow__field">
+                <span>
+                  <Tag size={16} /> Technologies used
+                </span>
+                <input
+                  type="text"
+                  value={formData.technologies}
+                  onChange={event => handleInputChange('technologies', event.target.value)}
+                  placeholder="React, Node.js, Tailwind CSS"
+                  className="upload-flow__input"
+                />
+              </label>
+
+              <label className="upload-flow__field">
+                <span>Client / Company</span>
+                <input
+                  type="text"
+                  value={formData.clientName}
+                  onChange={event => handleInputChange('clientName', event.target.value)}
+                  placeholder="Company name or Personal Project"
+                  className="upload-flow__input"
+                />
+              </label>
+            </div>
+
+            <button
+              type="button"
+              onClick={nextStep}
+              disabled={!formData.title.trim()}
+              className="upload-flow__primary-button upload-flow__primary-button--full"
+            >
+              Review &amp; publish
+              <ArrowRight size={18} />
+            </button>
+          </div>
+        )}
+
+        {currentStep === 3 && (
+          <div className="upload-flow__section">
+            <div className="upload-flow__intro upload-flow__intro--left">
+              <h2>Review your work</h2>
+              <p>Make sure everything is ready before you add it to your portfolio.</p>
+            </div>
+
+            <div className="upload-flow__review-card">
+              {uploadedFile?.preview && (
+                <img src={uploadedFile.preview} alt="Project preview" className="upload-flow__review-image" />
+              )}
+
+              <div className="upload-flow__review-headline">
+                <h3>{formData.title || 'Untitled project'}</h3>
+                {formData.description && <p>{formData.description}</p>}
+              </div>
+
+              <dl className="upload-flow__review-list">
+                {getSelectedProjectName() && (
+                  <div>
+                    <dt>Project</dt>
+                    <dd>{getSelectedProjectName()}</dd>
+                  </div>
+                )}
+                {formData.category && (
+                  <div>
+                    <dt>Category</dt>
+                    <dd>{formData.category}</dd>
+                  </div>
+                )}
+                {formData.technologies && (
+                  <div>
+                    <dt>Technologies</dt>
+                    <dd>{formData.technologies}</dd>
+                  </div>
+                )}
+                {formData.dateCompleted && (
+                  <div>
+                    <dt>Completed</dt>
+                    <dd>
+                      {new Date(`${formData.dateCompleted}-01`).toLocaleDateString(undefined, {
+                        month: 'long',
+                        year: 'numeric',
+                      })}
+                    </dd>
+                  </div>
+                )}
+                {formData.clientName && (
+                  <div>
+                    <dt>Client</dt>
+                    <dd>{formData.clientName}</dd>
+                  </div>
+                )}
+                {formData.projectUrl && (
+                  <div>
+                    <dt>URL</dt>
+                    <dd>{formData.projectUrl}</dd>
+                  </div>
+                )}
+              </dl>
+            </div>
+
+            <div className="upload-flow__action-grid">
+              <button
+                type="button"
+                onClick={prevStep}
+                className="upload-flow__secondary-button"
+              >
+                Edit details
+              </button>
+              <button
+                type="button"
+                onClick={handlePublish}
+                className="upload-flow__primary-button"
+                disabled={!formData.title.trim()}
+              >
+                Add to portfolio
+                <ArrowRight size={18} />
+              </button>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace the previous one-shot project intake with a guided four-step upload flow that handles assets, project selection, metadata entry, and review before calling `onComplete`
- add a dedicated stylesheet that styles the new flow elements, call-to-action buttons, and responsive layout states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc7bee09d4832f841a1298194b7907