### PR TITLE
Add portfolio hierarchy asset workspace to AI analysis sidebar

### DIFF
--- a/src/components/PortfolioHierarchy.css
+++ b/src/components/PortfolioHierarchy.css
@@ -1,0 +1,377 @@
+.portfolio-hierarchy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  padding: 1rem;
+  background: linear-gradient(145deg, rgba(248, 250, 252, 0.9), rgba(241, 245, 249, 0.9));
+}
+
+.analysis-page--dark .portfolio-hierarchy {
+  border-color: rgba(51, 65, 85, 0.6);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.92));
+}
+
+.portfolio-hierarchy__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.portfolio-hierarchy__header-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: rgba(99, 102, 241, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #4f46e5;
+}
+
+.analysis-page--dark .portfolio-hierarchy__header-icon {
+  background: rgba(129, 140, 248, 0.22);
+  color: #c7d2fe;
+}
+
+.portfolio-hierarchy__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  color: #64748b;
+  margin: 0 0 0.15rem;
+}
+
+.analysis-page--dark .portfolio-hierarchy__eyebrow {
+  color: #94a3b8;
+}
+
+.portfolio-hierarchy__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.analysis-page--dark .portfolio-hierarchy__title {
+  color: #e2e8f0;
+}
+
+.portfolio-hierarchy__status {
+  margin-left: auto;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #4f46e5;
+}
+
+.analysis-page--dark .portfolio-hierarchy__status {
+  color: #c7d2fe;
+}
+
+.portfolio-hierarchy__tree {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.75);
+  padding: 0.75rem 0.5rem;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.analysis-page--dark .portfolio-hierarchy__tree {
+  background: rgba(15, 23, 42, 0.65);
+  border-color: rgba(51, 65, 85, 0.55);
+}
+
+.portfolio-hierarchy__root-header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  margin-bottom: 0.5rem;
+  color: #475569;
+  font-weight: 600;
+}
+
+.analysis-page--dark .portfolio-hierarchy__root-header {
+  color: #cbd5f5;
+  border-bottom-color: rgba(71, 85, 105, 0.5);
+}
+
+.portfolio-hierarchy__root-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #4f46e5;
+}
+
+.analysis-page--dark .portfolio-hierarchy__root-icon {
+  color: #818cf8;
+}
+
+.portfolio-hierarchy__root-label {
+  font-size: 0.9rem;
+}
+
+.portfolio-hierarchy__root-meta {
+  margin-left: auto;
+  font-size: 0.75rem;
+  opacity: 0.8;
+}
+
+.portfolio-hierarchy__projects {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0 0.25rem;
+}
+
+.portfolio-hierarchy__project {
+  border-radius: 12px;
+  background: rgba(241, 245, 249, 0.6);
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.analysis-page--dark .portfolio-hierarchy__project {
+  background: rgba(30, 41, 59, 0.7);
+}
+
+.portfolio-hierarchy__project--drop {
+  border-color: rgba(79, 70, 229, 0.55);
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.15);
+}
+
+.portfolio-hierarchy__project-button {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto auto 1fr auto auto;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.55rem 0.75rem;
+  border: none;
+  background: transparent;
+  border-radius: 12px;
+  cursor: pointer;
+  color: inherit;
+}
+
+.portfolio-hierarchy__project-button:hover,
+.portfolio-hierarchy__project-button:focus-visible {
+  outline: none;
+  background: rgba(79, 70, 229, 0.08);
+}
+
+.analysis-page--dark .portfolio-hierarchy__project-button:hover,
+.analysis-page--dark .portfolio-hierarchy__project-button:focus-visible {
+  background: rgba(129, 140, 248, 0.18);
+}
+
+.portfolio-hierarchy__project-button--active {
+  background: rgba(79, 70, 229, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.35);
+}
+
+.analysis-page--dark .portfolio-hierarchy__project-button--active {
+  background: rgba(129, 140, 248, 0.24);
+}
+
+.portfolio-hierarchy__project-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+}
+
+.analysis-page--dark .portfolio-hierarchy__project-toggle {
+  color: #cbd5f5;
+}
+
+.portfolio-hierarchy__project-accent {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.portfolio-hierarchy__project-title {
+  font-weight: 600;
+  text-align: left;
+  color: #0f172a;
+}
+
+.analysis-page--dark .portfolio-hierarchy__project-title {
+  color: #e2e8f0;
+}
+
+.portfolio-hierarchy__project-meta {
+  font-size: 0.75rem;
+  color: #475569;
+}
+
+.analysis-page--dark .portfolio-hierarchy__project-meta {
+  color: #94a3b8;
+}
+
+.portfolio-hierarchy__project-handle {
+  color: #94a3b8;
+}
+
+.analysis-page--dark .portfolio-hierarchy__project-handle {
+  color: #cbd5f5;
+}
+
+.portfolio-hierarchy__asset-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem 0.75rem 0.6rem 2.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.portfolio-hierarchy__asset {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid transparent;
+  cursor: grab;
+}
+
+.analysis-page--dark .portfolio-hierarchy__asset {
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.portfolio-hierarchy__asset:hover {
+  border-color: rgba(79, 70, 229, 0.25);
+}
+
+.analysis-page--dark .portfolio-hierarchy__asset:hover {
+  border-color: rgba(129, 140, 248, 0.3);
+}
+
+.portfolio-hierarchy__asset--drop-before::before,
+.portfolio-hierarchy__asset--drop-after::after {
+  content: '';
+  position: absolute;
+  left: 2.2rem;
+  right: 0.75rem;
+  height: 2px;
+  background: rgba(79, 70, 229, 0.9);
+  border-radius: 999px;
+}
+
+.portfolio-hierarchy__asset--drop-before {
+  position: relative;
+}
+
+.portfolio-hierarchy__asset--drop-before::before {
+  top: -2px;
+}
+
+.portfolio-hierarchy__asset--drop-after {
+  position: relative;
+}
+
+.portfolio-hierarchy__asset--drop-after::after {
+  bottom: -2px;
+}
+
+.portfolio-hierarchy__asset-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 8px;
+  background: rgba(79, 70, 229, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #4f46e5;
+}
+
+.analysis-page--dark .portfolio-hierarchy__asset-icon {
+  background: rgba(129, 140, 248, 0.24);
+  color: #c7d2fe;
+}
+
+.portfolio-hierarchy__asset-name {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #1e293b;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.analysis-page--dark .portfolio-hierarchy__asset-name {
+  color: #e2e8f0;
+}
+
+.portfolio-hierarchy__asset-meta {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.analysis-page--dark .portfolio-hierarchy__asset-meta {
+  color: #cbd5f5;
+}
+
+.portfolio-hierarchy__asset-empty {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.analysis-page--dark .portfolio-hierarchy__asset-empty {
+  color: #94a3b8;
+}
+
+.portfolio-hierarchy__asset-dropzone {
+  margin-top: 0.35rem;
+  padding: 0.4rem 0.5rem;
+  font-size: 0.75rem;
+  color: #4f46e5;
+  background: rgba(79, 70, 229, 0.08);
+  border-radius: 8px;
+  text-align: center;
+  border: 1px dashed rgba(79, 70, 229, 0.35);
+}
+
+.analysis-page--dark .portfolio-hierarchy__asset-dropzone {
+  color: #c7d2fe;
+  background: rgba(129, 140, 248, 0.15);
+  border-color: rgba(129, 140, 248, 0.45);
+}
+
+.portfolio-hierarchy__empty {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.analysis-page--dark .portfolio-hierarchy__empty {
+  color: #94a3b8;
+}
+
+.portfolio-hierarchy__error {
+  margin: 0;
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  font-size: 0.8rem;
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+}
+
+.analysis-page--dark .portfolio-hierarchy__error {
+  background: rgba(248, 113, 113, 0.25);
+  color: #fecaca;
+}

--- a/src/components/PortfolioHierarchy.tsx
+++ b/src/components/PortfolioHierarchy.tsx
@@ -1,0 +1,489 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  ChevronDown,
+  ChevronRight,
+  FolderTree,
+  Folder,
+  GripVertical,
+  Image as ImageIcon,
+  Video as VideoIcon,
+  Music as MusicIcon,
+  FileText,
+  FileQuestion,
+  type LucideIcon,
+} from 'lucide-react'
+import type { ProjectAsset, ProjectMeta } from '../intake/schema'
+import { listProjects, saveProject } from '../utils/storageManager'
+
+import './PortfolioHierarchy.css'
+
+type PortfolioHierarchyProps = {
+  selectedProjectId?: string | null
+  onSelectProject?: (projectId: string) => void
+  onHierarchyChanged?: (projects: ProjectMeta[]) => void
+}
+
+type DragItem =
+  | { type: 'project'; projectSlug: string }
+  | { type: 'asset'; projectSlug: string; assetId: string }
+
+type DropIndicator =
+  | { type: 'project'; projectSlug: string }
+  | { type: 'asset'; projectSlug: string; assetId: string; position: 'before' | 'after' }
+
+const ASSET_ICONS: Array<{ matcher: (asset: ProjectAsset) => boolean; icon: LucideIcon }> = [
+  { matcher: asset => asset.mimeType.startsWith('image/'), icon: ImageIcon },
+  { matcher: asset => asset.mimeType.startsWith('video/'), icon: VideoIcon },
+  { matcher: asset => asset.mimeType.startsWith('audio/'), icon: MusicIcon },
+]
+
+const determineAssetIcon = (asset: ProjectAsset): LucideIcon => {
+  const match = ASSET_ICONS.find(entry => entry.matcher(asset))
+  return match ? match.icon : FileText
+}
+
+const formatAssetSize = (size: number): string => {
+  if (!Number.isFinite(size) || size <= 0) {
+    return '—'
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB']
+  let index = 0
+  let value = size
+
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024
+    index += 1
+  }
+
+  return `${value.toFixed(index === 0 ? 0 : 1)} ${units[index]}`
+}
+
+const accentFromSlug = (slug: string): string => {
+  let hash = 0
+  for (let index = 0; index < slug.length; index += 1) {
+    hash = slug.charCodeAt(index) + ((hash << 5) - hash)
+  }
+
+  const hue = Math.abs(hash) % 360
+  return `hsl(${hue}, 70%, 58%)`
+}
+
+export default function PortfolioHierarchy({ selectedProjectId, onSelectProject, onHierarchyChanged }: PortfolioHierarchyProps) {
+  const [projects, setProjects] = useState<ProjectMeta[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({})
+  const [dragItem, setDragItem] = useState<DragItem | null>(null)
+  const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null)
+  const [isUpdating, setIsUpdating] = useState(false)
+
+  const refreshProjects = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const storedProjects = await listProjects()
+      const sorted = [...storedProjects].sort((a, b) => a.title.localeCompare(b.title))
+      setProjects(sorted)
+      setExpandedProjects(previous => {
+        if (Object.keys(previous).length > 0) {
+          return previous
+        }
+        const defaults: Record<string, boolean> = {}
+        sorted.forEach(project => {
+          defaults[project.slug] = project.slug === selectedProjectId
+        })
+        return defaults
+      })
+    } catch (fetchError) {
+      console.error('Failed to load projects for hierarchy', fetchError)
+      setError('Unable to load local projects. Save a project in the workspace to continue.')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [selectedProjectId])
+
+  useEffect(() => {
+    void refreshProjects()
+  }, [refreshProjects])
+
+  useEffect(() => {
+    if (!selectedProjectId) {
+      return
+    }
+
+    setExpandedProjects(previous => ({
+      ...previous,
+      [selectedProjectId]: true,
+    }))
+  }, [selectedProjectId])
+
+  const handleToggleProject = (projectSlug: string) => {
+    setExpandedProjects(previous => ({
+      ...previous,
+      [projectSlug]: !previous[projectSlug],
+    }))
+  }
+
+  const handleSelectProject = (projectSlug: string) => {
+    onSelectProject?.(projectSlug)
+  }
+
+  const handleProjectDragStart = (projectSlug: string, event: React.DragEvent) => {
+    event.stopPropagation()
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', projectSlug)
+    setDragItem({ type: 'project', projectSlug })
+  }
+
+  const handleAssetDragStart = (projectSlug: string, assetId: string, event: React.DragEvent) => {
+    event.stopPropagation()
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', assetId)
+    setDragItem({ type: 'asset', projectSlug, assetId })
+  }
+
+  const clearDragState = () => {
+    setDragItem(null)
+    setDropIndicator(null)
+  }
+
+  const handleDragEnd = () => {
+    clearDragState()
+  }
+
+  const reorderProjects = (sourceSlug: string, targetSlug: string) => {
+    if (sourceSlug === targetSlug) {
+      return
+    }
+
+    setProjects(previous => {
+      const next = [...previous]
+      const fromIndex = next.findIndex(project => project.slug === sourceSlug)
+      const toIndex = next.findIndex(project => project.slug === targetSlug)
+
+      if (fromIndex === -1 || toIndex === -1) {
+        return previous
+      }
+
+      const [moved] = next.splice(fromIndex, 1)
+      next.splice(toIndex, 0, moved)
+      return next
+    })
+  }
+
+  const persistProjects = async (updated: ProjectMeta | ProjectMeta[]) => {
+    const projectList = Array.isArray(updated) ? updated : [updated]
+    await Promise.all(projectList.map(project => saveProject(project)))
+  }
+
+  const moveAsset = async (
+    sourceProjectSlug: string,
+    assetId: string,
+    targetProjectSlug: string,
+    targetIndex: number,
+  ) => {
+    setIsUpdating(true)
+    setError(null)
+
+    setProjects(previous => {
+      const next = previous.map(project => ({
+        ...project,
+        assets: [...project.assets],
+      }))
+
+      const sourceProject = next.find(project => project.slug === sourceProjectSlug)
+      const targetProject = next.find(project => project.slug === targetProjectSlug)
+
+      if (!sourceProject || !targetProject) {
+        setIsUpdating(false)
+        return previous
+      }
+
+      const assetIndex = sourceProject.assets.findIndex(asset => asset.id === assetId)
+      if (assetIndex === -1) {
+        setIsUpdating(false)
+        return previous
+      }
+
+      const [asset] = sourceProject.assets.splice(assetIndex, 1)
+      let insertionIndex = targetIndex
+
+      if (sourceProjectSlug === targetProjectSlug && assetIndex < insertionIndex) {
+        insertionIndex -= 1
+      }
+
+      if (sourceProject.cover === assetId) {
+        delete sourceProject.cover
+      }
+
+      const clampedIndex = Math.max(0, Math.min(insertionIndex, targetProject.assets.length))
+      targetProject.assets.splice(clampedIndex, 0, asset)
+
+      const timestamp = new Date().toISOString()
+      sourceProject.updatedAt = timestamp
+      targetProject.updatedAt = timestamp
+
+      void persistProjects(
+        sourceProjectSlug === targetProjectSlug
+          ? sourceProject
+          : [sourceProject, targetProject],
+      ).catch(persistError => {
+        console.error('Failed to persist asset move', persistError)
+        void refreshProjects()
+        setError('Unable to save asset changes. Try again.')
+      }).finally(() => {
+        setIsUpdating(false)
+      })
+
+      if (onHierarchyChanged) {
+        const payload = next.map(project => ({
+          ...project,
+          assets: [...project.assets],
+        }))
+        onHierarchyChanged(payload)
+      }
+
+      return next
+    })
+  }
+
+  const handleProjectDragOver = (projectSlug: string, event: React.DragEvent) => {
+    if (!dragItem) {
+      return
+    }
+
+    if (dragItem.type === 'project' && dragItem.projectSlug === projectSlug) {
+      return
+    }
+
+    if (dragItem.type === 'asset' || dragItem.type === 'project') {
+      event.preventDefault()
+      setDropIndicator({ type: 'project', projectSlug })
+    }
+  }
+
+  const handleProjectDrop = (projectSlug: string, event: React.DragEvent) => {
+    event.preventDefault()
+    if (!dragItem) {
+      return
+    }
+
+    if (dragItem.type === 'project') {
+      reorderProjects(dragItem.projectSlug, projectSlug)
+    }
+
+    if (dragItem.type === 'asset') {
+      const targetProject = projects.find(project => project.slug === projectSlug)
+      if (!targetProject) {
+        clearDragState()
+        return
+      }
+      void moveAsset(dragItem.projectSlug, dragItem.assetId, projectSlug, targetProject.assets.length)
+    }
+
+    clearDragState()
+  }
+
+  const handleAssetDragOver = (projectSlug: string, assetId: string, event: React.DragEvent) => {
+    if (!dragItem || dragItem.type !== 'asset') {
+      return
+    }
+
+    if (dragItem.projectSlug === projectSlug && dragItem.assetId === assetId) {
+      return
+    }
+
+    event.preventDefault()
+    const bounds = event.currentTarget.getBoundingClientRect()
+    const position = event.clientY - bounds.top > bounds.height / 2 ? 'after' : 'before'
+    setDropIndicator({ type: 'asset', projectSlug, assetId, position })
+  }
+
+  const handleAssetDrop = (projectSlug: string, assetId: string, event: React.DragEvent) => {
+    event.preventDefault()
+    if (!dragItem || dragItem.type !== 'asset') {
+      return
+    }
+
+    const targetProject = projects.find(project => project.slug === projectSlug)
+    if (!targetProject) {
+      clearDragState()
+      return
+    }
+
+    const targetIndex = targetProject.assets.findIndex(asset => asset.id === assetId)
+    if (targetIndex === -1) {
+      clearDragState()
+      return
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect()
+    const isAfter = event.clientY - bounds.top > bounds.height / 2
+    const insertionIndex = targetIndex + (isAfter ? 1 : 0)
+
+    void moveAsset(dragItem.projectSlug, dragItem.assetId, projectSlug, insertionIndex)
+    clearDragState()
+  }
+
+  const handleAssetListDrop = (projectSlug: string, event: React.DragEvent) => {
+    if (!dragItem || dragItem.type !== 'asset') {
+      return
+    }
+    event.preventDefault()
+    const targetProject = projects.find(project => project.slug === projectSlug)
+    if (!targetProject) {
+      clearDragState()
+      return
+    }
+
+    void moveAsset(dragItem.projectSlug, dragItem.assetId, projectSlug, targetProject.assets.length)
+    clearDragState()
+  }
+
+  const isProjectExpanded = useCallback((slug: string) => {
+    return expandedProjects[slug] ?? false
+  }, [expandedProjects])
+
+  const dropHint = useMemo(() => dropIndicator, [dropIndicator])
+
+  return (
+    <section className="portfolio-hierarchy" aria-label="Portfolio hierarchy">
+      <header className="portfolio-hierarchy__header">
+        <div className="portfolio-hierarchy__header-icon" aria-hidden="true">
+          <FolderTree size={18} />
+        </div>
+        <div>
+          <p className="portfolio-hierarchy__eyebrow">Asset workspace</p>
+          <h3 id="portfolio-hierarchy-title" className="portfolio-hierarchy__title">Portfolio hierarchy</h3>
+        </div>
+        {isUpdating ? (
+          <span className="portfolio-hierarchy__status" role="status">Saving…</span>
+        ) : null}
+      </header>
+
+      {error ? (
+        <p className="portfolio-hierarchy__error">{error}</p>
+      ) : null}
+
+      {isLoading ? (
+        <div className="portfolio-hierarchy__empty">Loading projects…</div>
+      ) : projects.length === 0 ? (
+        <div className="portfolio-hierarchy__empty">
+          <FileQuestion size={18} />
+          <p>No local projects found. Capture a project to explore its assets.</p>
+        </div>
+      ) : (
+        <div className="portfolio-hierarchy__tree" role="tree" aria-labelledby="portfolio-hierarchy-title">
+          <div className="portfolio-hierarchy__root" role="treeitem" aria-expanded="true">
+            <div className="portfolio-hierarchy__root-header">
+              <span className="portfolio-hierarchy__root-icon" aria-hidden="true">
+                <Folder size={16} />
+              </span>
+              <span className="portfolio-hierarchy__root-label">Portfolio</span>
+              <span className="portfolio-hierarchy__root-meta">{projects.length} project{projects.length === 1 ? '' : 's'}</span>
+            </div>
+            <div role="group" className="portfolio-hierarchy__projects">
+              {projects.map(project => {
+                const expanded = isProjectExpanded(project.slug)
+                const accent = accentFromSlug(project.slug)
+                const assetCount = project.assets.length
+                const isActive = selectedProjectId === project.slug
+                const projectDropActive = dropHint?.type === 'project' && dropHint.projectSlug === project.slug
+
+                return (
+                  <div
+                    key={project.slug}
+                    className={`portfolio-hierarchy__project${projectDropActive ? ' portfolio-hierarchy__project--drop' : ''}`}
+                    role="treeitem"
+                    aria-expanded={expanded}
+                    aria-selected={isActive}
+                  >
+                    <button
+                      type="button"
+                      className={`portfolio-hierarchy__project-button${isActive ? ' portfolio-hierarchy__project-button--active' : ''}`}
+                      onClick={() => handleSelectProject(project.slug)}
+                      onDoubleClick={() => handleToggleProject(project.slug)}
+                      onKeyDown={event => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault()
+                          handleToggleProject(project.slug)
+                        }
+                      }}
+                      draggable
+                      onDragStart={event => handleProjectDragStart(project.slug, event)}
+                      onDragEnd={handleDragEnd}
+                      onDragOver={event => handleProjectDragOver(project.slug, event)}
+                      onDrop={event => handleProjectDrop(project.slug, event)}
+                    >
+                      <span className="portfolio-hierarchy__project-toggle" onClick={() => handleToggleProject(project.slug)}>
+                        {expanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                      </span>
+                      <span className="portfolio-hierarchy__project-accent" style={{ backgroundColor: accent }} />
+                      <span className="portfolio-hierarchy__project-title">{project.title || project.slug}</span>
+                      <span className="portfolio-hierarchy__project-meta">{assetCount} asset{assetCount === 1 ? '' : 's'}</span>
+                      <span className="portfolio-hierarchy__project-handle" aria-hidden="true">
+                        <GripVertical size={16} />
+                      </span>
+                    </button>
+
+                    {expanded ? (
+                      <ul
+                        className="portfolio-hierarchy__asset-list"
+                        role="group"
+                        onDragOver={event => handleProjectDragOver(project.slug, event)}
+                        onDrop={event => handleProjectDrop(project.slug, event)}
+                      >
+                        {assetCount === 0 ? (
+                          <li className="portfolio-hierarchy__asset-empty">
+                            <p>No assets captured yet. Drag files from another project to start.</p>
+                          </li>
+                        ) : (
+                          project.assets.map(asset => {
+                            const Icon = determineAssetIcon(asset)
+                            const indicatorActive =
+                              dropHint?.type === 'asset' &&
+                              dropHint.projectSlug === project.slug &&
+                              dropHint.assetId === asset.id
+                            const indicatorPosition = indicatorActive ? dropHint.position : null
+
+                            return (
+                              <li
+                                key={asset.id}
+                                className={`portfolio-hierarchy__asset${indicatorPosition ? ` portfolio-hierarchy__asset--drop-${indicatorPosition}` : ''}`}
+                                draggable
+                                onDragStart={event => handleAssetDragStart(project.slug, asset.id, event)}
+                                onDragEnd={handleDragEnd}
+                                onDragOver={event => handleAssetDragOver(project.slug, asset.id, event)}
+                                onDrop={event => handleAssetDrop(project.slug, asset.id, event)}
+                              >
+                                <span className="portfolio-hierarchy__asset-icon" aria-hidden="true">
+                                  <Icon size={14} />
+                                </span>
+                                <span className="portfolio-hierarchy__asset-name" title={asset.name}>
+                                  {asset.name}
+                                </span>
+                                <span className="portfolio-hierarchy__asset-meta">{formatAssetSize(asset.size)}</span>
+                              </li>
+                            )
+                          })
+                        )}
+                        <li
+                          className="portfolio-hierarchy__asset-dropzone"
+                          onDragOver={event => handleProjectDragOver(project.slug, event)}
+                          onDrop={event => handleAssetListDrop(project.slug, event)}
+                        >
+                          Drop here to add to {project.title || project.slug}
+                        </li>
+                      </ul>
+                    ) : null}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/pages/PortfolioForgeAIAnalysis.tsx
+++ b/src/pages/PortfolioForgeAIAnalysis.tsx
@@ -25,6 +25,7 @@ import {
 import type { LucideIcon } from 'lucide-react'
 
 import './PortfolioForgeAIAnalysis.css'
+import PortfolioHierarchy from '../components/PortfolioHierarchy'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 const DEFAULT_USER_ID = import.meta.env.VITE_ANALYSIS_USER_ID ?? 'demo-user'
@@ -499,6 +500,11 @@ export default function PortfolioForgeAIAnalysis() {
   const baseHeaders = useMemo(createBaseHeaders, [])
   const jsonHeaders = useMemo(() => createJsonHeaders(baseHeaders), [baseHeaders])
 
+  const handleHierarchyProjectSelect = useCallback((projectSlug: string) => {
+    setProjectIdInput(projectSlug)
+    setAnalysisError(null)
+  }, [])
+
   const persistProjectSuggestions = useCallback(async (updates: ProjectSuggestionPayload) => {
     const targetId = selectedProjectId ?? projectIdInput.trim()
     if (!targetId) {
@@ -931,6 +937,10 @@ export default function PortfolioForgeAIAnalysis() {
       <div className="analysis-page__layout">
         <aside className="analysis-sidebar analysis-panel">
           <div className="analysis-sidebar__control">
+            <PortfolioHierarchy
+              selectedProjectId={projectIdInput.trim().length > 0 ? projectIdInput.trim() : undefined}
+              onSelectProject={handleHierarchyProjectSelect}
+            />
             <form onSubmit={handleSubmit} className="analysis-launcher">
               <label htmlFor="analysis-project-id">Project ID</label>
               <div className="analysis-launcher__row">


### PR DESCRIPTION
## Summary
- add a `PortfolioHierarchy` explorer that loads portfolio projects from storage, supports multi-level drag and drop, and persists asset moves back to the workspace
- surface the hierarchy inside the AI analysis sidebar so selecting a project populates the analysis ID field and clears prior error states
- style the hierarchy panel to match the asset workspace treatment with dark-mode support and drop-target affordances

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccd1b26d38832f92a0a61fe299a547