### PR TITLE
Add storage manager tests with Node runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --loader ./scripts/ts-loader.mjs --test tests/storageManager.test.ts"
   },
   "dependencies": {
     "lucide-react": "^0.453.0",

--- a/scripts/ts-loader.mjs
+++ b/scripts/ts-loader.mjs
@@ -1,0 +1,74 @@
+import { access, readFile } from 'node:fs/promises'
+import { dirname, extname, resolve as resolvePath } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import ts from 'typescript'
+
+const tryResolveTs = async (specifier, parentURL) => {
+  const parentPath = fileURLToPath(parentURL)
+  const baseDir = extname(parentPath) ? dirname(parentPath) : parentPath
+  const attempts = []
+
+  if (!extname(specifier)) {
+    attempts.push(
+      `${specifier}.ts`,
+      `${specifier}.tsx`,
+      `${specifier}/index.ts`,
+      `${specifier}/index.tsx`
+    )
+  } else {
+    attempts.push(specifier)
+  }
+
+  for (const attempt of attempts) {
+    const candidatePath = resolvePath(baseDir, attempt)
+    try {
+      await access(candidatePath)
+      return pathToFileURL(candidatePath).href
+    } catch {
+      // try next option
+    }
+  }
+
+  return undefined
+}
+
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) {
+    const parentURL = context.parentURL ?? pathToFileURL(`${process.cwd()}/`).href
+    const resolvedTs = await tryResolveTs(specifier, parentURL)
+
+    if (resolvedTs) {
+      return { url: resolvedTs, shortCircuit: true }
+    }
+  }
+
+  return defaultResolve(specifier, context, defaultResolve)
+}
+
+const compilerOptions = {
+  module: ts.ModuleKind.ESNext,
+  target: ts.ScriptTarget.ES2020,
+  jsx: ts.JsxEmit.ReactJSX,
+  esModuleInterop: true,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  resolveJsonModule: true,
+  allowSyntheticDefaultImports: true
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.ts') || url.endsWith('.tsx')) {
+    const source = await readFile(fileURLToPath(url), 'utf8')
+    const { outputText } = ts.transpileModule(source, {
+      compilerOptions,
+      fileName: fileURLToPath(url)
+    })
+
+    return {
+      format: 'module',
+      source: outputText,
+      shortCircuit: true
+    }
+  }
+
+  return defaultLoad(url, context, defaultLoad)
+}

