### PR TITLE
Fix nested button structure in asset editor

### DIFF
--- a/src/components/projectdash.tsx
+++ b/src/components/projectdash.tsx
@@ -342,12 +342,22 @@ export default function ProjectAssetEditor({ assets, onAssetUpdate, onAssetRemov
             const addedTimestamp = parseTimestamp(asset.addedAt)
             const addedLabel = addedTimestamp ? new Date(addedTimestamp).toLocaleDateString() : '—'
 
+            const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                setSelectedAssetId(asset.id)
+              }
+            }
+
             return (
-              <button
+              <div
                 key={asset.id}
-                type="button"
+                role="button"
+                tabIndex={0}
                 className={`asset-editor__item ${isSelected ? 'asset-editor__item--selected' : ''}`}
                 onClick={() => setSelectedAssetId(asset.id)}
+                onKeyDown={handleKeyDown}
+                aria-pressed={isSelected}
               >
                 <div className="asset-editor__thumb">
                   {category === 'image' ? (
@@ -383,7 +393,7 @@ export default function ProjectAssetEditor({ assets, onAssetUpdate, onAssetRemov
                   <span>{sizeLabel}</span>
                   <small>Added {addedLabel}</small>
                 </div>
-              </button>
+              </div>
             )
           })}
 


### PR DESCRIPTION
## Summary
- replace the asset selection button with a div that behaves like a button to avoid nesting interactive elements
- add keyboard support and pressed state for the new container to preserve accessibility while keeping the remove button inside

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccd4cb1fd8832fb9ebc1decc018d86