### PR TITLE
Add project analysis backend services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL="postgresql://username:password@localhost:5432/portfolioforge"
+REDIS_URL="redis://localhost:6379"
+OPENAI_API_KEY="your-openai-api-key"
+GOOGLE_CLOUD_PROJECT="your-gcp-project"
+GOOGLE_CLOUD_KEYFILE="path/to/service-account.json"
+JWT_SECRET="your-jwt-secret"
+NODE_ENV="development"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Node
 node_modules/
 dist/
+server/dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY server/package*.json ./
+RUN npm install --omit=dev
+
+COPY server/. .
+COPY prisma ./prisma
+
+RUN npm run build && npx prisma generate
+
+EXPOSE 3001
+
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: portfolioforge
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3001"
+    environment:
+      - DATABASE_URL=postgresql://postgres:password@postgres:5432/portfolioforge
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      - postgres
+      - redis
+    volumes:
+      - ./uploads:/app/uploads
+
+volumes:
+  postgres_data:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,128 @@
+// ===== DATABASE MODELS =====
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id          String   @id @default(cuid())
+  email       String   @unique
+  name        String?
+  avatar      String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  
+  projects    Project[]
+  
+  @@map("users")
+}
+
+model Project {
+  id           String   @id @default(cuid())
+  name         String
+  description  String?
+  category     String?
+  template     String?
+  color        String   @default("#5a3cf4")
+  visibility   String   @default("private")
+  featured     Boolean  @default(false)
+  userId       String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  files        ProjectFile[]
+  analysis     ProjectAnalysis?
+  
+  @@map("projects")
+}
+
+model ProjectFile {
+  id           String   @id @default(cuid())
+  name         String
+  filename     String
+  originalName String
+  mimeType     String
+  size         Int
+  url          String
+  thumbnailUrl String?
+  description  String?
+  tags         String[]
+  featured     Boolean  @default(false)
+  order        Int      @default(0)
+  projectId    String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  
+  project      Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  analysis     FileAnalysis?
+  
+  @@map("project_files")
+}
+
+model ProjectAnalysis {
+  id               String   @id @default(cuid())
+  projectId        String   @unique
+  status           String   @default("pending") // pending, analyzing, completed, failed
+  confidence       Float?
+  processingTime   Float?
+  filesAnalyzed    Int      @default(0)
+  insightsFound    Int      @default(0)
+  
+  // Problem Analysis
+  primaryProblem   String?
+  problemConfidence Float?
+  problemEvidence  Json?
+  problemAlternatives Json?
+  
+  // Solution Analysis  
+  primarySolution  String?
+  solutionConfidence Float?
+  solutionElements Json?
+  designPatterns   String[]
+  
+  // Impact Analysis
+  primaryImpact    String?
+  impactConfidence Float?
+  metrics          Json?
+  businessValue    String?
+  
+  // Narrative
+  story           String?
+  challenges      String[]
+  process         String[]
+  
+  // Suggestions
+  suggestedTitle   String?
+  suggestedCategory String?
+  suggestedTags    String[]
+  
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  
+  project         Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  
+  @@map("project_analyses")
+}
+
+model FileAnalysis {
+  id           String   @id @default(cuid())
+  fileId       String   @unique
+  status       String   @default("pending")
+  contentType  String?
+  insights     Json?
+  extractedText String?
+  metadata     Json?
+  processingTime Float?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  
+  file         ProjectFile @relation(fields: [fileId], references: [id], onDelete: Cascade)
+  
+  @@map("file_analyses")
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "portfolio-analysis-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/app.js",
+    "dev": "ts-node src/app.ts"
+  },
+  "dependencies": {
+    "@google-cloud/storage": "^7.11.0",
+    "@prisma/client": "^5.19.1",
+    "bull": "^4.12.2",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "fluent-ffmpeg": "^2.1.2",
+    "multer": "^1.4.5-lts.1",
+    "openai": "^4.58.0",
+    "pdf2pic": "^2.1.3",
+    "prisma": "^5.19.1",
+    "sharp": "^0.33.4",
+    "tesseract.js": "^4.1.1"
+  },
+  "devDependencies": {
+    "@types/bull": "^3.15.9",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/fluent-ffmpeg": "^2.1.24",
+    "@types/multer": "^1.4.12",
+    "@types/node": "^20.16.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
+  }
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import cors from 'cors';
+import multer from 'multer';
+import { PrismaClient } from '@prisma/client';
+import analysisRoutes from './routes/analysis';
+
+const app = express();
+const prisma = new PrismaClient();
+
+app.use(cors());
+app.use(express.json());
+
+const storage = multer.memoryStorage();
+const upload = multer({
+  storage,
+  limits: {
+    fileSize: 50 * 1024 * 1024
+  }
+});
+
+app.use('/api/analysis', analysisRoutes);
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'OK', timestamp: new Date().toISOString() });
+});
+
+const PORT = process.env.PORT || 3001;
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+export default app;

