### PR TITLE
Improve intake upload accessibility and skip flow

### DIFF
--- a/src/intake/IntakeForm.css
+++ b/src/intake/IntakeForm.css
@@ -157,6 +157,13 @@
   transform: translateY(-2px);
 }
 
+.upload-flow__dropzone:focus-visible {
+  outline: none;
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.2);
+  transform: translateY(-2px);
+}
+
 .upload-flow__dropzone h3 {
   font-weight: 600;
   font-size: 1rem;
@@ -183,6 +190,12 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 1rem;
+}
+
+.upload-flow__helper-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.25rem;
 }
 
 .upload-flow__option-btn {
@@ -418,6 +431,18 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
+}
+
+.upload-flow__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .upload-flow__review-card {

--- a/src/intake/IntakeForm.tsx
+++ b/src/intake/IntakeForm.tsx
@@ -328,6 +328,7 @@ export default function IntakeForm({ onComplete }: Props) {
               role="button"
               tabIndex={0}
               onKeyDown={handleDropzoneKeyDown}
+              aria-label="Upload file"
               aria-describedby={`${dropzoneDescriptionId} ${dropzoneHintId} ${dropzoneHelpId}`}
             >
               <Upload size={42} className="upload-flow__dropzone-icon" />

--- a/src/intake/IntakeForm.tsx
+++ b/src/intake/IntakeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useId, useRef, useState } from 'react'
 import {
   ArrowLeft,
   ArrowRight,
@@ -65,8 +65,12 @@ export default function IntakeForm({ onComplete }: Props) {
   const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(null)
   const [selectedProject, setSelectedProject] = useState('')
   const [formData, setFormData] = useState(initialFormState)
+  const [liveMessage, setLiveMessage] = useState('')
 
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const dropzoneDescriptionId = useId()
+  const dropzoneHintId = useId()
+  const dropzoneHelpId = useId()
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault()
@@ -76,7 +80,14 @@ export default function IntakeForm({ onComplete }: Props) {
   }
 
   const handleFileSelect = (file?: File) => {
-    if (!file) return
+    if (!file) {
+      setLiveMessage('No file selected. You can continue without an upload.')
+      return
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
 
     const reader = new FileReader()
     reader.onload = () => {
@@ -88,6 +99,8 @@ export default function IntakeForm({ onComplete }: Props) {
         preview: file.type.startsWith('image/') && result ? result : null,
         dataUrl: result,
       })
+      setCurrentStep(1)
+      setLiveMessage(`${file.name} ready to add. Continue to choose a project.`)
     }
     reader.onerror = () => {
       setUploadedFile({
@@ -97,9 +110,10 @@ export default function IntakeForm({ onComplete }: Props) {
         preview: null,
         dataUrl: null,
       })
+      setCurrentStep(1)
+      setLiveMessage(`Unable to preview ${file.name}. You can still continue to add project details.`)
     }
     reader.readAsDataURL(file)
-    setCurrentStep(1)
   }
 
   const handleInputChange = (field: keyof typeof initialFormState, value: string) => {
@@ -123,6 +137,7 @@ export default function IntakeForm({ onComplete }: Props) {
     setUploadedFile(null)
     setSelectedProject('')
     setFormData(initialFormState)
+    setLiveMessage('')
   }
 
   const formatFileSize = (bytes: number) => {
@@ -224,6 +239,19 @@ export default function IntakeForm({ onComplete }: Props) {
     onComplete(meta)
   }
 
+  const handleSkipUpload = () => {
+    setUploadedFile(null)
+    setCurrentStep(1)
+    setLiveMessage('Upload skipped. You can add assets later from the editor.')
+  }
+
+  const handleDropzoneKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      fileInputRef.current?.click()
+    }
+  }
+
   return (
     <div className="upload-flow">
       <header className="upload-flow__header">
@@ -297,11 +325,15 @@ export default function IntakeForm({ onComplete }: Props) {
               }}
               onDragLeave={() => setDragOver(false)}
               onClick={() => fileInputRef.current?.click()}
+              role="button"
+              tabIndex={0}
+              onKeyDown={handleDropzoneKeyDown}
+              aria-describedby={`${dropzoneDescriptionId} ${dropzoneHintId} ${dropzoneHelpId}`}
             >
               <Upload size={42} className="upload-flow__dropzone-icon" />
-              <h3>{dragOver ? 'Drop your file here' : 'Drag & drop or click to upload'}</h3>
-              <p>Supports JPG, PNG, PDF, MP4 and more.</p>
-              <small>Maximum file size: 50MB</small>
+              <h3 id={dropzoneDescriptionId}>{dragOver ? 'Drop your file here' : 'Drag & drop or click to upload'}</h3>
+              <p id={dropzoneHintId}>Supports JPG, PNG, PDF, MP4 and more.</p>
+              <small id={dropzoneHelpId}>Maximum file size: 50MB</small>
             </div>
 
             <input
@@ -320,6 +352,12 @@ export default function IntakeForm({ onComplete }: Props) {
               <button type="button" className="upload-flow__option-btn" onClick={() => fileInputRef.current?.click()}>
                 <FileText size={24} />
                 <span>Browse documents</span>
+              </button>
+            </div>
+
+            <div className="upload-flow__helper-actions">
+              <button type="button" className="upload-flow__secondary-button" onClick={handleSkipUpload}>
+                Skip for now
               </button>
             </div>
           </div>
@@ -599,6 +637,10 @@ export default function IntakeForm({ onComplete }: Props) {
           </div>
         )}
       </main>
+
+      <div className="upload-flow__sr-only" aria-live="polite">
+        {liveMessage}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add keyboard and screen-reader support to the intake upload dropzone
- allow users to skip the upload step while announcing status updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc9a67d9ac832f87c7638831fde46a