--- a/tests/storageManager.test.ts
+++ b/tests/storageManager.test.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, it, mock } from 'node:test'
+import type { ProjectMeta } from '../src/intake/schema.ts'
+import {
+  resetStorageDependencies,
+  resetStorageManagerForTesting,
+  setStorageDependencies,
+  storageManager
+} from '../src/utils/storageManager.ts'
+
+const createProject = (overrides: Partial<ProjectMeta> = {}): ProjectMeta => ({
+  title: 'Test Project',
+  slug: 'test-project',
+  summary: 'Summary',
+  problem: 'Problem',
+  solution: 'Solution',
+  outcomes: 'Outcomes',
+  tags: ['test'],
+  status: 'draft',
+  role: 'developer',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  assets: [],
+  ...overrides
+})
+
+type StorageMocks = {
+  indexedDbStore: ReturnType<typeof createIndexedDbStoreMock>
+  fileStore: ReturnType<typeof createFileStoreMock>
+  isIndexedDBSupported: ReturnType<typeof mock.fn>
+}
+
+const createIndexedDbStoreMock = () => ({
+  init: mock.fn(async () => {}),
+  saveProject: mock.fn(async (_project: ProjectMeta) => {}),
+  loadProject: mock.fn(async (_slug: string) => null),
+  listProjects: mock.fn(async () => [] as ProjectMeta[]),
+  deleteProject: mock.fn(async (_slug: string) => {}),
+  clearAllProjects: mock.fn(async () => {}),
+  getStorageUsage: mock.fn(async () => ({ used: 0, available: 100, percentage: 0 })),
+  getProjectSizes: mock.fn(async () => [] as Array<{ slug: string, title: string, size: number, sizeMB: string }>)
+})
+
+const createFileStoreMock = () => ({
+  saveProject: mock.fn((_project: ProjectMeta) => {}),
+  loadProject: mock.fn((_slug: string) => null as ProjectMeta | null),
+  listProjects: mock.fn(() => [] as ProjectMeta[]),
+  deleteProject: mock.fn((_slug: string) => {}),
+  clearAllProjects: mock.fn(() => {}),
+  getStorageUsage: mock.fn(() => ({ used: 0, available: 10, percentage: 0 })),
+  getProjectSizes: mock.fn(() => [] as Array<{ slug: string, title: string, size: number, sizeMB: string }>)
+})
+
+const setupMocks = (): StorageMocks => {
+  const indexedDbStore = createIndexedDbStoreMock()
+  const fileStore = createFileStoreMock()
+  const isIndexedDBSupported = mock.fn(() => true)
+
+  setStorageDependencies({ indexedDbStore, fileStore, isIndexedDBSupported })
+
+  return { indexedDbStore, fileStore, isIndexedDBSupported }
+}
+
+describe('storageManager', () => {
+  let mocks: StorageMocks
+
+  beforeEach(() => {
+    resetStorageDependencies()
+    resetStorageManagerForTesting()
+    mock.restoreAll()
+    mocks = setupMocks()
+  })
+
+  afterEach(() => {
+    resetStorageDependencies()
+    resetStorageManagerForTesting()
+    mock.restoreAll()
+  })
+
+  it('uses IndexedDB when it is supported and initialisation succeeds', async () => {
+    mocks.isIndexedDBSupported.mock.mockImplementation(() => true)
+
+    await storageManager.init()
+
+    assert.strictEqual(storageManager.getStorageType(), 'indexedDB')
+    assert.strictEqual(mocks.indexedDbStore.init.mock.calls.length, 1)
+    assert.strictEqual(mocks.fileStore.listProjects.mock.calls.length, 1)
+    assert.strictEqual(mocks.indexedDbStore.listProjects.mock.calls.length, 1)
+  })
+
+  it('falls back to localStorage when IndexedDB is not supported', async () => {
+    mocks.isIndexedDBSupported.mock.mockImplementation(() => false)
+
+    await storageManager.init()
+
+    assert.strictEqual(storageManager.getStorageType(), 'localStorage')
+    assert.strictEqual(mocks.indexedDbStore.init.mock.calls.length, 0)
+  })
+
+  it('falls back to localStorage when IndexedDB initialisation fails', async () => {
+    mocks.isIndexedDBSupported.mock.mockImplementation(() => true)
+    mocks.indexedDbStore.init.mock.mockImplementation(async () => {
+      throw new Error('boom')
+    })
+
+    await storageManager.init()
+
+    assert.strictEqual(storageManager.getStorageType(), 'localStorage')
+  })
+
+  it('migrates projects from localStorage when IndexedDB is empty', async () => {
+    const projectA = createProject({ slug: 'a', title: 'A' })
+    const projectB = createProject({ slug: 'b', title: 'B' })
+
+    mocks.fileStore.listProjects.mock.mockImplementation(() => [projectA, projectB])
+    mocks.indexedDbStore.listProjects.mock.mockImplementation(async () => [])
+
+    await storageManager.init()
+
+    assert.strictEqual(mocks.indexedDbStore.saveProject.mock.calls.length, 2)
+    assert.deepStrictEqual(mocks.indexedDbStore.saveProject.mock.calls[0].arguments, [projectA])
+    assert.deepStrictEqual(mocks.indexedDbStore.saveProject.mock.calls[1].arguments, [projectB])
+  })
+
+  it('delegates operations to IndexedDB when that store is active', async () => {
+    const project = createProject()
+    const projects = [project]
+    const usage = { used: 4, available: 100, percentage: 4 }
+    const sizes = [{ slug: project.slug, title: project.title, size: 42, sizeMB: '0.04MB' }]
+
+    mocks.indexedDbStore.loadProject.mock.mockImplementation(async () => project)
+    mocks.indexedDbStore.listProjects.mock.mockImplementation(async () => projects)
+    mocks.indexedDbStore.getStorageUsage.mock.mockImplementation(async () => usage)
+    mocks.indexedDbStore.getProjectSizes.mock.mockImplementation(async () => sizes)
+
+    await storageManager.saveProject(project)
+    const loaded = await storageManager.loadProject(project.slug)
+    const listed = await storageManager.listProjects()
+    await storageManager.deleteProject(project.slug)
+    await storageManager.clearAllProjects()
+    const usageResult = await storageManager.getStorageUsage()
+    const sizesResult = await storageManager.getProjectSizes()
+
+    assert.strictEqual(mocks.indexedDbStore.saveProject.mock.calls.length, 1)
+    assert.deepStrictEqual(mocks.indexedDbStore.saveProject.mock.calls[0].arguments, [project])
+    assert.deepStrictEqual(loaded, project)
+    assert.deepStrictEqual(listed, projects)
+    assert.strictEqual(mocks.indexedDbStore.deleteProject.mock.calls.length, 1)
+    assert.strictEqual(mocks.indexedDbStore.clearAllProjects.mock.calls.length, 1)
+    assert.deepStrictEqual(usageResult, { ...usage, type: 'indexedDB' })
+    assert.deepStrictEqual(sizesResult, sizes)
+  })
+
+  it('delegates operations to localStorage when IndexedDB is unavailable', async () => {
+    mocks.isIndexedDBSupported.mock.mockImplementation(() => false)
+    const project = createProject({ slug: 'local' })
+    const projects = [project]
+    const usage = { used: 2, available: 10, percentage: 20 }
+    const sizes = [{ slug: project.slug, title: project.title, size: 21, sizeMB: '0.02MB' }]
+
+    mocks.fileStore.loadProject.mock.mockImplementation(() => project)
+    mocks.fileStore.listProjects.mock.mockImplementation(() => projects)
+    mocks.fileStore.getStorageUsage.mock.mockImplementation(() => usage)
+    mocks.fileStore.getProjectSizes.mock.mockImplementation(() => sizes)
+
+    await storageManager.saveProject(project)
+    const loaded = await storageManager.loadProject(project.slug)
+    const listed = await storageManager.listProjects()
+    await storageManager.deleteProject(project.slug)
+    await storageManager.clearAllProjects()
+    const usageResult = await storageManager.getStorageUsage()
+    const sizesResult = await storageManager.getProjectSizes()
+
+    assert.strictEqual(mocks.fileStore.saveProject.mock.calls.length, 1)
+    assert.deepStrictEqual(mocks.fileStore.saveProject.mock.calls[0].arguments, [project])
+    assert.deepStrictEqual(loaded, project)
+    assert.deepStrictEqual(listed, projects)
+    assert.strictEqual(mocks.fileStore.deleteProject.mock.calls.length, 1)
+    assert.strictEqual(mocks.fileStore.clearAllProjects.mock.calls.length, 1)
+    assert.deepStrictEqual(usageResult, { ...usage, type: 'localStorage' })
+    assert.deepStrictEqual(sizesResult, sizes)
+  })
+})


### PR DESCRIPTION
## Summary
- add dependency injection hooks and a reset helper to the storage manager so its dependencies can be mocked during tests
- create a custom TypeScript-aware loader and npm script for running the test suite with Node's builtin runner
- cover the storage manager with node:test cases for storage selection, migration, and delegation behaviour

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cccdc065ec832fa1fc866277dc3497