### PR TITLE
Add AI analysis workspace page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Link, Route, Routes, Navigate } from 'react-router-dom'
 import IntakePage from './pages/IntakePage'
 import EditorPage from './pages/EditorPage'
+import PortfolioForgeAIAnalysis from './pages/PortfolioForgeAIAnalysis'
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
           <nav className="app-nav">
             <Link to="/intake" className="app-nav__link">New project</Link>
             <Link to={{ pathname: '/intake', hash: '#saved-projects' }} className="app-nav__link">Saved projects</Link>
+            <Link to="/analysis" className="app-nav__link">AI analysis</Link>
           </nav>
         </div>
       </header>
@@ -25,6 +27,7 @@ function App() {
           <Route path="/" element={<Navigate to="/intake" replace />} />
           <Route path="/intake" element={<IntakePage />} />
           <Route path="/editor/:slug" element={<EditorPage />} />
+          <Route path="/analysis" element={<PortfolioForgeAIAnalysis />} />
         </Routes>
       </main>
     </div>

--- a/src/pages/PortfolioForgeAIAnalysis.css
+++ b/src/pages/PortfolioForgeAIAnalysis.css
@@ -1,0 +1,887 @@
+.analysis-page {
+  min-height: 100vh;
+  background: #f3f4f6;
+  color: #111827;
+  display: flex;
+  flex-direction: column;
+}
+
+.analysis-page--dark {
+  background: #0b1120;
+  color: #e2e8f0;
+}
+
+.analysis-page__header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: #ffffff;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+.analysis-page--dark .analysis-page__header {
+  background: #0f172a;
+  border-bottom-color: rgba(30, 41, 59, 0.85);
+  box-shadow: 0 18px 42px rgba(2, 6, 23, 0.65);
+}
+
+.analysis-header__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem 2rem;
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.analysis-header__meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.analysis-header__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.2), rgba(79, 70, 229, 0.25));
+  color: #5b21b6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.analysis-page--dark .analysis-header__icon {
+  background: linear-gradient(135deg, rgba(167, 139, 250, 0.3), rgba(99, 102, 241, 0.35));
+  color: #c4b5fd;
+}
+
+.analysis-header__title {
+  font-size: clamp(1.5rem, 2.2vw, 2.1rem);
+  font-weight: 600;
+}
+
+.analysis-header__subtitle {
+  margin-top: 0.25rem;
+  color: #475569;
+}
+
+.analysis-page--dark .analysis-header__subtitle {
+  color: #94a3b8;
+}
+
+.analysis-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.analysis-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: none;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.analysis-page--dark .analysis-toggle {
+  background: rgba(148, 163, 184, 0.15);
+  color: #e2e8f0;
+}
+
+.analysis-page__layout {
+  flex: 1;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 2rem;
+  padding: 2.5rem 2rem 3.5rem;
+  align-items: flex-start;
+}
+
+@media (max-width: 1080px) {
+  .analysis-page__layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .analysis-sidebar {
+    position: static;
+  }
+}
+
+.analysis-panel {
+  background: #ffffff;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 16px 42px rgba(15, 23, 42, 0.08);
+}
+
+.analysis-page--dark .analysis-panel {
+  background: #111827;
+  border-color: rgba(148, 163, 184, 0.18);
+  box-shadow: 0 20px 48px rgba(2, 6, 23, 0.6);
+}
+
+.analysis-sidebar {
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  position: sticky;
+  top: 6.5rem;
+}
+
+.analysis-sidebar__title {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.analysis-sidebar__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  text-align: center;
+}
+
+.analysis-sidebar__stat strong {
+  display: block;
+  font-size: 1.75rem;
+  color: #4f46e5;
+}
+
+.analysis-page--dark .analysis-sidebar__stat strong {
+  color: #c4b5fd;
+}
+
+.analysis-sidebar__stat span {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
+}
+
+.analysis-page--dark .analysis-sidebar__stat span {
+  color: #94a3b8;
+}
+
+.analysis-sidebar__meta {
+  border-top: 1px solid rgba(148, 163, 184, 0.4);
+  padding-top: 1rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.analysis-page--dark .analysis-sidebar__meta {
+  border-top-color: rgba(148, 163, 184, 0.25);
+  color: #cbd5f5;
+}
+
+.analysis-sidebar__files {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.analysis-file-card {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.analysis-file-card:hover {
+  transform: translateY(-2px);
+  border-color: #6366f1;
+  box-shadow: 0 12px 28px rgba(99, 102, 241, 0.18);
+}
+
+.analysis-page--dark .analysis-file-card {
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.analysis-page--dark .analysis-file-card:hover {
+  border-color: #8b5cf6;
+  box-shadow: 0 14px 32px rgba(79, 70, 229, 0.35);
+}
+
+.analysis-file-card__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.analysis-page--dark .analysis-file-card__icon {
+  background: rgba(99, 102, 241, 0.22);
+  color: #c4b5fd;
+}
+
+.analysis-file-card__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.analysis-file-card__insights {
+  margin-top: 0.45rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.analysis-file-card__insight {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #4f46e5;
+}
+
+.analysis-file-card__bullet {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: #4f46e5;
+}
+
+.analysis-page--dark .analysis-file-card__insight {
+  color: #c4b5fd;
+}
+
+.analysis-page--dark .analysis-file-card__bullet {
+  background: #c4b5fd;
+}
+
+.analysis-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analysis-progress {
+  padding: 3rem 2.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analysis-progress__icon {
+  width: 68px;
+  height: 68px;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.analysis-page--dark .analysis-progress__icon {
+  background: rgba(99, 102, 241, 0.2);
+  color: #c4b5fd;
+}
+
+.analysis-progress__title {
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.analysis-progress__description {
+  color: #475569;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.analysis-page--dark .analysis-progress__description {
+  color: #94a3b8;
+}
+
+.analysis-progress__bar {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  overflow: hidden;
+}
+
+.analysis-progress__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7c3aed, #6366f1);
+  transition: width 0.3s ease;
+}
+
+.analysis-progress__status {
+  font-weight: 600;
+  color: #4f46e5;
+}
+
+.analysis-page--dark .analysis-progress__status {
+  color: #c4b5fd;
+}
+
+.analysis-results {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analysis-complete {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.6rem 2rem;
+}
+
+.analysis-complete__icon {
+  width: 50px;
+  height: 50px;
+  border-radius: 14px;
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.analysis-page--dark .analysis-complete__icon {
+  background: rgba(34, 197, 94, 0.28);
+  color: #86efac;
+}
+
+.analysis-complete h2 {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.analysis-complete p {
+  color: #475569;
+}
+
+.analysis-page--dark .analysis-complete p {
+  color: #94a3b8;
+}
+
+.analysis-summary {
+  padding: 2rem 2.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analysis-summary__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.analysis-summary__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #64748b;
+  margin-bottom: 0.4rem;
+}
+
+.analysis-summary__value {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.analysis-page--dark .analysis-summary__label {
+  color: #94a3b8;
+}
+
+.analysis-summary__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.analysis-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.analysis-page--dark .analysis-tag {
+  background: rgba(99, 102, 241, 0.22);
+  color: #c4b5fd;
+}
+
+.analysis-summary__footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.analysis-page--dark .analysis-summary__footer {
+  color: #94a3b8;
+}
+
+.analysis-card__toggle {
+  width: 100%;
+  padding: 1.75rem 2rem;
+  background: transparent;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s ease;
+}
+
+.analysis-card__toggle:hover {
+  background: rgba(79, 70, 229, 0.08);
+}
+
+.analysis-page--dark .analysis-card__toggle:hover {
+  background: rgba(99, 102, 241, 0.16);
+}
+
+.analysis-card__details {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.analysis-card__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.analysis-page--dark .analysis-card__icon {
+  background: rgba(99, 102, 241, 0.2);
+  color: #c4b5fd;
+}
+
+.analysis-card__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.analysis-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.analysis-page--dark .analysis-card__meta {
+  color: #94a3b8;
+}
+
+.analysis-card__bullet {
+  color: inherit;
+}
+
+.analysis-card__status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.analysis-card__signal {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.analysis-card__signal--high {
+  background: #16a34a;
+}
+
+.analysis-card__signal--medium {
+  background: #facc15;
+}
+
+.analysis-card__signal--low {
+  background: #dc2626;
+}
+
+.analysis-card__content {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0 2rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analysis-page--dark .analysis-card__content {
+  border-top-color: rgba(148, 163, 184, 0.18);
+}
+
+.analysis-suggestion {
+  border-radius: 14px;
+  border: 1px solid rgba(99, 102, 241, 0.22);
+  background: rgba(99, 102, 241, 0.08);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.analysis-page--dark .analysis-suggestion {
+  background: rgba(99, 102, 241, 0.18);
+  border-color: rgba(129, 140, 248, 0.35);
+}
+
+.analysis-suggestion__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.analysis-suggestion__title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.analysis-suggestion__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.analysis-suggestion__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+}
+
+.analysis-page--dark .analysis-suggestion__status {
+  background: rgba(34, 197, 94, 0.28);
+  color: #86efac;
+}
+
+.analysis-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid rgba(99, 102, 241, 0.32);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.analysis-icon-button:hover {
+  background: rgba(99, 102, 241, 0.14);
+}
+
+.analysis-page--dark .analysis-icon-button {
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.analysis-page--dark .analysis-icon-button:hover {
+  background: rgba(99, 102, 241, 0.25);
+}
+
+.analysis-suggestion p {
+  color: #1f2937;
+  line-height: 1.6;
+}
+
+.analysis-page--dark .analysis-suggestion p {
+  color: #e2e8f0;
+}
+
+.analysis-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.analysis-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.analysis-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: flex-start;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.analysis-page--dark .analysis-list__item {
+  color: #e2e8f0;
+}
+
+.analysis-list__icon {
+  margin-top: 0.2rem;
+  color: #16a34a;
+}
+
+.analysis-list__icon--accent {
+  color: #4f46e5;
+}
+
+.analysis-list__icon--warning {
+  color: #f59e0b;
+}
+
+.analysis-page--dark .analysis-list__icon {
+  color: #86efac;
+}
+
+.analysis-page--dark .analysis-list__icon--accent {
+  color: #c4b5fd;
+}
+
+.analysis-page--dark .analysis-list__icon--warning {
+  color: #facc15;
+}
+
+.analysis-alternatives {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.analysis-alternative {
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(148, 163, 184, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.analysis-alternative:hover {
+  border-color: #6366f1;
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.analysis-alternative--active {
+  border-style: solid;
+  border-color: #4f46e5;
+  background: rgba(99, 102, 241, 0.15);
+}
+
+.analysis-page--dark .analysis-alternative {
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.analysis-page--dark .analysis-alternative:hover {
+  border-color: #8b5cf6;
+  background: rgba(129, 140, 248, 0.18);
+}
+
+.analysis-page--dark .analysis-alternative--active {
+  border-color: #a855f7;
+  background: rgba(129, 140, 248, 0.25);
+}
+
+.analysis-alternative__button {
+  border: none;
+  background: none;
+  color: #4f46e5;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.analysis-alternative__button:hover {
+  text-decoration: underline;
+}
+
+.analysis-page--dark .analysis-alternative__button {
+  color: #c4b5fd;
+}
+
+.analysis-two-column {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.analysis-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.analysis-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.analysis-page--dark .analysis-chip {
+  background: rgba(148, 163, 184, 0.28);
+  color: #e2e8f0;
+}
+
+.analysis-metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.analysis-metric-card {
+  border-radius: 14px;
+  padding: 1.2rem;
+  background: rgba(148, 163, 184, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.analysis-page--dark .analysis-metric-card {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.analysis-metric-card__change {
+  font-weight: 700;
+  margin-top: 0.35rem;
+  color: #16a34a;
+}
+
+.analysis-page--dark .analysis-metric-card__change {
+  color: #86efac;
+}
+
+.analysis-business-value {
+  margin-top: 0.5rem;
+  border-radius: 14px;
+  padding: 1.1rem 1.4rem;
+  background: rgba(22, 163, 74, 0.12);
+  color: #166534;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.analysis-page--dark .analysis-business-value {
+  background: rgba(34, 197, 94, 0.25);
+  color: #bbf7d0;
+}
+
+.analysis-process {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.analysis-process__step {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.analysis-process__index {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4f46e5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.analysis-page--dark .analysis-process__index {
+  background: rgba(99, 102, 241, 0.22);
+  color: #c4b5fd;
+}
+
+.analysis-footer {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-top: 0.5rem;
+}
+
+.analysis-page--dark .button--ghost {
+  background: rgba(30, 41, 59, 0.85);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: #e2e8f0;
+}
+
+.analysis-page--dark .button--ghost:hover {
+  background: rgba(51, 65, 85, 0.9);
+  border-color: rgba(148, 163, 184, 0.6);
+}
+
+.analysis-page--dark .button--primary {
+  box-shadow: 0 14px 28px rgba(79, 70, 229, 0.35);
+}
+
+@media (max-width: 720px) {
+  .analysis-header__inner {
+    padding: 1.25rem 1.25rem 1.5rem;
+  }
+
+  .analysis-page__layout {
+    padding: 2rem 1.25rem 3rem;
+  }
+
+  .analysis-card__toggle {
+    padding: 1.5rem 1.5rem 1.4rem;
+  }
+
+  .analysis-card__content {
+    padding: 0 1.5rem 1.5rem;
+  }
+}

--- a/src/pages/PortfolioForgeAIAnalysis.tsx
+++ b/src/pages/PortfolioForgeAIAnalysis.tsx
@@ -1,0 +1,694 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import {
+  AlertCircle,
+  ArrowRight,
+  Brain,
+  CheckCircle,
+  ChevronDown,
+  ChevronRight,
+  Edit3,
+  FileText,
+  Image,
+  Lightbulb,
+  MessageSquare,
+  Moon,
+  RefreshCw,
+  Sparkles,
+  Sun,
+  Target,
+  TrendingUp,
+  Video,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+import './PortfolioForgeAIAnalysis.css'
+
+type AnalysisStep = 'analyzing' | 'complete'
+
+type SuggestionType = 'problem' | 'solution' | 'impact' | 'narrative'
+
+type AnalysisSectionKey = SuggestionType
+
+type ProjectFile = {
+  id: string
+  name: string
+  type: 'image' | 'video' | 'document'
+  insights: string[]
+}
+
+type ProblemAnalysis = {
+  primary: string
+  confidence: number
+  evidence: string[]
+  alternatives: string[]
+}
+
+type SolutionAnalysis = {
+  primary: string
+  confidence: number
+  keyElements: string[]
+  designPatterns: string[]
+}
+
+type ImpactMetric = {
+  metric: string
+  before: string
+  after: string
+  change: string
+}
+
+type ImpactAnalysis = {
+  primary: string
+  confidence: number
+  metrics: ImpactMetric[]
+  businessValue: string
+}
+
+type NarrativeAnalysis = {
+  story: string
+  challenges: string[]
+  process: string[]
+}
+
+type AIAnalysis = {
+  confidence: number
+  processingTime: string
+  filesAnalyzed: number
+  insights: number
+  problem: ProblemAnalysis
+  solution: SolutionAnalysis
+  impact: ImpactAnalysis
+  narrative: NarrativeAnalysis
+  tags: string[]
+  suggestedTitle: string
+  suggestedCategory: string
+}
+
+const PROJECT_FILES: ProjectFile[] = [
+  {
+    id: 'f1',
+    name: 'Before-After-Comparison.png',
+    type: 'image',
+    insights: ['UI comparison', 'Design evolution', 'User interface improvement'],
+  },
+  {
+    id: 'f2',
+    name: 'User-Journey-Map.pdf',
+    type: 'document',
+    insights: ['User flow analysis', 'Pain point identification', 'Experience mapping'],
+  },
+  {
+    id: 'f3',
+    name: 'Prototype-Demo.mp4',
+    type: 'video',
+    insights: ['Interactive prototype', 'User testing', 'Feature demonstration'],
+  },
+  {
+    id: 'f4',
+    name: 'Analytics-Dashboard.png',
+    type: 'image',
+    insights: ['Performance metrics', 'User behavior data', 'Success indicators'],
+  },
+]
+
+const AI_ANALYSIS: AIAnalysis = {
+  confidence: 94,
+  processingTime: '2.3s',
+  filesAnalyzed: 8,
+  insights: 23,
+  problem: {
+    primary: 'Low user engagement and high abandonment rates in the checkout process',
+    confidence: 92,
+    evidence: [
+      'User journey map shows 68% drop-off at payment step',
+      'Before/after comparison reveals cluttered UI design',
+      'Analytics dashboard indicates 3.2 minute average completion time',
+      'User feedback mentions confusion about shipping options',
+    ],
+    alternatives: [
+      'Complex navigation structure causing user confusion',
+      'Lack of trust signals during payment process',
+      'Mobile responsiveness issues affecting conversion',
+    ],
+  },
+  solution: {
+    primary: 'Streamlined checkout flow with progressive disclosure and trust signals',
+    confidence: 89,
+    keyElements: [
+      'Reduced form fields from 12 to 6 essential inputs',
+      'Added progress indicators and breadcrumbs',
+      'Implemented guest checkout option',
+      'Enhanced mobile-first responsive design',
+      'Added security badges and payment icons',
+    ],
+    designPatterns: [
+      'Progressive disclosure',
+      'Single-page checkout',
+      'Auto-fill functionality',
+      'Error prevention and handling',
+    ],
+  },
+  impact: {
+    primary: '78% improvement in checkout completion rates',
+    confidence: 87,
+    metrics: [
+      { metric: 'Conversion Rate', before: '12.4%', after: '22.1%', change: '+78%' },
+      { metric: 'Completion Time', before: '3.2 min', after: '1.8 min', change: '-44%' },
+      { metric: 'User Satisfaction', before: '6.2/10', after: '8.7/10', change: '+40%' },
+      { metric: 'Mobile Conversions', before: '8.1%', after: '19.3%', change: '+138%' },
+    ],
+    businessValue: 'Generated an estimated $2.4M additional annual revenue',
+  },
+  narrative: {
+    story:
+      'This e-commerce checkout redesign transformed a frustrating user experience into a seamless conversion engine. By analyzing user behavior data and conducting usability testing, we identified that users were overwhelmed by too many form fields and lacked confidence in the security of their transaction. The solution focused on simplification and trust-building, resulting in a checkout process that not only converts better but also creates a positive lasting impression of the brand.',
+    challenges: [
+      'Balancing information collection needs with user experience',
+      'Maintaining security compliance while reducing friction',
+      'Ensuring mobile optimization without desktop compromise',
+    ],
+    process: [
+      'User research and behavior analysis',
+      'Competitive analysis and best practice review',
+      'Wireframing and prototype development',
+      'A/B testing and iterative refinement',
+      'Full deployment and performance monitoring',
+    ],
+  },
+  tags: [
+    'E-commerce',
+    'UX Design',
+    'Conversion Optimization',
+    'Mobile-First',
+    'User Research',
+    'A/B Testing',
+    'Checkout Flow',
+    'UI/UX',
+  ],
+  suggestedTitle: 'E-commerce Checkout Redesign: 78% Conversion Improvement',
+  suggestedCategory: 'UX/UI Design',
+}
+
+const FILE_ICONS: Record<ProjectFile['type'], LucideIcon> = {
+  image: Image,
+  video: Video,
+  document: FileText,
+}
+
+const INITIAL_SECTIONS: Record<AnalysisSectionKey, boolean> = {
+  problem: true,
+  solution: false,
+  impact: false,
+  narrative: false,
+}
+
+type AnalysisCardProps = {
+  title: string
+  confidence: number
+  isExpanded: boolean
+  onToggle: () => void
+  icon: LucideIcon
+  children: ReactNode
+}
+
+const AnalysisCard = ({ title, confidence, isExpanded, onToggle, icon: Icon, children }: AnalysisCardProps) => {
+  const confidenceLevel = confidence >= 90 ? 'high' : confidence >= 70 ? 'medium' : 'low'
+
+  return (
+    <section className="analysis-card analysis-panel">
+      <button type="button" className="analysis-card__toggle" onClick={onToggle}>
+        <div className="analysis-card__details">
+          <div className="analysis-card__icon">
+            <Icon size={20} />
+          </div>
+          <div>
+            <h3 className="analysis-card__title">{title}</h3>
+            <div className="analysis-card__meta">
+              <span className="analysis-card__confidence">{confidence}% confidence</span>
+              <span className="analysis-card__bullet" aria-hidden="true">
+                •
+              </span>
+              <span className="analysis-card__note">AI generated</span>
+            </div>
+          </div>
+        </div>
+        <div className="analysis-card__status">
+          <span className={`analysis-card__signal analysis-card__signal--${confidenceLevel}`} aria-hidden="true" />
+          {isExpanded ? <ChevronDown size={20} /> : <ChevronRight size={20} />}
+        </div>
+      </button>
+      {isExpanded ? <div className="analysis-card__content">{children}</div> : null}
+    </section>
+  )
+}
+
+type SuggestionCardProps = {
+  title: string
+  content: string
+  onApply: () => void
+  onEdit?: () => void
+  isApplied?: boolean
+}
+
+const SuggestionCard = ({ title, content, onApply, onEdit, isApplied }: SuggestionCardProps) => (
+  <div className="analysis-suggestion">
+    <div className="analysis-suggestion__header">
+      <h4 className="analysis-suggestion__title">{title}</h4>
+      <div className="analysis-suggestion__actions">
+        {isApplied ? (
+          <span className="analysis-suggestion__status">
+            <CheckCircle size={14} />
+            Applied
+          </span>
+        ) : null}
+        {onEdit ? (
+          <button type="button" className="analysis-icon-button" onClick={onEdit} aria-label={`Edit ${title}`}>
+            <Edit3 size={16} />
+          </button>
+        ) : null}
+        <button type="button" className="button button--primary button--small" onClick={onApply}>
+          Apply
+        </button>
+      </div>
+    </div>
+    <p>{content}</p>
+  </div>
+)
+
+export default function PortfolioForgeAIAnalysis() {
+  const [isDarkMode, setIsDarkMode] = useState(false)
+  const [analysisStep, setAnalysisStep] = useState<AnalysisStep>('analyzing')
+  const [analysisProgress, setAnalysisProgress] = useState(0)
+  const [analysisRunId, setAnalysisRunId] = useState(0)
+  const [expandedSections, setExpandedSections] = useState(INITIAL_SECTIONS)
+  const [customEdits, setCustomEdits] = useState<Partial<Record<SuggestionType, string>>>({})
+
+  useEffect(() => {
+    if (analysisStep !== 'analyzing') {
+      return
+    }
+
+    const timer = window.setInterval(() => {
+      setAnalysisProgress(previous => {
+        const nextValue = Math.min(previous + Math.random() * 12 + 6, 100)
+        if (nextValue >= 100) {
+          setAnalysisStep('complete')
+        }
+        return nextValue
+      })
+    }, 240)
+
+    return () => window.clearInterval(timer)
+  }, [analysisRunId, analysisStep])
+
+  const progressLabel = useMemo(() => {
+    if (analysisProgress < 25) {
+      return 'Scanning uploaded files...'
+    }
+    if (analysisProgress < 50) {
+      return 'Identifying design patterns...'
+    }
+    if (analysisProgress < 75) {
+      return 'Extracting user insights...'
+    }
+    if (analysisProgress < 100) {
+      return 'Generating narrative...'
+    }
+    return 'Analysis complete!'
+  }, [analysisProgress])
+
+  const handleToggleSection = (section: AnalysisSectionKey) => {
+    setExpandedSections(previous => ({
+      ...previous,
+      [section]: !previous[section],
+    }))
+  }
+
+  const handleApplySuggestion = (type: SuggestionType, content: string) => {
+    setCustomEdits(previous => ({
+      ...previous,
+      [type]: content,
+    }))
+  }
+
+  const handleApplyAllSuggestions = () => {
+    setCustomEdits({
+      problem: AI_ANALYSIS.problem.primary,
+      solution: AI_ANALYSIS.solution.primary,
+      impact: AI_ANALYSIS.impact.primary,
+      narrative: AI_ANALYSIS.narrative.story,
+    })
+    setExpandedSections({
+      problem: true,
+      solution: true,
+      impact: true,
+      narrative: true,
+    })
+  }
+
+  const handleReanalyze = () => {
+    setCustomEdits({})
+    setExpandedSections(INITIAL_SECTIONS)
+    setAnalysisProgress(0)
+    setAnalysisStep('analyzing')
+    setAnalysisRunId(previous => previous + 1)
+  }
+
+  const appliedCount = Object.keys(customEdits).length
+
+  return (
+    <div className={`analysis-page${isDarkMode ? ' analysis-page--dark' : ''}`}>
+      <header className="analysis-page__header">
+        <div className="analysis-header__inner">
+          <div className="analysis-header__meta">
+            <div className="analysis-header__icon">
+              <Brain size={22} />
+            </div>
+            <div>
+              <h1 className="analysis-header__title">AI Project Analysis</h1>
+              <p className="analysis-header__subtitle">
+                E-commerce Checkout Redesign • {PROJECT_FILES.length} files
+              </p>
+            </div>
+          </div>
+          <div className="analysis-header__actions">
+            <button
+              type="button"
+              className="analysis-toggle"
+              onClick={() => setIsDarkMode(previous => !previous)}
+              aria-pressed={isDarkMode}
+            >
+              {isDarkMode ? <Sun size={16} /> : <Moon size={16} />}
+              <span>{isDarkMode ? 'Light mode' : 'Dark mode'}</span>
+            </button>
+            <button type="button" className="button button--ghost" onClick={handleReanalyze}>
+              <RefreshCw size={16} />
+              Re-analyze
+            </button>
+            <button
+              type="button"
+              className="button button--primary"
+              onClick={handleApplyAllSuggestions}
+              disabled={analysisStep !== 'complete'}
+            >
+              <Sparkles size={16} />
+              Apply all suggestions
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="analysis-page__layout">
+        <aside className="analysis-sidebar analysis-panel">
+          <div>
+            <h2 className="analysis-sidebar__title">File analysis</h2>
+          </div>
+          <div className="analysis-sidebar__stats">
+            <div className="analysis-sidebar__stat">
+              <strong>{AI_ANALYSIS.confidence}%</strong>
+              <span>Confidence</span>
+            </div>
+            <div className="analysis-sidebar__stat">
+              <strong>{AI_ANALYSIS.insights}</strong>
+              <span>Insights</span>
+            </div>
+          </div>
+          <div className="analysis-sidebar__meta">
+            <p>Processed in {AI_ANALYSIS.processingTime}</p>
+            <p>{AI_ANALYSIS.filesAnalyzed} files analyzed</p>
+          </div>
+          <div className="analysis-sidebar__files">
+            {PROJECT_FILES.map(file => {
+              const FileIcon = FILE_ICONS[file.type]
+
+              return (
+                <div key={file.id} className="analysis-file-card">
+                  <div className="analysis-file-card__icon">
+                    <FileIcon size={18} />
+                  </div>
+                  <div className="analysis-file-card__details">
+                    <div className="analysis-file-card__name">{file.name}</div>
+                    <div className="analysis-file-card__insights">
+                      {file.insights.map(insight => (
+                        <span key={insight} className="analysis-file-card__insight">
+                          <span className="analysis-file-card__bullet" />
+                          {insight}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </aside>
+
+        <main className="analysis-main">
+          {analysisStep === 'analyzing' ? (
+            <section className="analysis-progress analysis-panel">
+              <div className="analysis-progress__icon">
+                <Brain size={32} />
+              </div>
+              <h2 className="analysis-progress__title">Analyzing your project</h2>
+              <p className="analysis-progress__description">
+                Our AI is reviewing uploaded files to understand the problem you solved, the solution you delivered, and the impact it created.
+              </p>
+              <div className="analysis-progress__bar">
+                <div className="analysis-progress__fill" style={{ width: `${Math.min(analysisProgress, 100)}%` }} />
+              </div>
+              <p className="analysis-progress__status">
+                {Math.round(Math.min(analysisProgress, 100))}% • {progressLabel}
+              </p>
+            </section>
+          ) : (
+            <div className="analysis-results">
+              <section className="analysis-complete analysis-panel">
+                <div className="analysis-complete__icon">
+                  <CheckCircle size={24} />
+                </div>
+                <div>
+                  <h2>Analysis complete!</h2>
+                  <p>We&apos;ve reverse-engineered your project and surfaced the highlights worth showcasing.</p>
+                </div>
+              </section>
+
+              <section className="analysis-summary analysis-panel">
+                <div>
+                  <h3>Suggested project details</h3>
+                </div>
+                <div className="analysis-summary__grid">
+                  <div>
+                    <p className="analysis-summary__label">Title</p>
+                    <p className="analysis-summary__value">{AI_ANALYSIS.suggestedTitle}</p>
+                  </div>
+                  <div>
+                    <p className="analysis-summary__label">Category</p>
+                    <p className="analysis-summary__value">{AI_ANALYSIS.suggestedCategory}</p>
+                  </div>
+                  <div>
+                    <p className="analysis-summary__label">Tags</p>
+                    <div className="analysis-summary__tags">
+                      {AI_ANALYSIS.tags.map(tag => (
+                        <span key={tag} className="analysis-tag">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                <div className="analysis-summary__footer">
+                  <span>Generated from {AI_ANALYSIS.insights} insights across your project files.</span>
+                  <span>
+                    {appliedCount > 0
+                      ? `${appliedCount} suggestion${appliedCount === 1 ? '' : 's'} applied`
+                      : 'No suggestions applied yet'}
+                  </span>
+                </div>
+              </section>
+
+              <AnalysisCard
+                title="Problem identified"
+                confidence={AI_ANALYSIS.problem.confidence}
+                isExpanded={expandedSections.problem}
+                onToggle={() => handleToggleSection('problem')}
+                icon={Target}
+              >
+                <SuggestionCard
+                  title="Primary problem"
+                  content={AI_ANALYSIS.problem.primary}
+                  onApply={() => handleApplySuggestion('problem', AI_ANALYSIS.problem.primary)}
+                  isApplied={customEdits.problem === AI_ANALYSIS.problem.primary}
+                />
+
+                <div>
+                  <h4 className="analysis-section-title">Supporting evidence</h4>
+                  <div className="analysis-list">
+                    {AI_ANALYSIS.problem.evidence.map(evidence => (
+                      <div key={evidence} className="analysis-list__item">
+                        <CheckCircle size={18} className="analysis-list__icon" />
+                        <span>{evidence}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <h4 className="analysis-section-title">Alternative interpretations</h4>
+                  <div className="analysis-alternatives">
+                    {AI_ANALYSIS.problem.alternatives.map(alternative => {
+                      const isActive = customEdits.problem === alternative
+                      return (
+                        <div
+                          key={alternative}
+                          className={`analysis-alternative${isActive ? ' analysis-alternative--active' : ''}`}
+                        >
+                          <span>{alternative}</span>
+                          <button
+                            type="button"
+                            className="analysis-alternative__button"
+                            onClick={() => handleApplySuggestion('problem', alternative)}
+                          >
+                            Use this
+                          </button>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              </AnalysisCard>
+
+              <AnalysisCard
+                title="Solution approach"
+                confidence={AI_ANALYSIS.solution.confidence}
+                isExpanded={expandedSections.solution}
+                onToggle={() => handleToggleSection('solution')}
+                icon={Lightbulb}
+              >
+                <SuggestionCard
+                  title="Primary solution"
+                  content={AI_ANALYSIS.solution.primary}
+                  onApply={() => handleApplySuggestion('solution', AI_ANALYSIS.solution.primary)}
+                  isApplied={customEdits.solution === AI_ANALYSIS.solution.primary}
+                />
+
+                <div className="analysis-two-column">
+                  <div>
+                    <h4 className="analysis-section-title">Key elements</h4>
+                    <div className="analysis-list">
+                      {AI_ANALYSIS.solution.keyElements.map(element => (
+                        <div key={element} className="analysis-list__item">
+                          <ArrowRight size={16} className="analysis-list__icon analysis-list__icon--accent" />
+                          <span>{element}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <h4 className="analysis-section-title">Design patterns</h4>
+                    <div className="analysis-chips">
+                      {AI_ANALYSIS.solution.designPatterns.map(pattern => (
+                        <span key={pattern} className="analysis-chip">
+                          {pattern}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </AnalysisCard>
+
+              <AnalysisCard
+                title="Impact &amp; results"
+                confidence={AI_ANALYSIS.impact.confidence}
+                isExpanded={expandedSections.impact}
+                onToggle={() => handleToggleSection('impact')}
+                icon={TrendingUp}
+              >
+                <SuggestionCard
+                  title="Primary impact"
+                  content={AI_ANALYSIS.impact.primary}
+                  onApply={() => handleApplySuggestion('impact', AI_ANALYSIS.impact.primary)}
+                  isApplied={customEdits.impact === AI_ANALYSIS.impact.primary}
+                />
+
+                <div>
+                  <h4 className="analysis-section-title">Key metrics</h4>
+                  <div className="analysis-metrics">
+                    {AI_ANALYSIS.impact.metrics.map(metric => (
+                      <div key={metric.metric} className="analysis-metric-card">
+                        <strong>{metric.metric}</strong>
+                        <span>Before: {metric.before}</span>
+                        <span>After: {metric.after}</span>
+                        <div className="analysis-metric-card__change">{metric.change}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="analysis-business-value">
+                  <TrendingUp size={18} />
+                  <span>{AI_ANALYSIS.impact.businessValue}</span>
+                </div>
+              </AnalysisCard>
+
+              <AnalysisCard
+                title="Generated story"
+                confidence={91}
+                isExpanded={expandedSections.narrative}
+                onToggle={() => handleToggleSection('narrative')}
+                icon={MessageSquare}
+              >
+                <SuggestionCard
+                  title="Project story"
+                  content={AI_ANALYSIS.narrative.story}
+                  onApply={() => handleApplySuggestion('narrative', AI_ANALYSIS.narrative.story)}
+                  isApplied={customEdits.narrative === AI_ANALYSIS.narrative.story}
+                />
+
+                <div className="analysis-two-column">
+                  <div>
+                    <h4 className="analysis-section-title">Key challenges</h4>
+                    <div className="analysis-list">
+                      {AI_ANALYSIS.narrative.challenges.map(challenge => (
+                        <div key={challenge} className="analysis-list__item">
+                          <AlertCircle size={18} className="analysis-list__icon analysis-list__icon--warning" />
+                          <span>{challenge}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <h4 className="analysis-section-title">Process steps</h4>
+                    <div className="analysis-process">
+                      {AI_ANALYSIS.narrative.process.map((step, index) => (
+                        <div key={step} className="analysis-process__step">
+                          <span className="analysis-process__index">{index + 1}</span>
+                          <span>{step}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </AnalysisCard>
+
+              <div className="analysis-footer">
+                <button type="button" className="button button--ghost" onClick={handleReanalyze}>
+                  <RefreshCw size={16} />
+                  Re-analyze with different focus
+                </button>
+                <button
+                  type="button"
+                  className="button button--primary"
+                  onClick={handleApplyAllSuggestions}
+                  disabled={analysisStep !== 'complete'}
+                >
+                  <Sparkles size={16} />
+                  Apply all suggestions
+                </button>
+              </div>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a PortfolioForgeAIAnalysis page that simulates an AI-powered project review with progress states, collapsible insight cards, and suggestion actions
- add dedicated styling for the analysis workspace including dark mode support and responsive layout rules
- expose the AI analysis view through the router and top-level navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc8cfbf2cc832f89b776a027e68b41