### PR TITLE
Enable editing saved projects and managing local assets

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -225,6 +225,12 @@ input, textarea, select {
   text-decoration: none;
 }
 
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
 .button--primary {
   background: #2563eb;
   color: #f9fafb;
@@ -245,6 +251,22 @@ input, textarea, select {
 
 .button--ghost:hover {
   border-color: #111827;
+}
+
+.button--small {
+  padding: 0.45rem 0.85rem;
+  font-size: 0.9rem;
+  border-radius: 8px;
+}
+
+.button--danger {
+  border-color: rgba(220, 38, 38, 0.18);
+  color: #dc2626;
+}
+
+.button--danger:hover {
+  background: rgba(220, 38, 38, 0.08);
+  border-color: #dc2626;
 }
 
 .saved-projects {
@@ -375,6 +397,10 @@ input, textarea, select {
   gap: 1rem;
 }
 
+.editor-page__card--form {
+  grid-column: 1 / -1;
+}
+
 .editor-page__card--files {
   grid-column: 1 / -1;
   padding: 0;
@@ -403,6 +429,186 @@ input, textarea, select {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1.25rem;
+}
+
+.editor-page__card-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.editor-page__card-subtitle {
+  margin: 0.35rem 0 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.editor-page__meta-text {
+  font-size: 0.85rem;
+  color: #6b7280;
+  align-self: center;
+}
+
+.editor-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.editor-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.editor-form__input,
+.editor-form__textarea {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.65rem 0.85rem;
+  font-size: 1rem;
+  background: #f9fafb;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.editor-form__input:focus,
+.editor-form__textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  background: #ffffff;
+}
+
+.editor-form__textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.editor-form__field small {
+  color: #6b7280;
+}
+
+.editor-form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.editor-page__file-input {
+  display: none;
+}
+
+.editor-page__card-helper {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.editor-feedback {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.editor-feedback--success {
+  background: rgba(16, 185, 129, 0.16);
+  color: #047857;
+}
+
+.editor-feedback--error {
+  background: rgba(220, 38, 38, 0.14);
+  color: #b91c1c;
+}
+
+.editor-feedback--info {
+  background: rgba(59, 130, 246, 0.14);
+  color: #1d4ed8;
+}
+
+.editor-assets__empty {
+  border: 1px dashed #d1d5db;
+  border-radius: 14px;
+  padding: 1.5rem;
+  text-align: center;
+  color: #6b7280;
+  background: #f9fafb;
+}
+
+.editor-assets__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.editor-assets__item {
+  display: grid;
+  grid-template-columns: minmax(52px, max-content) minmax(0, 1fr) max-content;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: #ffffff;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.06);
+}
+
+.editor-assets__preview {
+  width: 60px;
+  height: 60px;
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f4f6;
+}
+
+.editor-assets__preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.editor-assets__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-weight: 600;
+  color: #3730a3;
+  background: #eef2ff;
+}
+
+.editor-assets__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.editor-assets__meta span {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.editor-assets__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 720px) {
+  .editor-assets__item {
+    grid-template-columns: minmax(52px, max-content) minmax(0, 1fr);
+  }
+
+  .editor-assets__actions {
+    justify-content: flex-start;
+  }
 }
 
 .file-explorer__header-copy {

--- a/src/intake/schema.ts
+++ b/src/intake/schema.ts
@@ -1,3 +1,13 @@
+export type ProjectAsset = {
+  id: string
+  name: string
+  mimeType: string
+  size: number
+  dataUrl: string
+  addedAt: string
+  description?: string
+}
+
 export type ProjectMeta = {
   title: string
   slug: string
@@ -8,6 +18,8 @@ export type ProjectMeta = {
   technologies?: string[]
   cover?: string    // relative path to 06_Exports/cover.jpg
   createdAt: string
+  updatedAt?: string
+  assets: ProjectAsset[]
 }
 
 export const defaultTags = [
@@ -22,5 +34,7 @@ export const newProject = (title: string): ProjectMeta => ({
   solution: "",
   outcomes: "",
   tags: [],
-  createdAt: new Date().toISOString()
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  assets: []
 })

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -1,10 +1,249 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { loadProject } from '../utils/fileStore'
 import ProjectFileExplorer from '../components/ProjectFileExplorer'
+import { loadProject, saveProject } from '../utils/fileStore'
+import type { ProjectAsset, ProjectMeta } from '../intake/schema'
+
+type FormState = {
+  title: string
+  problem: string
+  solution: string
+  outcomes: string
+  tags: string
+  technologies: string
+}
+
+type Feedback = { type: 'success' | 'error' | 'info'; message: string }
+
+const initialFormState: FormState = {
+  title: '',
+  problem: '',
+  solution: '',
+  outcomes: '',
+  tags: '',
+  technologies: '',
+}
+
+const parseList = (value: string) =>
+  value
+    .split(/[;,\n]+/)
+    .map(entry => entry.trim())
+    .filter(Boolean)
+
+const createAssetId = () =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `asset-${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+const formatBytes = (bytes: number) => {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B'
+  }
+  const units = ['B', 'KB', 'MB', 'GB']
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  const value = bytes / 1024 ** exponent
+  return `${value >= 10 || exponent === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[exponent]}`
+}
+
+const MAX_INLINE_ASSET_SIZE = 5 * 1024 * 1024
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+      } else {
+        reject(new Error('Unsupported file type'))
+      }
+    }
+    reader.onerror = () => {
+      reject(reader.error ?? new Error('Unable to read file'))
+    }
+    reader.readAsDataURL(file)
+  })
 
 export default function EditorPage() {
   const { slug } = useParams()
+  const [project, setProject] = useState<ProjectMeta | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [formState, setFormState] = useState<FormState>(initialFormState)
+  const [isDirty, setIsDirty] = useState(false)
+  const [formFeedback, setFormFeedback] = useState<Feedback | null>(null)
+  const [assetFeedback, setAssetFeedback] = useState<Feedback | null>(null)
+  const assetInputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    setIsLoading(true)
+    if (!slug) {
+      setProject(null)
+      setIsLoading(false)
+      return
+    }
+
+    const meta = loadProject(slug)
+    setProject(meta)
+    setIsLoading(false)
+  }, [slug])
+
+  useEffect(() => {
+    if (!project) {
+      setFormState(initialFormState)
+      setIsDirty(false)
+      return
+    }
+
+    setFormState({
+      title: project.title,
+      problem: project.problem,
+      solution: project.solution,
+      outcomes: project.outcomes,
+      tags: project.tags.join(', '),
+      technologies: project.technologies?.join(', ') ?? '',
+    })
+    setIsDirty(false)
+  }, [project?.slug, project?.updatedAt])
+
+  useEffect(() => {
+    if (!formFeedback) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => setFormFeedback(null), 3000)
+    return () => window.clearTimeout(timeout)
+  }, [formFeedback])
+
+  useEffect(() => {
+    if (!assetFeedback) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => setAssetFeedback(null), 4000)
+    return () => window.clearTimeout(timeout)
+  }, [assetFeedback])
+
+  const handleFieldChange = (field: keyof FormState, value: string) => {
+    setFormState(previous => ({
+      ...previous,
+      [field]: value,
+    }))
+    setIsDirty(true)
+  }
+
+  const handleSave = (event?: React.FormEvent) => {
+    event?.preventDefault()
+    if (!project) {
+      return
+    }
+
+    const tags = parseList(formState.tags)
+    const technologies = parseList(formState.technologies)
+    const timestamp = new Date().toISOString()
+
+    const updatedProject: ProjectMeta = {
+      ...project,
+      title: formState.title.trim() || project.title,
+      problem: formState.problem.trim(),
+      solution: formState.solution.trim(),
+      outcomes: formState.outcomes.trim(),
+      tags,
+      technologies: technologies.length > 0 ? technologies : undefined,
+      updatedAt: timestamp,
+    }
+
+    try {
+      saveProject(updatedProject)
+      setProject(updatedProject)
+      setIsDirty(false)
+      setFormFeedback({ type: 'success', message: 'Project details updated.' })
+    } catch (error) {
+      console.error('Unable to save project', error)
+      setFormFeedback({ type: 'error', message: 'Something went wrong while saving changes.' })
+    }
+  }
+
+  const handleAssetUpload = async (fileList: FileList | null) => {
+    if (!project || !fileList || fileList.length === 0) {
+      return
+    }
+
+    const files = Array.from(fileList)
+    const skipped: string[] = []
+    const additions: ProjectAsset[] = []
+
+    for (const file of files) {
+      if (file.size > MAX_INLINE_ASSET_SIZE) {
+        skipped.push(`${file.name} (${formatBytes(file.size)})`)
+        continue
+      }
+
+      try {
+        const dataUrl = await readFileAsDataUrl(file)
+        additions.push({
+          id: createAssetId(),
+          name: file.name,
+          mimeType: file.type || 'application/octet-stream',
+          size: file.size,
+          dataUrl,
+          addedAt: new Date().toISOString(),
+        })
+      } catch (error) {
+        console.error('Unable to read uploaded file', error)
+        skipped.push(`${file.name} (failed to read)`) 
+      }
+    }
+
+    if (assetInputRef.current) {
+      assetInputRef.current.value = ''
+    }
+
+    if (additions.length === 0) {
+      setAssetFeedback({
+        type: 'error',
+        message: skipped.length > 0 ? `Unable to add files: ${skipped.join(', ')}` : 'No files were added.',
+      })
+      return
+    }
+
+    const timestamp = new Date().toISOString()
+    const updatedProject: ProjectMeta = {
+      ...project,
+      assets: [...project.assets, ...additions],
+      updatedAt: timestamp,
+    }
+
+    saveProject(updatedProject)
+    setProject(updatedProject)
+
+    setAssetFeedback({
+      type: skipped.length > 0 ? 'info' : 'success',
+      message:
+        skipped.length > 0
+          ? `Added ${additions.length} asset${additions.length === 1 ? '' : 's'}, skipped ${skipped.length}.`
+          : `Added ${additions.length} asset${additions.length === 1 ? '' : 's'}.`,
+    })
+  }
+
+  const handleAssetRemove = (assetId: string) => {
+    if (!project) {
+      return
+    }
+
+    const updatedAssets = project.assets.filter(asset => asset.id !== assetId)
+    const timestamp = new Date().toISOString()
+    const updatedProject: ProjectMeta = {
+      ...project,
+      assets: updatedAssets,
+      updatedAt: timestamp,
+    }
+
+    saveProject(updatedProject)
+    setProject(updatedProject)
+    setAssetFeedback({ type: 'success', message: 'Asset removed from project.' })
+  }
+
+  const assetCount = project?.assets.length ?? 0
+  const lastUpdated = project?.updatedAt ? new Date(project.updatedAt).toLocaleString() : null
 
   if (!slug) {
     return (
@@ -15,9 +254,17 @@ export default function EditorPage() {
     )
   }
 
-  const meta = loadProject(slug)
+  if (isLoading) {
+    return (
+      <div className="editor-page">
+        <div className="editor-page__card">
+          <p>Loading project…</p>
+        </div>
+      </div>
+    )
+  }
 
-  if (!meta) {
+  if (!project) {
     return (
       <div className="editor-page">
         <div className="editor-page__card">
@@ -29,45 +276,236 @@ export default function EditorPage() {
     )
   }
 
+  const assetLimitCopy = `Uploads are stored locally (max ${formatBytes(MAX_INLINE_ASSET_SIZE)} per file).`
+
   return (
     <div className="editor-page">
       <header className="editor-page__header">
         <div>
           <p className="editor-page__eyebrow">Project workspace</p>
-          <h1>{meta.title}</h1>
+          <h1>{project.title}</h1>
         </div>
         <Link to="/intake" className="button button--ghost">Switch project</Link>
       </header>
 
       <div className="editor-page__grid">
+        <section className="editor-page__card editor-page__card--form">
+          <div className="editor-page__card-header">
+            <div>
+              <h2>Edit project details</h2>
+              <p className="editor-page__card-subtitle">Keep the narrative and metadata up to date.</p>
+            </div>
+            {lastUpdated && <span className="editor-page__meta-text">Last updated {lastUpdated}</span>}
+          </div>
+
+          {formFeedback && (
+            <div className={`editor-feedback editor-feedback--${formFeedback.type}`}>
+              {formFeedback.message}
+            </div>
+          )}
+
+          <form className="editor-form" onSubmit={handleSave}>
+            <label className="editor-form__field">
+              <span>Project title</span>
+              <input
+                type="text"
+                value={formState.title}
+                onChange={event => handleFieldChange('title', event.target.value)}
+                className="editor-form__input"
+                placeholder="Design system refresh"
+              />
+            </label>
+
+            <label className="editor-form__field">
+              <span>Problem</span>
+              <textarea
+                value={formState.problem}
+                onChange={event => handleFieldChange('problem', event.target.value)}
+                className="editor-form__textarea"
+                rows={3}
+                placeholder="What challenge did this project address?"
+              />
+            </label>
+
+            <label className="editor-form__field">
+              <span>Solution</span>
+              <textarea
+                value={formState.solution}
+                onChange={event => handleFieldChange('solution', event.target.value)}
+                className="editor-form__textarea"
+                rows={3}
+                placeholder="Summarise the approach and key decisions."
+              />
+            </label>
+
+            <label className="editor-form__field">
+              <span>Outcomes</span>
+              <textarea
+                value={formState.outcomes}
+                onChange={event => handleFieldChange('outcomes', event.target.value)}
+                className="editor-form__textarea"
+                rows={3}
+                placeholder="Highlight measurable impact or learnings."
+              />
+            </label>
+
+            <label className="editor-form__field">
+              <span>Tags</span>
+              <input
+                type="text"
+                value={formState.tags}
+                onChange={event => handleFieldChange('tags', event.target.value)}
+                className="editor-form__input"
+                placeholder="branding, ui design, automation"
+              />
+              <small>Separate tags with commas, semicolons, or line breaks.</small>
+            </label>
+
+            <label className="editor-form__field">
+              <span>Technologies</span>
+              <input
+                type="text"
+                value={formState.technologies}
+                onChange={event => handleFieldChange('technologies', event.target.value)}
+                className="editor-form__input"
+                placeholder="React, Prisma, Figma"
+              />
+              <small>Optional. These help when generating case studies.</small>
+            </label>
+
+            <div className="editor-form__actions">
+              <button type="submit" className="button button--primary" disabled={!isDirty}>
+                Save changes
+              </button>
+              <button
+                type="button"
+                className="button button--ghost"
+                onClick={() => {
+                  if (project) {
+                    setFormState({
+                      title: project.title,
+                      problem: project.problem,
+                      solution: project.solution,
+                      outcomes: project.outcomes,
+                      tags: project.tags.join(', '),
+                      technologies: project.technologies?.join(', ') ?? '',
+                    })
+                    setIsDirty(false)
+                  }
+                }}
+                disabled={!isDirty}
+              >
+                Reset
+              </button>
+            </div>
+          </form>
+        </section>
+
         <section className="editor-page__card">
           <h2>Quick summary</h2>
           <dl className="editor-page__summary">
             <div>
               <dt>Problem</dt>
-              <dd>{meta.problem || '—'}</dd>
+              <dd>{project.problem || '—'}</dd>
             </div>
             <div>
               <dt>Solution</dt>
-              <dd>{meta.solution || '—'}</dd>
+              <dd>{project.solution || '—'}</dd>
             </div>
             <div>
               <dt>Outcomes</dt>
-              <dd>{meta.outcomes || '—'}</dd>
+              <dd>{project.outcomes || '—'}</dd>
             </div>
             <div>
               <dt>Tags</dt>
-              <dd>{meta.tags.length > 0 ? meta.tags.join(', ') : '—'}</dd>
+              <dd>{project.tags.length > 0 ? project.tags.join(', ') : '—'}</dd>
+            </div>
+            <div>
+              <dt>Technologies</dt>
+              <dd>{project.technologies?.length ? project.technologies.join(', ') : '—'}</dd>
+            </div>
+            <div>
+              <dt>Assets</dt>
+              <dd>{assetCount}</dd>
             </div>
             <div>
               <dt>Created</dt>
-              <dd>{new Date(meta.createdAt).toLocaleString()}</dd>
+              <dd>{new Date(project.createdAt).toLocaleString()}</dd>
             </div>
           </dl>
         </section>
 
+        <section className="editor-page__card editor-page__card--assets">
+          <div className="editor-page__card-header">
+            <div>
+              <h2>Project assets</h2>
+              <p className="editor-page__card-subtitle">Drop in supporting files, briefs, or exports.</p>
+            </div>
+            <button type="button" className="button button--primary button--small" onClick={() => assetInputRef.current?.click()}>
+              Upload files
+            </button>
+            <input
+              ref={assetInputRef}
+              type="file"
+              className="editor-page__file-input"
+              multiple
+              onChange={event => handleAssetUpload(event.target.files)}
+            />
+          </div>
+
+          <p className="editor-page__card-helper">{assetLimitCopy}</p>
+
+          {assetFeedback && (
+            <div className={`editor-feedback editor-feedback--${assetFeedback.type}`}>
+              {assetFeedback.message}
+            </div>
+          )}
+
+          {project.assets.length === 0 ? (
+            <div className="editor-assets__empty">
+              <p>No assets yet. Upload renders, documents, or media to keep everything together.</p>
+            </div>
+          ) : (
+            <ul className="editor-assets__list">
+              {project.assets.map(asset => {
+                const isImage = asset.mimeType.startsWith('image/')
+                return (
+                  <li key={asset.id} className="editor-assets__item">
+                    <div className="editor-assets__preview">
+                      {isImage ? (
+                        <img src={asset.dataUrl} alt={asset.name} />
+                      ) : (
+                        <span className="editor-assets__icon">{asset.mimeType.split('/')[0].toUpperCase()}</span>
+                      )}
+                    </div>
+                    <div className="editor-assets__meta">
+                      <strong>{asset.name}</strong>
+                      <span>
+                        {formatBytes(asset.size)} • Added{' '}
+                        {new Date(asset.addedAt).toLocaleDateString()} 
+                      </span>
+                    </div>
+                    <div className="editor-assets__actions">
+                      <a href={asset.dataUrl} download={asset.name} className="button button--ghost button--small">
+                        Download
+                      </a>
+                      <button
+                        type="button"
+                        className="button button--ghost button--danger button--small"
+                        onClick={() => handleAssetRemove(asset.id)}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </section>
+
         <section className="editor-page__card editor-page__card--files">
-          <ProjectFileExplorer projectSlug={slug} projectTitle={meta.title} />
+          <ProjectFileExplorer projectSlug={slug} projectTitle={project.title} />
         </section>
 
         <section className="editor-page__card editor-page__card--placeholder">

--- a/src/utils/fileStore.ts
+++ b/src/utils/fileStore.ts
@@ -1,15 +1,88 @@
-import type { ProjectMeta } from '../intake/schema'
+import type { ProjectAsset, ProjectMeta } from '../intake/schema'
 
 const KEY = 'pf-projects-v1'
 
 type Store = Record<string, ProjectMeta>
 
-const readStore = (): Store => JSON.parse(localStorage.getItem(KEY) || '{}')
+const isAssetArray = (value: unknown): value is ProjectAsset[] =>
+  Array.isArray(value) &&
+  value.every(asset =>
+    asset &&
+    typeof asset === 'object' &&
+    'id' in asset &&
+    typeof (asset as ProjectAsset).id === 'string',
+  )
+
+const normaliseStringArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item): item is string => typeof item === 'string')
+      .map(item => item.trim())
+      .filter(item => item.length > 0)
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(/[;,]+/)
+      .map(item => item.trim())
+      .filter(item => item.length > 0)
+  }
+
+  return []
+}
+
+const readStore = (): Store => {
+  const raw = JSON.parse(localStorage.getItem(KEY) || '{}') as Record<string, unknown>
+  const normalised: Store = {}
+
+  Object.entries(raw).forEach(([slug, entry]) => {
+    if (!entry || typeof entry !== 'object') {
+      return
+    }
+
+    const meta = entry as Partial<ProjectMeta> & Record<string, unknown>
+
+    const tags = normaliseStringArray(meta.tags)
+    const technologiesArray = normaliseStringArray(meta.technologies)
+    const assets = isAssetArray(meta.assets) ? meta.assets : []
+
+    const createdAt = typeof meta.createdAt === 'string' ? meta.createdAt : new Date().toISOString()
+    const updatedAt = typeof meta.updatedAt === 'string' ? meta.updatedAt : createdAt
+
+    normalised[slug] = {
+      title: typeof meta.title === 'string' ? meta.title : slug,
+      slug,
+      problem: typeof meta.problem === 'string' ? meta.problem : '',
+      solution: typeof meta.solution === 'string' ? meta.solution : '',
+      outcomes: typeof meta.outcomes === 'string' ? meta.outcomes : '',
+      tags,
+      technologies: technologiesArray.length > 0 ? technologiesArray : undefined,
+      cover: typeof meta.cover === 'string' ? meta.cover : undefined,
+      createdAt,
+      updatedAt,
+      assets,
+    }
+  })
+
+  return normalised
+}
+
 const writeStore = (store: Store) => localStorage.setItem(KEY, JSON.stringify(store))
 
 export function saveProject(meta: ProjectMeta) {
   const store = readStore()
-  store[meta.slug] = meta
+  const timestamp = new Date().toISOString()
+  store[meta.slug] = {
+    ...meta,
+    slug: meta.slug,
+    createdAt: meta.createdAt,
+    updatedAt: timestamp,
+    tags: Array.isArray(meta.tags) ? meta.tags : [],
+    technologies: Array.isArray(meta.technologies)
+      ? meta.technologies.filter(Boolean)
+      : undefined,
+    assets: Array.isArray(meta.assets) ? meta.assets : [],
+  }
   writeStore(store)
 }
 


### PR DESCRIPTION
## Summary
- add project asset metadata to the schema and persistence layer
- capture uploaded files as stored assets during intake and expose metadata editing in the workspace
- add an asset manager UI with supporting styling updates on the editor page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc8406b1a4832fb3d1916364fc8af6