### PR TITLE
Improve intake upload accessibility and skip flow

### DIFF
--- a/src/intake/IntakeForm.css
+++ b/src/intake/IntakeForm.css
@@ -48,6 +48,13 @@
   cursor: not-allowed;
 }
 
+.upload-flow__icon-button:focus-visible {
+  outline: none;
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.2);
+  color: #4c1d95;
+}
+
 .upload-flow__steps {
   list-style: none;
   padding: 0;
@@ -157,6 +164,13 @@
   transform: translateY(-2px);
 }
 
+.upload-flow__dropzone:focus-visible {
+  outline: none;
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.2);
+  transform: translateY(-2px);
+}
+
 .upload-flow__dropzone h3 {
   font-weight: 600;
   font-size: 1rem;
@@ -185,6 +199,12 @@
   gap: 1rem;
 }
 
+.upload-flow__helper-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.25rem;
+}
+
 .upload-flow__option-btn {
   border: 1px solid #e5e7eb;
   border-radius: 1rem;
@@ -202,6 +222,13 @@
 .upload-flow__option-btn:hover {
   border-color: #a855f7;
   background: #f5f3ff;
+  transform: translateY(-2px);
+}
+
+.upload-flow__option-btn:focus-visible {
+  outline: none;
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.18);
   transform: translateY(-2px);
 }
 
@@ -264,6 +291,13 @@
 .upload-flow__project-btn:hover {
   border-color: #c4b5fd;
   box-shadow: 0 12px 24px rgba(124, 58, 237, 0.08);
+  transform: translateY(-2px);
+}
+
+.upload-flow__project-btn:focus-visible {
+  outline: none;
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.22);
   transform: translateY(-2px);
 }
 
@@ -390,6 +424,11 @@
   box-shadow: 0 12px 24px rgba(109, 40, 217, 0.28);
 }
 
+.upload-flow__primary-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.24);
+}
+
 .upload-flow__primary-button:disabled {
   background: #d1d5db;
   color: #6b7280;
@@ -414,10 +453,28 @@
   transform: translateY(-1px);
 }
 
+.upload-flow__secondary-button:focus-visible {
+  outline: none;
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.18);
+}
+
 .upload-flow__action-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
+}
+
+.upload-flow__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .upload-flow__review-card {


### PR DESCRIPTION
## Summary
- add keyboard and screen-reader support to the intake upload dropzone
- allow users to skip the upload step while announcing status updates
- ensure the skip flow clears the file picker and add consistent focus-visible styles for interactive controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc9a67d9ac832f87c7638831fde46a