--- a/server/src/jobs/analysisQueue.ts
+++ b/server/src/jobs/analysisQueue.ts
@@ -1,0 +1,29 @@
+import Queue from 'bull';
+import { FileProcessor } from '../services/fileProcessor';
+import { AIAnalysisService } from '../services/aiAnalysis';
+
+const analysisQueue = new Queue('analysis processing', process.env.REDIS_URL || 'redis://localhost:6379');
+const fileProcessor = new FileProcessor();
+const aiAnalysisService = new AIAnalysisService();
+
+analysisQueue.process('analyze-file', async (job) => {
+  const { fileId } = job.data as { fileId: string };
+
+  job.progress(0);
+  await fileProcessor.processFile(fileId);
+  job.progress(100);
+
+  return { fileId, status: 'completed' };
+});
+
+analysisQueue.process('analyze-project', async (job) => {
+  const { projectId } = job.data as { projectId: string };
+
+  job.progress(0);
+  const result = await aiAnalysisService.analyzeProject(projectId);
+  job.progress(100);
+
+  return { projectId, status: 'completed', result };
+});
+
+export { analysisQueue };

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+
+export interface AuthenticatedRequest extends Request {
+  user?: {
+    id: string;
+    [key: string]: unknown;
+  };
+}
+
+export const requireAuth = (req: AuthenticatedRequest, res: Response, next: NextFunction): void => {
+  if (!req.user?.id) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  next();
+};

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -1,0 +1,207 @@
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+import { analysisQueue } from '../jobs/analysisQueue';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth';
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+router.post('/projects/:projectId/analyze', requireAuth, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { projectId } = req.params;
+    const userId = req.user!.id;
+
+    const project = await prisma.project.findFirst({
+      where: {
+        id: projectId,
+        userId: userId
+      },
+      include: {
+        files: true
+      }
+    });
+
+    if (!project) {
+      res.status(404).json({ error: 'Project not found' });
+      return;
+    }
+
+    if (project.files.length === 0) {
+      res.status(400).json({ error: 'Project must have files to analyze' });
+      return;
+    }
+
+    for (const file of project.files) {
+      await analysisQueue.add('analyze-file', { fileId: file.id });
+    }
+
+    await analysisQueue.add('analyze-project', { projectId }, {
+      delay: project.files.length * 5000
+    });
+
+    res.json({ 
+      message: 'Analysis started',
+      projectId,
+      filesQueued: project.files.length
+    });
+
+  } catch (error) {
+    console.error('Error starting analysis:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.get('/projects/:projectId/analysis', requireAuth, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { projectId } = req.params;
+    const userId = req.user!.id;
+
+    const project = await prisma.project.findFirst({
+      where: {
+        id: projectId,
+        userId: userId
+      }
+    });
+
+    if (!project) {
+      res.status(404).json({ error: 'Project not found' });
+      return;
+    }
+
+    const analysis = await prisma.projectAnalysis.findUnique({
+      where: { projectId }
+    });
+
+    if (!analysis) {
+      res.status(404).json({ error: 'No analysis found' });
+      return;
+    }
+
+    const fileAnalyses = await prisma.fileAnalysis.findMany({
+      where: {
+        file: {
+          projectId: projectId
+        }
+      },
+      select: {
+        status: true,
+        fileId: true
+      }
+    });
+
+    res.json({
+      ...analysis,
+      fileAnalyses
+    });
+
+  } catch (error) {
+    console.error('Error getting analysis:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.get('/projects/:projectId/analysis/results', requireAuth, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { projectId } = req.params;
+    const userId = req.user!.id;
+
+    const project = await prisma.project.findFirst({
+      where: {
+        id: projectId,
+        userId: userId
+      }
+    });
+
+    if (!project) {
+      res.status(404).json({ error: 'Project not found' });
+      return;
+    }
+
+    const analysis = await prisma.projectAnalysis.findUnique({
+      where: { projectId }
+    });
+
+    if (!analysis || analysis.status !== 'completed') {
+      res.status(404).json({ error: 'Analysis not completed' });
+      return;
+    }
+
+    const result = {
+      confidence: analysis.confidence,
+      processingTime: analysis.processingTime,
+      filesAnalyzed: analysis.filesAnalyzed,
+      insights: analysis.insightsFound,
+      problem: {
+        primary: analysis.primaryProblem,
+        confidence: analysis.problemConfidence,
+        evidence: analysis.problemEvidence,
+        alternatives: analysis.problemAlternatives
+      },
+      solution: {
+        primary: analysis.primarySolution,
+        confidence: analysis.solutionConfidence,
+        keyElements: analysis.solutionElements,
+        designPatterns: analysis.designPatterns
+      },
+      impact: {
+        primary: analysis.primaryImpact,
+        confidence: analysis.impactConfidence,
+        metrics: analysis.metrics,
+        businessValue: analysis.businessValue
+      },
+      narrative: {
+        story: analysis.story,
+        challenges: analysis.challenges,
+        process: analysis.process
+      },
+      suggestedTitle: analysis.suggestedTitle,
+      suggestedCategory: analysis.suggestedCategory,
+      tags: analysis.suggestedTags
+    };
+
+    res.json(result);
+
+  } catch (error) {
+    console.error('Error getting analysis results:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.post('/projects/:projectId/analysis/apply', requireAuth, async (req: AuthenticatedRequest, res) => {
+  try {
+    const { projectId } = req.params;
+    const userId = req.user!.id;
+    const { suggestions } = req.body as { suggestions: { title?: string; category?: string; description?: string } };
+
+    const project = await prisma.project.findFirst({
+      where: {
+        id: projectId,
+        userId: userId
+      }
+    });
+
+    if (!project) {
+      res.status(404).json({ error: 'Project not found' });
+      return;
+    }
+
+    const updateData: Record<string, unknown> = {};
+    
+    if (suggestions?.title) updateData.name = suggestions.title;
+    if (suggestions?.category) updateData.category = suggestions.category;
+    if (suggestions?.description) updateData.description = suggestions.description;
+
+    await prisma.project.update({
+      where: { id: projectId },
+      data: updateData
+    });
+
+    res.json({ message: 'Suggestions applied successfully' });
+
+  } catch (error) {
+    console.error('Error applying suggestions:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/server/src/services/aiAnalysis.ts
+++ b/server/src/services/aiAnalysis.ts
@@ -1,0 +1,253 @@
+import OpenAI from 'openai';
+import { PrismaClient, Project, ProjectFile, FileAnalysis } from '@prisma/client';
+import { AnalysisResult, AnalysisInsight } from '../types/analysis';
+
+type ProjectWithFiles = Project & {
+  files: Array<ProjectFile & { analysis: FileAnalysis | null }>;
+};
+
+export class AIAnalysisService {
+  private openai: OpenAI;
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    });
+    this.prisma = new PrismaClient();
+  }
+
+  async analyzeProject(projectId: string): Promise<AnalysisResult> {
+    const startTime = Date.now();
+
+    try {
+      await this.prisma.projectAnalysis.upsert({
+        where: { projectId },
+        create: {
+          projectId,
+          status: 'analyzing'
+        },
+        update: {
+          status: 'analyzing'
+        }
+      });
+
+      const project = await this.prisma.project.findUnique({
+        where: { id: projectId },
+        include: {
+          files: {
+            include: {
+              analysis: true
+            }
+          }
+        }
+      }) as ProjectWithFiles | null;
+
+      if (!project) {
+        throw new Error(`Project ${projectId} not found`);
+      }
+
+      const compiledData = this.compileAnalysisData(project);
+      const analysis = await this.generateAIAnalysis(compiledData);
+
+      const processingTime = (Date.now() - startTime) / 1000;
+      const filesAnalyzed = project.files.length;
+      const insightsFound = compiledData.allInsights.length;
+
+      await this.prisma.projectAnalysis.update({
+        where: { projectId },
+        data: {
+          status: 'completed',
+          confidence: analysis.confidence,
+          processingTime,
+          filesAnalyzed,
+          insightsFound,
+          primaryProblem: analysis.problem.primary,
+          problemConfidence: analysis.problem.confidence,
+          problemEvidence: analysis.problem.evidence,
+          problemAlternatives: analysis.problem.alternatives,
+          primarySolution: analysis.solution.primary,
+          solutionConfidence: analysis.solution.confidence,
+          solutionElements: analysis.solution.keyElements,
+          designPatterns: analysis.solution.designPatterns,
+          primaryImpact: analysis.impact.primary,
+          impactConfidence: analysis.impact.confidence,
+          metrics: analysis.impact.metrics,
+          businessValue: analysis.impact.businessValue,
+          story: analysis.narrative.story,
+          challenges: analysis.narrative.challenges,
+          process: analysis.narrative.process,
+          suggestedTitle: analysis.suggestedTitle,
+          suggestedCategory: analysis.suggestedCategory,
+          suggestedTags: analysis.tags
+        }
+      });
+
+      return {
+        confidence: analysis.confidence,
+        processingTime,
+        filesAnalyzed,
+        insights: insightsFound,
+        problem: analysis.problem,
+        solution: analysis.solution,
+        impact: analysis.impact,
+        narrative: analysis.narrative,
+        suggestedTitle: analysis.suggestedTitle,
+        suggestedCategory: analysis.suggestedCategory,
+        tags: analysis.tags
+      };
+
+    } catch (error) {
+      console.error(`Error analyzing project ${projectId}:`, error);
+      
+      await this.prisma.projectAnalysis.update({
+        where: { projectId },
+        data: {
+          status: 'failed',
+          processingTime: (Date.now() - startTime) / 1000
+        }
+      });
+
+      throw error;
+    }
+  }
+
+  private compileAnalysisData(project: ProjectWithFiles) {
+    const allInsights: AnalysisInsight[] = [];
+    const extractedTexts: string[] = [];
+    const fileMetadata: Array<{ filename: string; type: string; metadata: unknown }> = [];
+
+    for (const file of project.files) {
+      if (file.analysis?.insights) {
+        const insights = file.analysis.insights as AnalysisInsight[];
+        allInsights.push(...insights.map(insight => ({
+          ...insight,
+          source: file.name
+        })));
+      }
+
+      if (file.analysis?.extractedText) {
+        extractedTexts.push(file.analysis.extractedText);
+      }
+
+      if (file.analysis?.metadata) {
+        fileMetadata.push({
+          filename: file.name,
+          type: file.mimeType,
+          metadata: file.analysis.metadata
+        });
+      }
+    }
+
+    return {
+      projectName: project.name,
+      projectDescription: project.description,
+      projectCategory: project.category,
+      allInsights,
+      extractedTexts,
+      fileMetadata,
+      fileCount: project.files.length
+    };
+  }
+
+  private async generateAIAnalysis(data: ReturnType<typeof AIAnalysisService.prototype.compileAnalysisData>): Promise<any> {
+    const prompt = this.buildAnalysisPrompt(data);
+
+    const completion = await this.openai.chat.completions.create({
+      model: 'gpt-4-turbo-preview',
+      messages: [
+        {
+          role: 'system',
+          content: `You are an expert design and product analyst. Your job is to analyze creative projects and reverse-engineer the problems they solved, the solutions they implemented, and the impact they created. 
+
+          Respond with a JSON object containing:
+          {
+            "confidence": number (0-100),
+            "problem": {
+              "primary": "main problem statement",
+              "confidence": number (0-100),
+              "evidence": ["evidence1", "evidence2"],
+              "alternatives": ["alternative1", "alternative2"]
+            },
+            "solution": {
+              "primary": "main solution description",
+              "confidence": number (0-100), 
+              "keyElements": ["element1", "element2"],
+              "designPatterns": ["pattern1", "pattern2"]
+            },
+            "impact": {
+              "primary": "main impact statement",
+              "confidence": number (0-100),
+              "metrics": [{"metric": "name", "before": "value", "after": "value", "change": "percentage"}],
+              "businessValue": "business impact description"
+            },
+            "narrative": {
+              "story": "comprehensive project story",
+              "challenges": ["challenge1", "challenge2"],
+              "process": ["step1", "step2"]
+            },
+            "suggestedTitle": "compelling project title",
+            "suggestedCategory": "project category",
+            "tags": ["tag1", "tag2"]
+          }`
+        },
+        {
+          role: 'user',
+          content: prompt
+        }
+      ],
+      temperature: 0.7,
+      max_tokens: 2000
+    });
+
+    const response = completion.choices[0]?.message?.content;
+    if (!response) {
+      throw new Error('No response from AI service');
+    }
+
+    try {
+      return JSON.parse(response);
+    } catch (error) {
+      console.error('Failed to parse AI response:', response);
+      throw new Error('Invalid AI response format');
+    }
+  }
+
+  private buildAnalysisPrompt(data: ReturnType<typeof AIAnalysisService.prototype.compileAnalysisData>): string {
+    const insightsSection = data.allInsights.map((insight, i) =>
+      `${i + 1}. [${insight.type}] ${insight.content} (confidence: ${insight.confidence}) from ${insight.source}`
+    ).join('\n');
+
+    const textSection = data.extractedTexts.join('\n\n');
+    const metadataSection = data.fileMetadata.map(meta =>
+      `- ${meta.filename} (${meta.type}): ${JSON.stringify(meta.metadata)}`
+    ).join('\n');
+
+    return `
+Please analyze this creative project and identify:
+
+PROJECT CONTEXT:
+- Name: ${data.projectName}
+- Description: ${data.projectDescription || 'Not provided'}
+- Category: ${data.projectCategory || 'Not specified'}
+- Files: ${data.fileCount} files
+
+EXTRACTED INSIGHTS:
+${insightsSection}
+
+EXTRACTED TEXT CONTENT:
+${textSection}
+
+FILE METADATA:
+${metadataSection}
+
+Based on this information, reverse-engineer:
+1. What problem was this project trying to solve?
+2. What solution approach was taken?
+3. What impact/results were achieved?
+4. What's the compelling story of this project?
+
+Focus on extracting concrete, specific insights rather than generic statements. If you see metrics or before/after comparisons, include them. If you identify specific design patterns or methodologies, mention them.
+    `.trim();
+  }
+}

--- a/server/src/services/fileProcessor.ts
+++ b/server/src/services/fileProcessor.ts
@@ -1,0 +1,369 @@
+import { Storage } from '@google-cloud/storage';
+import { createWorker, Worker } from 'tesseract.js';
+import { fromBuffer as pdfFromBuffer, FromBufferResult } from 'pdf2pic';
+import ffmpeg from 'fluent-ffmpeg';
+import sharp from 'sharp';
+import { PrismaClient } from '@prisma/client';
+import { readFileSync } from 'fs';
+
+interface ProcessResult {
+  insights: unknown;
+  text: string;
+  metadata: Record<string, unknown>;
+}
+
+export class FileProcessor {
+  private storage: Storage;
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.storage = new Storage();
+    this.prisma = new PrismaClient();
+  }
+
+  async processFile(fileId: string): Promise<void> {
+    const file = await this.prisma.projectFile.findUnique({
+      where: { id: fileId }
+    });
+
+    if (!file) {
+      throw new Error(`File ${fileId} not found`);
+    }
+
+    const startTime = Date.now();
+
+    try {
+      await this.prisma.fileAnalysis.upsert({
+        where: { fileId },
+        create: {
+          fileId,
+          status: 'processing',
+        },
+        update: {
+          status: 'processing',
+        }
+      });
+
+      let insights: unknown = {};
+      let extractedText = '';
+      let metadata: Record<string, unknown> = {};
+
+      switch (file.mimeType.split('/')[0]) {
+        case 'image': {
+          const imageResult = await this.processImage(file.url);
+          insights = imageResult.insights;
+          extractedText = imageResult.text;
+          metadata = imageResult.metadata;
+          break;
+        }
+
+        case 'application': {
+          if (file.mimeType === 'application/pdf') {
+            const pdfResult = await this.processPDF(file.url);
+            insights = pdfResult.insights;
+            extractedText = pdfResult.text;
+            metadata = pdfResult.metadata;
+          }
+          break;
+        }
+
+        case 'video': {
+          const videoResult = await this.processVideo(file.url);
+          insights = videoResult.insights;
+          extractedText = videoResult.text;
+          metadata = videoResult.metadata;
+          break;
+        }
+
+        default:
+          break;
+      }
+
+      const processingTime = (Date.now() - startTime) / 1000;
+
+      await this.prisma.fileAnalysis.update({
+        where: { fileId },
+        data: {
+          status: 'completed',
+          contentType: file.mimeType,
+          insights,
+          extractedText,
+          metadata,
+          processingTime
+        }
+      });
+
+    } catch (error) {
+      console.error(`Error processing file ${fileId}:`, error);
+      
+      await this.prisma.fileAnalysis.update({
+        where: { fileId },
+        data: {
+          status: 'failed',
+          processingTime: (Date.now() - startTime) / 1000
+        }
+      });
+
+      throw error;
+    }
+  }
+
+  private async processImage(url: string): Promise<ProcessResult> {
+    const imageBuffer = await this.downloadFile(url);
+    
+    // Generate thumbnail for potential use
+    await sharp(imageBuffer)
+      .resize(400, 300, { fit: 'cover' })
+      .jpeg({ quality: 80 })
+      .toBuffer();
+
+    const worker = await this.createOcrWorker();
+    const { data: { text } } = await worker.recognize(imageBuffer);
+    await worker.terminate();
+
+    const insights = await this.analyzeImageContent(imageBuffer, text);
+    const metadata = await sharp(imageBuffer).metadata();
+
+    return {
+      insights,
+      text: text.trim(),
+      metadata: {
+        width: metadata.width,
+        height: metadata.height,
+        format: metadata.format,
+        hasAlpha: metadata.hasAlpha
+      }
+    };
+  }
+
+  private async processPDF(url: string): Promise<ProcessResult> {
+    const pdfBuffer = await this.downloadFile(url);
+    
+    const converter: FromBufferResult = pdfFromBuffer(pdfBuffer, {
+      density: 200,
+      saveFilename: 'untitled',
+      savePath: '/tmp',
+      format: 'png',
+      width: 2000,
+      height: 2000
+    });
+
+    const images = await converter.bulk(-1);
+
+    let fullText = '';
+    const insights: unknown[] = [];
+
+    for (const image of images) {
+      const worker = await this.createOcrWorker();
+      const { data: { text } } = await worker.recognize(image.path);
+      await worker.terminate();
+      
+      fullText += `${text}\n`;
+      
+      const pageInsights = await this.analyzeTextContent(text);
+      insights.push(...pageInsights);
+    }
+
+    return {
+      insights: this.consolidateInsights(insights),
+      text: fullText.trim(),
+      metadata: {
+        pages: images.length,
+        format: 'pdf'
+      }
+    };
+  }
+
+  private async processVideo(url: string): Promise<ProcessResult> {
+    return new Promise((resolve, reject) => {
+      const insights: unknown[] = [];
+      let metadata: Record<string, unknown> = {};
+
+      ffmpeg(url)
+        .screenshots({
+          count: 5,
+          folder: '/tmp',
+          filename: 'screenshot-%i.png'
+        })
+        .on('end', async () => {
+          try {
+            for (let i = 1; i <= 5; i++) {
+              const screenshotPath = `/tmp/screenshot-${i}.png`;
+              const screenshotBuffer = readFileSync(screenshotPath);
+
+              const worker = await this.createOcrWorker();
+              const { data: { text } } = await worker.recognize(screenshotBuffer);
+              await worker.terminate();
+              
+              if (text.trim()) {
+                const textInsights = await this.analyzeTextContent(text);
+                insights.push(...textInsights);
+              }
+            }
+
+            resolve({
+              insights: this.consolidateInsights(insights),
+              text: '',
+              metadata
+            });
+          } catch (error) {
+            reject(error);
+          }
+        })
+        .on('error', reject)
+        .ffprobe((err, data) => {
+          if (!err && data) {
+            metadata = {
+              duration: data.format?.duration,
+              width: data.streams?.[0]?.width,
+              height: data.streams?.[0]?.height,
+              format: data.format?.format_name
+            };
+          }
+        });
+    });
+  }
+
+  private async downloadFile(url: string): Promise<Buffer> {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download file from ${url}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  private async analyzeImageContent(imageBuffer: Buffer, text: string): Promise<unknown[]> {
+    const insights: unknown[] = [];
+    const normalizedText = text.toLowerCase();
+    
+    if (normalizedText.includes('dashboard') || normalizedText.includes('analytics')) {
+      insights.push({
+        type: 'metric',
+        confidence: 0.8,
+        content: 'Analytics dashboard detected',
+        keywords: ['dashboard', 'analytics', 'metrics']
+      });
+    }
+    
+    if (normalizedText.includes('before') || normalizedText.includes('after')) {
+      insights.push({
+        type: 'comparison',
+        confidence: 0.9,
+        content: 'Before/after comparison detected',
+        keywords: ['before', 'after', 'comparison']
+      });
+    }
+
+    const colorAnalysis = await this.analyzeImageColors(imageBuffer);
+    if (colorAnalysis.dominantColors.length > 0) {
+      insights.push({
+        type: 'design',
+        confidence: 0.7,
+        content: 'Color palette analysis',
+        colors: colorAnalysis.dominantColors
+      });
+    }
+
+    return insights;
+  }
+
+  private async analyzeTextContent(text: string): Promise<unknown[]> {
+    const insights: unknown[] = [];
+    const normalized = text.toLowerCase();
+    
+    const problemKeywords = ['problem', 'challenge', 'issue', 'pain point', 'difficulty'];
+    const solutionKeywords = ['solution', 'approach', 'strategy', 'implementation'];
+    const impactKeywords = ['result', 'improvement', 'increase', 'decrease', 'success'];
+
+    if (problemKeywords.some(keyword => normalized.includes(keyword))) {
+      insights.push({
+        type: 'problem',
+        confidence: 0.8,
+        content: this.extractSentencesContaining(text, problemKeywords),
+        keywords: problemKeywords
+      });
+    }
+
+    if (solutionKeywords.some(keyword => normalized.includes(keyword))) {
+      insights.push({
+        type: 'solution',
+        confidence: 0.8,
+        content: this.extractSentencesContaining(text, solutionKeywords),
+        keywords: solutionKeywords
+      });
+    }
+
+    if (impactKeywords.some(keyword => normalized.includes(keyword))) {
+      insights.push({
+        type: 'impact',
+        confidence: 0.8,
+        content: this.extractSentencesContaining(text, impactKeywords),
+        keywords: impactKeywords
+      });
+    }
+
+    const metricPattern = /(\d+(?:\.\d+)?%|\$\d+(?:,\d{3})*(?:\.\d{2})?|\d+(?:,\d{3})*)/g;
+    const metrics = text.match(metricPattern);
+    if (metrics && metrics.length > 0) {
+      insights.push({
+        type: 'metric',
+        confidence: 0.9,
+        content: 'Performance metrics detected',
+        metrics: metrics
+      });
+    }
+
+    return insights;
+  }
+
+  private extractSentencesContaining(text: string, keywords: string[]): string {
+    const sentences = text.split(/[.!?]+/);
+    return sentences
+      .filter(sentence => 
+        keywords.some(keyword => 
+          sentence.toLowerCase().includes(keyword.toLowerCase())
+        )
+      )
+      .join('. ')
+      .trim();
+  }
+
+  private async analyzeImageColors(imageBuffer: Buffer): Promise<{ dominantColors: string[] }> {
+    const stats = await sharp(imageBuffer).stats();
+    const dominant = stats.dominant;
+    if (!dominant) {
+      return { dominantColors: [] };
+    }
+
+    return {
+      dominantColors: [
+        `rgb(${dominant.r}, ${dominant.g}, ${dominant.b})`
+      ]
+    };
+  }
+
+  private consolidateInsights(insights: unknown[]): unknown[] {
+    const grouped = new Map<string, any>();
+    
+    for (const insight of insights as Array<Record<string, any>>) {
+      const type = insight.type ?? 'general';
+      const content = typeof insight.content === 'string' ? insight.content : JSON.stringify(insight.content ?? '');
+      const key = `${type}-${content.substring(0, 50)}`;
+      if (!grouped.has(key)) {
+        grouped.set(key, insight);
+      } else {
+        const existing = grouped.get(key);
+        existing.confidence = Math.max(existing.confidence ?? 0, insight.confidence ?? 0);
+      }
+    }
+    
+    return Array.from(grouped.values());
+  }
+
+  private async createOcrWorker(): Promise<Worker> {
+    const worker = await createWorker();
+    await worker.loadLanguage('eng');
+    await worker.initialize('eng');
+    return worker;
+  }
+}

--- a/server/src/types/analysis.ts
+++ b/server/src/types/analysis.ts
@@ -1,0 +1,54 @@
+export interface AnalysisInsight {
+  type: 'problem' | 'solution' | 'impact' | 'process' | 'metric' | string;
+  confidence: number;
+  content: string;
+  evidence?: string[];
+  source: string; // file ID or name
+  [key: string]: unknown;
+}
+
+export interface ProblemAnalysis {
+  primary: string;
+  confidence: number;
+  evidence: string[];
+  alternatives: string[];
+}
+
+export interface SolutionAnalysis {
+  primary: string;
+  confidence: number;
+  keyElements: string[];
+  designPatterns: string[];
+}
+
+export interface ImpactAnalysis {
+  primary: string;
+  confidence: number;
+  metrics: Array<{
+    metric: string;
+    before: string;
+    after: string;
+    change: string;
+  }>;
+  businessValue: string;
+}
+
+export interface ProjectNarrative {
+  story: string;
+  challenges: string[];
+  process: string[];
+}
+
+export interface AnalysisResult {
+  confidence: number;
+  processingTime: number;
+  filesAnalyzed: number;
+  insights: number;
+  problem: ProblemAnalysis;
+  solution: SolutionAnalysis;
+  impact: ImpactAnalysis;
+  narrative: ProjectNarrative;
+  suggestedTitle: string;
+  suggestedCategory: string;
+  tags: string[];
+}

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -1,0 +1,10 @@
+import 'express';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    user?: {
+      id: string;
+      [key: string]: unknown;
+    };
+  }
+}

--- a/server/src/types/pdf2pic.d.ts
+++ b/server/src/types/pdf2pic.d.ts
@@ -1,0 +1,18 @@
+declare module 'pdf2pic' {
+  export interface ConvertOptions {
+    density?: number;
+    saveFilename?: string;
+    savePath?: string;
+    format?: string;
+    width?: number;
+    height?: number;
+  }
+
+  export interface FromBufferResult {
+    bulk: (pageRange: number) => Promise<Array<{ name: string; size: number; path: string }>>;
+  }
+
+  export function fromBuffer(data: Buffer, options?: ConvertOptions): FromBufferResult;
+  export const fromPath: unknown;
+  export default function pdf2pic(): void;
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"],
+    "typeRoots": [
+      "./src/types",
+      "./node_modules/@types"
+    ]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add Prisma models to support project, file, and analysis metadata
- implement Express-based services for file processing and AI-driven project analysis
- configure background job queue, API routes, and container resources for the analysis pipeline

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc80682a3c832fa4e2e5609d6fcec9