### PR TITLE
Implement integrated project visual editor

### DIFF
--- a/src/components/ProjectEditor.tsx
+++ b/src/components/ProjectEditor.tsx
@@ -1,35 +1,35 @@
-import React, { useState, useRef } from 'react'
-import { 
-  Eye, 
-  Download, 
-  Layout, 
-  Image, 
-  Type, 
-  Link2, 
-  Grid, 
-  Move,
-  Trash2,
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  AlertCircle,
+  Download,
+  Eye,
+  Grid,
+  Image as ImageIcon,
+  Layout,
+  Link2,
+  Monitor,
   Plus,
   Settings,
-  Monitor,
   Smartphone,
   Tablet,
-  Video
+  Trash2,
+  Type,
+  Video,
 } from 'lucide-react'
-import type { ProjectMeta, ProjectAsset } from '../intake/schema'
-
-export type LayoutBlock = {
-  id: string
-  type: 'hero' | 'text' | 'image' | 'gallery' | 'video' | 'link' | 'metrics' | 'spacer'
-  content: any
-  order: number
-  settings: {
-    width?: 'full' | 'half' | 'third' | 'two-thirds'
-    alignment?: 'left' | 'center' | 'right'
-    padding?: 'none' | 'small' | 'medium' | 'large'
-    backgroundColor?: string
-  }
-}
+import type {
+  GalleryBlockContent,
+  HeroBlockContent,
+  ImageBlockContent,
+  LinkBlockContent,
+  MetricsBlockContent,
+  ProjectAsset,
+  ProjectBlockSettings,
+  ProjectLayoutBlock,
+  ProjectLink,
+  ProjectMeta,
+  TextBlockContent,
+  VideoBlockContent,
+} from '../intake/schema'
 
 type ProjectEditorProps = {
   project: ProjectMeta
@@ -38,198 +38,582 @@ type ProjectEditorProps = {
 
 type ViewMode = 'desktop' | 'tablet' | 'mobile'
 
-const defaultBlockSettings = {
-  width: 'full' as const,
-  alignment: 'left' as const,
-  padding: 'medium' as const,
-  backgroundColor: 'transparent'
+type SaveState = { type: 'success' | 'error' | 'info'; message: string } | null
+
+const DEFAULT_SETTINGS: Required<ProjectBlockSettings> = {
+  width: 'full',
+  alignment: 'left',
+  padding: 'medium',
+  backgroundColor: 'transparent',
 }
 
-export default function ProjectEditor({ project, onUpdateProject }: ProjectEditorProps) {
-  const [blocks, setBlocks] = useState<LayoutBlock[]>(() => {
-    // Initialize with default blocks based on project data
-    const initialBlocks: LayoutBlock[] = []
-    
-    // Hero block
-    if (project.cover) {
-      const heroAsset = project.assets.find(a => a.id === project.cover)
-      if (heroAsset) {
-        initialBlocks.push({
-          id: 'hero-1',
-          type: 'hero',
-          content: {
-            title: project.title,
-            subtitle: project.summary,
-            imageUrl: heroAsset.dataUrl,
-            imageAlt: heroAsset.description || project.title
-          },
-          order: 0,
-          settings: { ...defaultBlockSettings, width: 'full' }
-        })
+const TEXT_STYLE_OPTIONS: Array<{ value: TextBlockContent['style']; label: string }> = [
+  { value: 'section', label: 'Section heading' },
+  { value: 'body', label: 'Body copy' },
+  { value: 'quote', label: 'Quote' },
+]
+
+const LINK_TYPE_OPTIONS: Array<{ value: ProjectLink['type']; label: string }> = [
+  { value: 'website', label: 'Website' },
+  { value: 'demo', label: 'Live demo' },
+  { value: 'github', label: 'Repository' },
+  { value: 'behance', label: 'Behance' },
+  { value: 'youtube', label: 'YouTube' },
+  { value: 'other', label: 'Other' },
+]
+
+const ensureSettings = (settings?: ProjectBlockSettings): Required<ProjectBlockSettings> => ({
+  width: settings?.width ?? DEFAULT_SETTINGS.width,
+  alignment: settings?.alignment ?? DEFAULT_SETTINGS.alignment,
+  padding: settings?.padding ?? DEFAULT_SETTINGS.padding,
+  backgroundColor: settings?.backgroundColor ?? DEFAULT_SETTINGS.backgroundColor,
+})
+
+const getAssetById = (assets: ProjectAsset[], id?: string | null) =>
+  (id ? assets.find(asset => asset.id === id) ?? null : null)
+
+const generateDefaultLayout = (project: ProjectMeta): ProjectLayoutBlock[] => {
+  const blocks: ProjectLayoutBlock[] = []
+  let order = 0
+
+  const imageAssets = project.assets.filter(asset => asset.mimeType.startsWith('image/'))
+  const videoAssets = project.assets.filter(asset => asset.mimeType.startsWith('video/'))
+
+  const heroAsset =
+    (project.cover && imageAssets.find(asset => asset.id === project.cover)) ||
+    imageAssets[0]
+
+  if (heroAsset) {
+    const content: HeroBlockContent = {
+      title: project.title,
+      subtitle: project.summary ?? project.problem ?? undefined,
+      assetId: heroAsset.id,
+    }
+
+    blocks.push({
+      id: `hero-${heroAsset.id}`,
+      type: 'hero',
+      order: order++,
+      settings: { ...DEFAULT_SETTINGS, width: 'full' },
+      content,
+    })
+  }
+
+  if (project.problem) {
+    const content: TextBlockContent = {
+      title: 'The Problem',
+      text: project.problem,
+      style: 'section',
+    }
+
+    blocks.push({
+      id: 'problem-block',
+      type: 'text',
+      order: order++,
+      settings: DEFAULT_SETTINGS,
+      content,
+    })
+  }
+
+  if (project.solution) {
+    const content: TextBlockContent = {
+      title: 'The Solution',
+      text: project.solution,
+      style: 'section',
+    }
+
+    blocks.push({
+      id: 'solution-block',
+      type: 'text',
+      order: order++,
+      settings: DEFAULT_SETTINGS,
+      content,
+    })
+  }
+
+  const galleryImages = imageAssets.filter(asset => asset.id !== heroAsset?.id)
+  if (galleryImages.length > 0) {
+    const content: GalleryBlockContent = {
+      title: 'Project Gallery',
+      items: galleryImages.map(asset => ({
+        assetId: asset.id,
+        caption: asset.description ?? '',
+      })),
+    }
+
+    blocks.push({
+      id: 'gallery-block',
+      type: 'gallery',
+      order: order++,
+      settings: DEFAULT_SETTINGS,
+      content,
+    })
+  }
+
+  if (videoAssets.length > 0) {
+    const primaryVideo = videoAssets[0]
+    const content: VideoBlockContent = {
+      assetId: primaryVideo.id,
+      caption: primaryVideo.description ?? '',
+      controls: true,
+      autoplay: false,
+      loop: false,
+      muted: false,
+    }
+
+    blocks.push({
+      id: `video-${primaryVideo.id}`,
+      type: 'video',
+      order: order++,
+      settings: DEFAULT_SETTINGS,
+      content,
+    })
+  }
+
+  if (project.outcomes) {
+    const content: TextBlockContent = {
+      title: 'Outcomes & Impact',
+      text: project.outcomes,
+      style: 'section',
+    }
+
+    blocks.push({
+      id: 'outcomes-block',
+      type: 'text',
+      order: order++,
+      settings: DEFAULT_SETTINGS,
+      content,
+    })
+  }
+
+  const metrics: MetricsBlockContent['metrics'] = []
+  if (project.metrics?.sales) {
+    metrics.push({ label: 'Sales Impact', value: project.metrics.sales })
+  }
+  if (project.metrics?.engagement) {
+    metrics.push({ label: 'Engagement', value: project.metrics.engagement })
+  }
+  if (project.metrics?.other) {
+    metrics.push({ label: 'Additional Impact', value: project.metrics.other })
+  }
+
+  if (metrics.length > 0) {
+    blocks.push({
+      id: 'metrics-block',
+      type: 'metrics',
+      order: order++,
+      settings: DEFAULT_SETTINGS,
+      content: {
+        title: 'Key Metrics',
+        metrics,
+      },
+    })
+  }
+
+  if (project.links && project.links.length > 0) {
+    const content: LinkBlockContent = {
+      title: 'Project Links',
+      links: project.links,
+    }
+
+    blocks.push({
+      id: 'links-block',
+      type: 'link',
+      order: order++,
+      settings: DEFAULT_SETTINGS,
+      content,
+    })
+  }
+
+  if (blocks.length === 0) {
+    blocks.push({
+      id: 'text-intro',
+      type: 'text',
+      order: 0,
+      settings: DEFAULT_SETTINGS,
+      content: {
+        title: project.title,
+        text: 'Start building your story by adding blocks from the sidebar.',
+        style: 'section',
+      },
+    })
+  }
+
+  return blocks
+}
+
+const normaliseBlocks = (layout: ProjectLayoutBlock[] | undefined, project: ProjectMeta): ProjectLayoutBlock[] => {
+  if (!layout || layout.length === 0) {
+    return generateDefaultLayout(project)
+  }
+
+  return layout
+    .map((block, index) => ({
+      ...block,
+      id: typeof block.id === 'string' ? block.id : `${block.type}-${index}`,
+      order: typeof block.order === 'number' ? block.order : index,
+      settings: ensureSettings(block.settings),
+      content: { ...block.content },
+    }))
+    .sort((a, b) => a.order - b.order)
+    .map((block, index) => ({ ...block, order: index })) as ProjectLayoutBlock[]
+}
+
+const reconcileBlocksWithAssets = (blocks: ProjectLayoutBlock[], assets: ProjectAsset[]): ProjectLayoutBlock[] => {
+  if (blocks.length === 0) {
+    return blocks
+  }
+
+  const assetIds = new Set(assets.map(asset => asset.id))
+  let mutated = false
+
+  const nextBlocks = blocks.map(block => {
+    switch (block.type) {
+      case 'hero': {
+        const assetId = (block.content as HeroBlockContent).assetId ?? null
+        if (assetId && !assetIds.has(assetId)) {
+          mutated = true
+          return { ...block, content: { ...block.content, assetId: null } as HeroBlockContent }
+        }
+        return block
+      }
+      case 'image': {
+        const assetId = (block.content as ImageBlockContent).assetId ?? null
+        if (assetId && !assetIds.has(assetId)) {
+          mutated = true
+          return { ...block, content: { ...block.content, assetId: null } as ImageBlockContent }
+        }
+        return block
+      }
+      case 'video': {
+        const assetId = (block.content as VideoBlockContent).assetId ?? null
+        if (assetId && !assetIds.has(assetId)) {
+          mutated = true
+          return { ...block, content: { ...block.content, assetId: null } as VideoBlockContent }
+        }
+        return block
+      }
+      case 'gallery': {
+        const gallery = block.content as GalleryBlockContent
+        const items = gallery.items.filter(item => !item.assetId || assetIds.has(item.assetId))
+        if (items.length !== gallery.items.length) {
+          mutated = true
+          return { ...block, content: { ...gallery, items } }
+        }
+        return block
+      }
+      default:
+        return block
+    }
+  })
+
+  const filtered = nextBlocks.filter(block =>
+    block.type !== 'gallery' || (block.content as GalleryBlockContent).items.length > 0,
+  )
+
+  return mutated || filtered.length !== blocks.length ? filtered : blocks
+}
+
+const createBlock = (
+  type: ProjectLayoutBlock['type'],
+  order: number,
+  project: ProjectMeta,
+): ProjectLayoutBlock => {
+  switch (type) {
+    case 'hero': {
+      const imageAssets = project.assets.filter(asset => asset.mimeType.startsWith('image/'))
+      const heroAsset =
+        (project.cover && imageAssets.find(asset => asset.id === project.cover)) || imageAssets[0] || null
+
+      const content: HeroBlockContent = {
+        title: project.title,
+        subtitle: project.summary ?? undefined,
+        assetId: heroAsset?.id ?? null,
+      }
+
+      return {
+        id: `hero-${Date.now()}`,
+        type: 'hero',
+        order,
+        settings: { ...DEFAULT_SETTINGS, width: 'full' },
+        content,
       }
     }
-    
-    // Problem statement
-    if (project.problem) {
-      initialBlocks.push({
-        id: 'text-problem',
+    case 'text':
+      return {
+        id: `text-${Date.now()}`,
         type: 'text',
+        order,
+        settings: DEFAULT_SETTINGS,
         content: {
-          title: 'The Problem',
-          text: project.problem,
-          style: 'section'
+          title: 'Section Title',
+          text: 'Add your content here…',
+          style: 'section',
         },
-        order: 1,
-        settings: defaultBlockSettings
-      })
+      }
+    case 'image': {
+      const imageAssets = project.assets.filter(asset => asset.mimeType.startsWith('image/'))
+      const defaultAsset = imageAssets[0] ?? null
+      const content: ImageBlockContent = {
+        assetId: defaultAsset?.id ?? null,
+        alt: defaultAsset?.description ?? defaultAsset?.name,
+        caption: defaultAsset?.description ?? '',
+      }
+      return {
+        id: `image-${Date.now()}`,
+        type: 'image',
+        order,
+        settings: DEFAULT_SETTINGS,
+        content,
+      }
     }
-    
-    // Solution
-    if (project.solution) {
-      initialBlocks.push({
-        id: 'text-solution',
-        type: 'text',
-        content: {
-          title: 'The Solution',
-          text: project.solution,
-          style: 'section'
-        },
-        order: 2,
-        settings: defaultBlockSettings
-      })
-    }
-    
-    // Gallery of remaining assets
-    const galleryAssets = project.assets.filter(a => a.id !== project.cover)
-    if (galleryAssets.length > 0) {
-      initialBlocks.push({
-        id: 'gallery-1',
+    case 'gallery': {
+      const imageAssets = project.assets.filter(asset => asset.mimeType.startsWith('image/'))
+      const content: GalleryBlockContent = {
+        title: 'Gallery',
+        items: imageAssets.map(asset => ({ assetId: asset.id, caption: asset.description ?? '' })),
+      }
+      return {
+        id: `gallery-${Date.now()}`,
         type: 'gallery',
-        content: {
-          title: 'Project Gallery',
-          images: galleryAssets.map(asset => ({
-            url: asset.dataUrl,
-            alt: asset.description || asset.name,
-            caption: asset.description
-          }))
-        },
-        order: 3,
-        settings: defaultBlockSettings
-      })
+        order,
+        settings: DEFAULT_SETTINGS,
+        content,
+      }
     }
-    
-    // Outcomes
-    if (project.outcomes) {
-      initialBlocks.push({
-        id: 'text-outcomes',
-        type: 'text',
-        content: {
-          title: 'Outcomes & Impact',
-          text: project.outcomes,
-          style: 'section'
-        },
-        order: 4,
-        settings: defaultBlockSettings
-      })
+    case 'video': {
+      const videoAssets = project.assets.filter(asset => asset.mimeType.startsWith('video/'))
+      const asset = videoAssets[0] ?? null
+      const content: VideoBlockContent = {
+        assetId: asset?.id ?? null,
+        caption: asset?.description ?? '',
+        controls: true,
+        autoplay: false,
+        loop: false,
+        muted: false,
+      }
+      return {
+        id: `video-${Date.now()}`,
+        type: 'video',
+        order,
+        settings: DEFAULT_SETTINGS,
+        content,
+      }
     }
-    
-    // Metrics
-    if (project.metrics && (project.metrics.sales || project.metrics.engagement || project.metrics.other)) {
-      initialBlocks.push({
-        id: 'metrics-1',
+    case 'metrics': {
+      const metrics: MetricsBlockContent = {
+        title: 'Metrics',
+        metrics: project.metrics
+          ? [
+              project.metrics.sales && { label: 'Sales Impact', value: project.metrics.sales },
+              project.metrics.engagement && { label: 'Engagement', value: project.metrics.engagement },
+              project.metrics.other && { label: 'Additional Impact', value: project.metrics.other },
+            ].filter(Boolean) as Array<{ label: string; value: string }>
+          : [],
+      }
+      return {
+        id: `metrics-${Date.now()}`,
         type: 'metrics',
-        content: {
-          title: 'Key Metrics',
-          metrics: [
-            project.metrics.sales && { label: 'Sales Impact', value: project.metrics.sales },
-            project.metrics.engagement && { label: 'Engagement', value: project.metrics.engagement },
-            project.metrics.other && { label: 'Additional Impact', value: project.metrics.other }
-          ].filter(Boolean)
-        },
-        order: 5,
-        settings: defaultBlockSettings
-      })
+        order,
+        settings: DEFAULT_SETTINGS,
+        content: metrics,
+      }
     }
-    
-    // Links
-    if (project.links && project.links.length > 0) {
-      initialBlocks.push({
-        id: 'links-1',
+    case 'link': {
+      const content: LinkBlockContent = {
+        title: 'Project Links',
+        links: project.links && project.links.length > 0
+          ? project.links
+          : [{ type: 'website', url: '', label: '' }],
+      }
+      return {
+        id: `link-${Date.now()}`,
         type: 'link',
-        content: {
-          title: 'Project Links',
-          links: project.links
-        },
-        order: 6,
-        settings: defaultBlockSettings
-      })
+        order,
+        settings: DEFAULT_SETTINGS,
+        content,
+      }
     }
-    
-    return initialBlocks
-  })
-  
-  const [selectedBlock, setSelectedBlock] = useState<string | null>(null)
+    default:
+      return {
+        id: `text-${Date.now()}`,
+        type: 'text',
+        order,
+        settings: DEFAULT_SETTINGS,
+        content: {
+          title: 'Section Title',
+          text: 'Add your content here…',
+          style: 'section',
+        },
+      }
+  }
+}
+export default function ProjectEditor({ project, onUpdateProject }: ProjectEditorProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('desktop')
   const [showPreview, setShowPreview] = useState(false)
-  const draggedBlock = useRef<string | null>(null)
+  const [blocks, setBlocks] = useState<ProjectLayoutBlock[]>(() => normaliseBlocks(project.layout, project))
+  const [selectedBlockId, setSelectedBlockId] = useState<string | null>(
+    () => normaliseBlocks(project.layout, project)[0]?.id ?? null,
+  )
+  const [hasChanges, setHasChanges] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveState, setSaveState] = useState<SaveState>(null)
+  const layoutSignature = useRef(JSON.stringify(project.layout ?? []))
 
-  const addBlock = (type: LayoutBlock['type']) => {
-    const newBlock: LayoutBlock = {
-      id: `${type}-${Date.now()}`,
-      type,
-      content: getDefaultContent(type),
-      order: blocks.length,
-      settings: defaultBlockSettings
+  useEffect(() => {
+    const signature = JSON.stringify(project.layout ?? [])
+    if (signature !== layoutSignature.current) {
+      const initial = normaliseBlocks(project.layout, project)
+      setBlocks(initial)
+      setSelectedBlockId(initial[0]?.id ?? null)
+      setHasChanges(false)
+      layoutSignature.current = signature
+      return
     }
-    setBlocks([...blocks, newBlock])
-    setSelectedBlock(newBlock.id)
-  }
 
-  const deleteBlock = (blockId: string) => {
-    setBlocks(blocks.filter(b => b.id !== blockId))
-    if (selectedBlock === blockId) {
-      setSelectedBlock(null)
+    setBlocks(current => reconcileBlocksWithAssets(current, project.assets))
+  }, [project.layout, project.assets, project.slug, project.cover, project.title, project.summary])
+
+  useEffect(() => {
+    if (!selectedBlockId && blocks.length > 0) {
+      setSelectedBlockId(blocks[0].id)
+      return
     }
+
+    if (selectedBlockId && !blocks.some(block => block.id === selectedBlockId)) {
+      setSelectedBlockId(blocks[0]?.id ?? null)
+    }
+  }, [blocks, selectedBlockId])
+
+  useEffect(() => {
+    if (!saveState) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => setSaveState(null), 3000)
+    return () => window.clearTimeout(timeout)
+  }, [saveState])
+
+  const selectedBlock = useMemo(
+    () => blocks.find(block => block.id === selectedBlockId) ?? null,
+    [blocks, selectedBlockId],
+  )
+
+  const sortedBlocks = useMemo(
+    () => [...blocks].sort((a, b) => a.order - b.order),
+    [blocks],
+  )
+
+  const handleAddBlock = (type: ProjectLayoutBlock['type']) => {
+    setBlocks(current => {
+      const next = [...current]
+      const newBlock = createBlock(type, next.length, project)
+      next.push(newBlock)
+      setSelectedBlockId(newBlock.id)
+      return next
+    })
+    setHasChanges(true)
   }
 
-  const updateBlock = (blockId: string, updates: Partial<LayoutBlock>) => {
-    setBlocks(blocks.map(block => 
-      block.id === blockId ? { ...block, ...updates } : block
-    ))
+  const handleDeleteBlock = (blockId: string) => {
+    setBlocks(current => {
+      const filtered = current.filter(block => block.id !== blockId)
+      return filtered.map((block, index) => ({ ...block, order: index }))
+    })
+    if (selectedBlockId === blockId) {
+      setSelectedBlockId(null)
+    }
+    setHasChanges(true)
   }
 
-  const reorderBlocks = (fromIndex: number, toIndex: number) => {
-    const newBlocks = [...blocks]
-    const [movedBlock] = newBlocks.splice(fromIndex, 1)
-    newBlocks.splice(toIndex, 0, movedBlock)
-    
-    // Update order values
-    const reorderedBlocks = newBlocks.map((block, index) => ({
+  const handleUpdateBlock = (blockId: string, updates: Partial<ProjectLayoutBlock>) => {
+    setBlocks(current => {
+      const mapped = current.map(block =>
+        block.id === blockId
+          ? {
+              ...block,
+              ...updates,
+              settings: ensureSettings(updates.settings ?? block.settings),
+              content: updates.content ? { ...block.content, ...updates.content } : block.content,
+            }
+          : block,
+      )
+      return mapped as ProjectLayoutBlock[]
+    })
+    setHasChanges(true)
+  }
+
+  const handleReorder = (fromIndex: number, toIndex: number) => {
+    setBlocks(current => {
+      if (toIndex < 0 || toIndex >= current.length) {
+        return current
+      }
+      const reordered = [...current]
+      const [moved] = reordered.splice(fromIndex, 1)
+      reordered.splice(toIndex, 0, moved)
+      return reordered.map((block, index) => ({ ...block, order: index }))
+    })
+    setHasChanges(true)
+  }
+
+  const handleResetLayout = () => {
+    const initial = normaliseBlocks(project.layout, project)
+    setBlocks(initial)
+    setSelectedBlockId(initial[0]?.id ?? null)
+    setHasChanges(false)
+  }
+
+  const handleSaveLayout = async () => {
+    if (isSaving || blocks.length === 0) {
+      return
+    }
+
+    setIsSaving(true)
+    const sorted = [...blocks].sort((a, b) => a.order - b.order).map((block, index) => ({
       ...block,
-      order: index
+      order: index,
+      settings: ensureSettings(block.settings),
     }))
-    
-    setBlocks(reorderedBlocks)
+
+    const heroBlock = sorted.find(block => block.type === 'hero')
+    const updates: Partial<ProjectMeta> = {
+      layout: sorted,
+    }
+
+    if (heroBlock) {
+      updates.cover = (heroBlock.content as HeroBlockContent).assetId ?? undefined
+    }
+
+    try {
+      await onUpdateProject(updates)
+      layoutSignature.current = JSON.stringify(sorted)
+      setHasChanges(false)
+      setSaveState({ type: 'success', message: 'Layout saved.' })
+    } catch (error) {
+      console.error('Failed to save layout', error)
+      setSaveState({ type: 'error', message: 'Unable to save layout changes.' })
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   const exportAsHTML = () => {
-    const html = generateHTML(blocks, project)
+    const html = generateHTML(blocks, project, project.assets)
     const blob = new Blob([html], { type: 'text/html' })
     const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `${project.slug}-portfolio.html`
-    a.click()
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${project.slug}-portfolio.html`
+    link.click()
     URL.revokeObjectURL(url)
   }
-
-  const sortedBlocks = [...blocks].sort((a, b) => a.order - b.order)
 
   return (
     <div className="project-editor">
       <div className="project-editor__toolbar">
         <div className="project-editor__view-controls">
           <button
+            type="button"
             className={`project-editor__view-btn ${viewMode === 'desktop' ? 'active' : ''}`}
             onClick={() => setViewMode('desktop')}
           >
@@ -237,6 +621,7 @@ export default function ProjectEditor({ project, onUpdateProject }: ProjectEdito
             Desktop
           </button>
           <button
+            type="button"
             className={`project-editor__view-btn ${viewMode === 'tablet' ? 'active' : ''}`}
             onClick={() => setViewMode('tablet')}
           >
@@ -244,6 +629,7 @@ export default function ProjectEditor({ project, onUpdateProject }: ProjectEdito
             Tablet
           </button>
           <button
+            type="button"
             className={`project-editor__view-btn ${viewMode === 'mobile' ? 'active' : ''}`}
             onClick={() => setViewMode('mobile')}
           >
@@ -251,19 +637,45 @@ export default function ProjectEditor({ project, onUpdateProject }: ProjectEdito
             Mobile
           </button>
         </div>
-        
-        <div className="project-editor__actions">
+
+        <div className="project-editor__toolbar-actions">
+          {saveState && (
+            <span className={`project-editor__status project-editor__status--${saveState.type}`}>
+              {saveState.message}
+            </span>
+          )}
+          {!saveState && hasChanges && (
+            <span className="project-editor__status project-editor__status--info">Unsaved layout changes</span>
+          )}
+
           <button
+            type="button"
             className="button button--ghost"
-            onClick={() => setShowPreview(!showPreview)}
+            onClick={() => setShowPreview(previous => !previous)}
           >
             <Eye size={16} />
-            {showPreview ? 'Edit' : 'Preview'}
+            {showPreview ? 'Return to editor' : 'Preview layout'}
           </button>
+
           <button
-            className="button button--primary"
-            onClick={exportAsHTML}
+            type="button"
+            className="button button--ghost"
+            onClick={handleResetLayout}
+            disabled={isSaving || !hasChanges}
           >
+            Reset
+          </button>
+
+          <button
+            type="button"
+            className="button button--primary"
+            onClick={handleSaveLayout}
+            disabled={isSaving || !hasChanges}
+          >
+            {isSaving ? 'Saving…' : 'Save layout'}
+          </button>
+
+          <button type="button" className="button button--ghost" onClick={exportAsHTML}>
             <Download size={16} />
             Export HTML
           </button>
@@ -274,42 +686,48 @@ export default function ProjectEditor({ project, onUpdateProject }: ProjectEdito
         {!showPreview && (
           <div className="project-editor__sidebar">
             <div className="project-editor__block-library">
-              <h3>Add Blocks</h3>
+              <h3>Add blocks</h3>
               <div className="project-editor__block-buttons">
-                <BlockButton icon={Layout} label="Hero" onClick={() => addBlock('hero')} />
-                <BlockButton icon={Type} label="Text" onClick={() => addBlock('text')} />
-                <BlockButton icon={Image} label="Image" onClick={() => addBlock('image')} />
-                <BlockButton icon={Grid} label="Gallery" onClick={() => addBlock('gallery')} />
-                <BlockButton icon={Video} label="Video" onClick={() => addBlock('video')} />
-                <BlockButton icon={Link2} label="Links" onClick={() => addBlock('link')} />
-                <BlockButton icon={Settings} label="Metrics" onClick={() => addBlock('metrics')} />
+                <BlockButton icon={Layout} label="Hero" onClick={() => handleAddBlock('hero')} />
+                <BlockButton icon={Type} label="Text" onClick={() => handleAddBlock('text')} />
+                <BlockButton icon={ImageIcon} label="Image" onClick={() => handleAddBlock('image')} />
+                <BlockButton icon={Grid} label="Gallery" onClick={() => handleAddBlock('gallery')} />
+                <BlockButton icon={Video} label="Video" onClick={() => handleAddBlock('video')} />
+                <BlockButton icon={Settings} label="Metrics" onClick={() => handleAddBlock('metrics')} />
+                <BlockButton icon={Link2} label="Links" onClick={() => handleAddBlock('link')} />
               </div>
             </div>
-            
+
             {selectedBlock && (
               <BlockSettings
-                block={blocks.find(b => b.id === selectedBlock)!}
-                onUpdate={(updates) => updateBlock(selectedBlock, updates)}
+                block={selectedBlock}
                 assets={project.assets}
+                onUpdate={updates => handleUpdateBlock(selectedBlock.id, updates)}
               />
             )}
           </div>
         )}
 
-        <div className={`project-editor__canvas project-editor__canvas--${viewMode} ${showPreview ? 'project-editor__canvas--preview' : ''}`}>
+        <div
+          className={`project-editor__canvas project-editor__canvas--${viewMode} ${
+            showPreview ? 'project-editor__canvas--preview' : ''
+          }`}
+        >
           {sortedBlocks.map((block, index) => (
             <BlockRenderer
               key={block.id}
               block={block}
-              isSelected={selectedBlock === block.id}
+              project={project}
+              assets={project.assets}
+              isSelected={!showPreview && selectedBlockId === block.id}
               isPreview={showPreview}
-              onClick={() => !showPreview && setSelectedBlock(block.id)}
-              onDelete={() => deleteBlock(block.id)}
-              onMoveUp={index > 0 ? () => reorderBlocks(index, index - 1) : undefined}
-              onMoveDown={index < sortedBlocks.length - 1 ? () => reorderBlocks(index, index + 1) : undefined}
+              onClick={() => !showPreview && setSelectedBlockId(block.id)}
+              onDelete={() => handleDeleteBlock(block.id)}
+              onMoveUp={index > 0 ? () => handleReorder(index, index - 1) : undefined}
+              onMoveDown={index < sortedBlocks.length - 1 ? () => handleReorder(index, index + 1) : undefined}
             />
           ))}
-          
+
           {!showPreview && sortedBlocks.length === 0 && (
             <div className="project-editor__empty">
               <p>Start building your project by adding blocks from the sidebar.</p>
@@ -321,223 +739,335 @@ export default function ProjectEditor({ project, onUpdateProject }: ProjectEdito
   )
 }
 
-function BlockButton({ icon: Icon, label, onClick }: { icon: any, label: string, onClick: () => void }) {
+type BlockButtonProps = {
+  icon: typeof Layout
+  label: string
+  onClick: () => void
+}
+
+function BlockButton({ icon: Icon, label, onClick }: BlockButtonProps) {
   return (
-    <button className="project-editor__block-btn" onClick={onClick}>
+    <button type="button" className="project-editor__block-btn" onClick={onClick}>
       <Icon size={20} />
       <span>{label}</span>
     </button>
   )
 }
 
-function BlockRenderer({ 
-  block, 
-  isSelected, 
-  isPreview, 
-  onClick, 
-  onDelete, 
-  onMoveUp, 
-  onMoveDown 
-}: { 
-  block: LayoutBlock
+type BlockRendererProps = {
+  block: ProjectLayoutBlock
+  project: ProjectMeta
+  assets: ProjectAsset[]
   isSelected: boolean
   isPreview: boolean
   onClick: () => void
   onDelete: () => void
   onMoveUp?: () => void
   onMoveDown?: () => void
-}) {
-  const blockClass = `project-block project-block--${block.type} project-block--${block.settings.width} project-block--align-${block.settings.alignment} project-block--padding-${block.settings.padding} ${isSelected ? 'project-block--selected' : ''}`
+}
+
+function BlockRenderer({
+  block,
+  project,
+  assets,
+  isSelected,
+  isPreview,
+  onClick,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: BlockRendererProps) {
+  const blockClass = `project-block project-block--${block.type} project-block--${block.settings.width} project-block--align-${
+    block.settings.alignment
+  } project-block--padding-${block.settings.padding} ${isSelected ? 'project-block--selected' : ''}`
+
+  const handleDelete = (event: React.MouseEvent) => {
+    event.stopPropagation()
+    onDelete()
+  }
+
+  const handleMoveUp = (event: React.MouseEvent) => {
+    event.stopPropagation()
+    onMoveUp?.()
+  }
+
+  const handleMoveDown = (event: React.MouseEvent) => {
+    event.stopPropagation()
+    onMoveDown?.()
+  }
 
   return (
-    <div 
-      className={blockClass}
-      onClick={onClick}
-      style={{ backgroundColor: block.settings.backgroundColor }}
-    >
+    <div className={blockClass} onClick={onClick} style={{ backgroundColor: block.settings.backgroundColor }}>
       {!isPreview && (
         <div className="project-block__controls">
           {onMoveUp && (
-            <button className="project-block__control" onClick={(e) => { e.stopPropagation(); onMoveUp() }}>
+            <button type="button" className="project-block__control" onClick={handleMoveUp}>
               ↑
             </button>
           )}
           {onMoveDown && (
-            <button className="project-block__control" onClick={(e) => { e.stopPropagation(); onMoveDown() }}>
+            <button type="button" className="project-block__control" onClick={handleMoveDown}>
               ↓
             </button>
           )}
-          <button className="project-block__control project-block__control--delete" onClick={(e) => { e.stopPropagation(); onDelete() }}>
+          <button
+            type="button"
+            className="project-block__control project-block__control--delete"
+            onClick={handleDelete}
+          >
             <Trash2 size={14} />
           </button>
         </div>
       )}
-      
-      <BlockContent block={block} isPreview={isPreview} />
+
+      <BlockContent block={block} project={project} assets={assets} />
     </div>
   )
 }
 
-function BlockContent({ block, isPreview }: { block: LayoutBlock, isPreview: boolean }) {
+type BlockContentProps = {
+  block: ProjectLayoutBlock
+  project: ProjectMeta
+  assets: ProjectAsset[]
+}
+
+function BlockContent({ block, project, assets }: BlockContentProps) {
   switch (block.type) {
-    case 'hero':
+    case 'hero': {
+      const heroContent = block.content as HeroBlockContent
+      const asset = getAssetById(assets, heroContent.assetId)
+
       return (
         <div className="block-hero">
-          {block.content.imageUrl && (
-            <img src={block.content.imageUrl} alt={block.content.imageAlt} className="block-hero__image" />
-          )}
-          <div className="block-hero__content">
-            <h1>{block.content.title}</h1>
-            {block.content.subtitle && <p className="block-hero__subtitle">{block.content.subtitle}</p>}
-          </div>
-        </div>
-      )
-    
-    case 'text':
-      return (
-        <div className="block-text">
-          {block.content.title && <h2>{block.content.title}</h2>}
-          <div className="block-text__content">
-            {block.content.text.split('\n').map((paragraph: string, i: number) => (
-              <p key={i}>{paragraph}</p>
-            ))}
-          </div>
-        </div>
-      )
-    
-    case 'image':
-      return (
-        <div className="block-image">
-          {block.content.imageUrl ? (
-            <img src={block.content.imageUrl} alt={block.content.alt} />
+          {asset ? (
+            <img
+              src={asset.dataUrl}
+              alt={asset.description ?? asset.name ?? project.title}
+              className="block-hero__image"
+            />
           ) : (
             <div className="block-image__placeholder">
-              <Image size={48} />
-              <p>Select an image</p>
+              <ImageIcon size={48} />
+              <p>Select an image for your hero section</p>
             </div>
           )}
-          {block.content.caption && <p className="block-image__caption">{block.content.caption}</p>}
-        </div>
-      )
-    
-    case 'gallery':
-      return (
-        <div className="block-gallery">
-          {block.content.title && <h2>{block.content.title}</h2>}
-          <div className="block-gallery__grid">
-            {block.content.images.map((img: any, i: number) => (
-              <div key={i} className="block-gallery__item">
-                <img src={img.url} alt={img.alt} />
-                {img.caption && <p className="block-gallery__caption">{img.caption}</p>}
-              </div>
-            ))}
+          <div className="block-hero__content">
+            <h1>{heroContent.title || project.title}</h1>
+            {heroContent.subtitle && <p className="block-hero__subtitle">{heroContent.subtitle}</p>}
           </div>
         </div>
       )
-
-    case 'video':
+    }
+    case 'text': {
+      const textContent = block.content as TextBlockContent
+      const paragraphs = textContent.text ? textContent.text.split('\n') : []
+      return (
+        <div className="block-text">
+          {textContent.title && <h2>{textContent.title}</h2>}
+          <div className="block-text__content">
+            {paragraphs.length > 0
+              ? paragraphs.map((paragraph, index) => <p key={index}>{paragraph}</p>)
+              : <p>Add narrative copy to bring this section to life.</p>}
+          </div>
+        </div>
+      )
+    }
+    case 'image': {
+      const imageContent = block.content as ImageBlockContent
+      const asset = getAssetById(assets, imageContent.assetId)
+      return (
+        <div className="block-image">
+          {asset ? (
+            <img src={asset.dataUrl} alt={imageContent.alt ?? asset.description ?? asset.name} />
+          ) : (
+            <div className="block-image__placeholder">
+              <ImageIcon size={48} />
+              <p>Select an image asset to show here.</p>
+            </div>
+          )}
+          {imageContent.caption && <p className="block-image__caption">{imageContent.caption}</p>}
+        </div>
+      )
+    }
+    case 'gallery': {
+      const galleryContent = block.content as GalleryBlockContent
+      return (
+        <div className="block-gallery">
+          {galleryContent.title && <h2>{galleryContent.title}</h2>}
+          {galleryContent.items.length === 0 ? (
+            <div className="project-editor__empty-option">
+              <AlertCircle size={16} />
+              <span>Add images from your asset library to populate this gallery.</span>
+            </div>
+          ) : (
+            <div className="block-gallery__grid">
+              {galleryContent.items.map((item, index) => {
+                const asset = getAssetById(assets, item.assetId)
+                return (
+                  <div key={item.assetId ?? index} className="block-gallery__item">
+                    {asset ? (
+                      <img src={asset.dataUrl} alt={asset.description ?? asset.name} />
+                    ) : (
+                      <div className="block-image__placeholder">
+                        <ImageIcon size={32} />
+                        <p>Missing asset</p>
+                      </div>
+                    )}
+                    {item.caption && <p className="block-gallery__caption">{item.caption}</p>}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )
+    }
+    case 'video': {
+      const videoContent = block.content as VideoBlockContent
+      const asset = getAssetById(assets, videoContent.assetId)
       return (
         <div className="block-video">
-          {block.content.videoUrl ? (
+          {asset ? (
             <video
-              controls={block.content.controls ?? true}
-              autoPlay={block.content.autoplay ?? false}
-              loop={block.content.loop ?? false}
-              muted={block.content.muted ?? false}
+              controls={videoContent.controls ?? true}
+              autoPlay={videoContent.autoplay ?? false}
+              loop={videoContent.loop ?? false}
+              muted={videoContent.muted ?? false}
               playsInline
-              poster={block.content.posterUrl ?? undefined}
+              poster={asset.thumbnailUrl ?? undefined}
             >
-              <source src={block.content.videoUrl} type={block.content.mimeType ?? undefined} />
+              <source src={asset.dataUrl} type={asset.mimeType} />
               Your browser does not support the video tag.
             </video>
           ) : (
             <div className="block-video__placeholder">
               <Video size={48} />
-              <p>Select a video</p>
+              <p>Select a video asset to play here.</p>
             </div>
           )}
-          {block.content.caption && <p className="block-video__caption">{block.content.caption}</p>}
+          {videoContent.caption && <p className="block-video__caption">{videoContent.caption}</p>}
         </div>
       )
-
-    case 'metrics':
+    }
+    case 'metrics': {
+      const metricsContent = block.content as MetricsBlockContent
       return (
         <div className="block-metrics">
-          {block.content.title && <h2>{block.content.title}</h2>}
-          <div className="block-metrics__grid">
-            {block.content.metrics.map((metric: any, i: number) => (
-              <div key={i} className="block-metrics__item">
-                <div className="block-metrics__value">{metric.value}</div>
-                <div className="block-metrics__label">{metric.label}</div>
-              </div>
-            ))}
-          </div>
+          {metricsContent.title && <h2>{metricsContent.title}</h2>}
+          {metricsContent.metrics.length === 0 ? (
+            <div className="project-editor__empty-option">
+              <AlertCircle size={16} />
+              <span>Add metrics to highlight the impact of your work.</span>
+            </div>
+          ) : (
+            <div className="block-metrics__grid">
+              {metricsContent.metrics.map((metric, index) => (
+                <div key={`${metric.label}-${index}`} className="block-metrics__item">
+                  <div className="block-metrics__value">{metric.value}</div>
+                  <div className="block-metrics__label">{metric.label}</div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )
-    
-    case 'link':
+    }
+    case 'link': {
+      const linkContent = block.content as LinkBlockContent
       return (
         <div className="block-links">
-          {block.content.title && <h2>{block.content.title}</h2>}
-          <div className="block-links__list">
-            {block.content.links.map((link: any, i: number) => (
-              <a key={i} href={link.url} target="_blank" rel="noopener noreferrer" className="block-links__item">
-                <Link2 size={16} />
-                {link.label || link.url}
-              </a>
-            ))}
-          </div>
+          {linkContent.title && <h2>{linkContent.title}</h2>}
+          {linkContent.links.length === 0 ? (
+            <div className="project-editor__empty-option">
+              <AlertCircle size={16} />
+              <span>Add project links to help visitors explore more.</span>
+            </div>
+          ) : (
+            <div className="block-links__list">
+              {linkContent.links.map((link, index) => (
+                <a
+                  key={`${link.url}-${index}`}
+                  href={link.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block-links__item"
+                >
+                  <Link2 size={16} />
+                  {link.label || link.url}
+                </a>
+              ))}
+            </div>
+          )}
         </div>
       )
-    
+    }
     default:
-      return <div>Unknown block type</div>
+      return <div>Unsupported block type</div>
   }
 }
 
-function BlockSettings({ 
-  block, 
-  onUpdate, 
-  assets 
-}: { 
-  block: LayoutBlock
-  onUpdate: (updates: Partial<LayoutBlock>) => void
+type BlockSettingsProps = {
+  block: ProjectLayoutBlock
   assets: ProjectAsset[]
-}) {
+  onUpdate: (updates: Partial<ProjectLayoutBlock>) => void
+}
+
+function BlockSettings({ block, assets, onUpdate }: BlockSettingsProps) {
+  const imageAssets = useMemo(
+    () => assets.filter(asset => asset.mimeType.startsWith('image/')),
+    [assets],
+  )
+  const videoAssets = useMemo(
+    () => assets.filter(asset => asset.mimeType.startsWith('video/')),
+    [assets],
+  )
+
+  const [gallerySelection, setGallerySelection] = useState('')
+
+  useEffect(() => {
+    setGallerySelection('')
+  }, [block.id])
+
   return (
     <div className="project-editor__settings">
-      <h3>Block Settings</h3>
-      
+      <h3>Block settings</h3>
+
       <div className="setting-group">
         <label>Width</label>
-        <select 
-          value={block.settings.width} 
-          onChange={(e) => onUpdate({ settings: { ...block.settings, width: e.target.value as any } })}
+        <select
+          value={block.settings.width}
+          onChange={event =>
+            onUpdate({ settings: { ...block.settings, width: event.target.value as ProjectBlockSettings['width'] } })
+          }
         >
-          <option value="full">Full Width</option>
-          <option value="two-thirds">Two Thirds</option>
-          <option value="half">Half Width</option>
-          <option value="third">One Third</option>
+          <option value="full">Full width</option>
+          <option value="two-thirds">Two thirds</option>
+          <option value="half">Half</option>
+          <option value="third">One third</option>
         </select>
       </div>
-      
+
       <div className="setting-group">
         <label>Alignment</label>
-        <select 
-          value={block.settings.alignment} 
-          onChange={(e) => onUpdate({ settings: { ...block.settings, alignment: e.target.value as any } })}
+        <select
+          value={block.settings.alignment}
+          onChange={event =>
+            onUpdate({ settings: { ...block.settings, alignment: event.target.value as ProjectBlockSettings['alignment'] } })
+          }
         >
           <option value="left">Left</option>
           <option value="center">Center</option>
           <option value="right">Right</option>
         </select>
       </div>
-      
+
       <div className="setting-group">
         <label>Padding</label>
-        <select 
-          value={block.settings.padding} 
-          onChange={(e) => onUpdate({ settings: { ...block.settings, padding: e.target.value as any } })}
+        <select
+          value={block.settings.padding}
+          onChange={event =>
+            onUpdate({ settings: { ...block.settings, padding: event.target.value as ProjectBlockSettings['padding'] } })
+          }
         >
           <option value="none">None</option>
           <option value="small">Small</option>
@@ -546,88 +1076,284 @@ function BlockSettings({
         </select>
       </div>
 
-      {/* Block-specific settings */}
+      {block.type === 'hero' && (
+        <>
+          <div className="setting-group">
+            <label>Headline</label>
+            <input
+              value={(block.content as HeroBlockContent).title ?? ''}
+              onChange={event => onUpdate({ content: { ...block.content, title: event.target.value } })}
+            />
+          </div>
+
+          <div className="setting-group">
+            <label>Subheading</label>
+            <textarea
+              value={(block.content as HeroBlockContent).subtitle ?? ''}
+              onChange={event => onUpdate({ content: { ...block.content, subtitle: event.target.value } })}
+              placeholder="Summarise the project in one or two sentences"
+            />
+          </div>
+
+          <div className="setting-group">
+            <label>Hero image</label>
+            <select
+              value={(block.content as HeroBlockContent).assetId ?? ''}
+              onChange={event =>
+                onUpdate({
+                  content: { ...block.content, assetId: event.target.value ? event.target.value : null },
+                })
+              }
+            >
+              <option value="">Select an image…</option>
+              {imageAssets.map(asset => (
+                <option key={asset.id} value={asset.id}>
+                  {asset.name}
+                </option>
+              ))}
+            </select>
+            {imageAssets.length === 0 && (
+              <p className="project-editor__helper">Upload image assets to select a hero visual.</p>
+            )}
+          </div>
+        </>
+      )}
+
+      {block.type === 'text' && (
+        <>
+          <div className="setting-group">
+            <label>Title</label>
+            <input
+              value={(block.content as TextBlockContent).title ?? ''}
+              onChange={event => onUpdate({ content: { ...block.content, title: event.target.value } })}
+            />
+          </div>
+
+          <div className="setting-group">
+            <label>Copy</label>
+            <textarea
+              value={(block.content as TextBlockContent).text}
+              onChange={event => onUpdate({ content: { ...block.content, text: event.target.value } })}
+              placeholder="Tell the story behind this section"
+            />
+          </div>
+
+          <div className="setting-group">
+            <label>Style</label>
+            <select
+              value={(block.content as TextBlockContent).style ?? 'section'}
+              onChange={event =>
+                onUpdate({ content: { ...block.content, style: event.target.value as TextBlockContent['style'] } })
+              }
+            >
+              {TEXT_STYLE_OPTIONS.map(option => (
+                <option key={option.value} value={option.value ?? 'section'}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
+      )}
+
       {block.type === 'image' && (
-        <div className="setting-group">
-          <label>Select Image</label>
-          <select
-            value={block.content.assetId || ''}
-            onChange={(e) => {
-              const asset = assets.find(a => a.id === e.target.value)
-              onUpdate({
-                content: {
-                  ...block.content,
-                  assetId: e.target.value,
-                  imageUrl: asset?.dataUrl,
-                  alt: asset?.description || asset?.name
-                }
+        <>
+          <div className="setting-group">
+            <label>Image asset</label>
+            <select
+              value={(block.content as ImageBlockContent).assetId ?? ''}
+              onChange={event =>
+                onUpdate({ content: { ...block.content, assetId: event.target.value || null } })
+              }
+            >
+              <option value="">Select an image…</option>
+              {imageAssets.map(asset => (
+                <option key={asset.id} value={asset.id}>
+                  {asset.name}
+                </option>
+              ))}
+            </select>
+            {imageAssets.length === 0 && (
+              <p className="project-editor__helper">Upload images to showcase visuals inside this block.</p>
+            )}
+          </div>
+
+          <div className="setting-group">
+            <label>Alt text</label>
+            <input
+              value={(block.content as ImageBlockContent).alt ?? ''}
+              onChange={event => onUpdate({ content: { ...block.content, alt: event.target.value } })}
+              placeholder="Describe the image for accessibility"
+            />
+          </div>
+
+          <div className="setting-group">
+            <label>Caption</label>
+            <textarea
+              value={(block.content as ImageBlockContent).caption ?? ''}
+              onChange={event => onUpdate({ content: { ...block.content, caption: event.target.value } })}
+              placeholder="Add context or credit information"
+            />
+          </div>
+        </>
+      )}
+
+      {block.type === 'gallery' && (
+        <>
+          <div className="setting-group">
+            <label>Gallery title</label>
+            <input
+              value={(block.content as GalleryBlockContent).title ?? ''}
+              onChange={event => onUpdate({ content: { ...block.content, title: event.target.value } })}
+            />
+          </div>
+
+          <div className="setting-group">
+            <label>Add image from assets</label>
+            <div className="project-editor__inline-field">
+              <select
+                value={gallerySelection}
+                onChange={event => setGallerySelection(event.target.value)}
+              >
+                <option value="">Select an image…</option>
+                {imageAssets.map(asset => (
+                  <option
+                    key={asset.id}
+                    value={asset.id}
+                    disabled={(block.content as GalleryBlockContent).items.some(item => item.assetId === asset.id)}
+                  >
+                    {asset.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="button button--ghost button--small"
+                onClick={() => {
+                  if (!gallerySelection) {
+                    return
+                  }
+                  const gallery = block.content as GalleryBlockContent
+                  onUpdate({
+                    content: {
+                      ...gallery,
+                      items: [...gallery.items, { assetId: gallerySelection, caption: '' }],
+                    },
+                  })
+                  setGallerySelection('')
+                }}
+                disabled={!gallerySelection}
+              >
+                <Plus size={16} />
+                Add
+              </button>
+            </div>
+            {imageAssets.length === 0 && (
+              <p className="project-editor__helper">Upload images to populate this gallery.</p>
+            )}
+          </div>
+
+          <div className="project-editor__gallery-editor">
+            {(block.content as GalleryBlockContent).items.length === 0 ? (
+              <p className="project-editor__empty-option">No gallery items selected yet.</p>
+            ) : (
+              (block.content as GalleryBlockContent).items.map((item, index) => {
+                const asset = getAssetById(assets, item.assetId)
+                return (
+                  <div key={item.assetId ?? index} className="project-editor__gallery-item">
+                    <div className="project-editor__gallery-thumb">
+                      {asset ? (
+                        <img src={asset.thumbnailUrl ?? asset.dataUrl} alt={asset.description ?? asset.name} />
+                      ) : (
+                        <div className="project-editor__gallery-thumb--empty">
+                          <ImageIcon size={20} />
+                        </div>
+                      )}
+                    </div>
+                    <div className="project-editor__gallery-fields">
+                      <span className="project-editor__gallery-name">{asset?.name ?? 'Missing asset'}</span>
+                      <textarea
+                        value={item.caption ?? ''}
+                        placeholder="Add a caption or credit"
+                        onChange={event => {
+                          const gallery = block.content as GalleryBlockContent
+                          const nextItems = [...gallery.items]
+                          nextItems[index] = { ...nextItems[index], caption: event.target.value }
+                          onUpdate({ content: { ...gallery, items: nextItems } })
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="button button--ghost button--danger"
+                        onClick={() => {
+                          const gallery = block.content as GalleryBlockContent
+                          const nextItems = gallery.items.filter((_, itemIndex) => itemIndex !== index)
+                          onUpdate({ content: { ...gallery, items: nextItems } })
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                )
               })
-            }}
-          >
-            <option value="">Select an image...</option>
-            {assets.filter(a => a.mimeType.startsWith('image/')).map(asset => (
-              <option key={asset.id} value={asset.id}>{asset.name}</option>
-            ))}
-          </select>
-        </div>
+            )}
+          </div>
+        </>
       )}
 
       {block.type === 'video' && (
         <>
           <div className="setting-group">
-            <label>Select Video</label>
+            <label>Video asset</label>
             <select
-              value={block.content.assetId || ''}
-              onChange={(event) => {
-                const asset = assets.find(a => a.id === event.target.value)
-                onUpdate({
-                  content: {
-                    ...block.content,
-                    assetId: event.target.value || null,
-                    videoUrl: asset?.dataUrl ?? null,
-                    posterUrl: asset?.thumbnailUrl ?? null,
-                    mimeType: asset?.mimeType ?? null,
-                  }
-                })
-              }}
+              value={(block.content as VideoBlockContent).assetId ?? ''}
+              onChange={event =>
+                onUpdate({ content: { ...block.content, assetId: event.target.value || null } })
+              }
             >
-              <option value="">Select a video...</option>
-              {assets.filter(a => a.mimeType.startsWith('video/')).map(asset => (
-                <option key={asset.id} value={asset.id}>{asset.name}</option>
+              <option value="">Select a video…</option>
+              {videoAssets.map(asset => (
+                <option key={asset.id} value={asset.id}>
+                  {asset.name}
+                </option>
               ))}
             </select>
+            {videoAssets.length === 0 && (
+              <p className="project-editor__helper">Upload video assets to showcase motion work.</p>
+            )}
           </div>
 
           <div className="setting-group setting-group--toggles">
             <label className="setting-group__checkbox">
               <input
                 type="checkbox"
-                checked={block.content.controls ?? true}
-                onChange={(event) => onUpdate({ content: { ...block.content, controls: event.target.checked } })}
+                checked={(block.content as VideoBlockContent).controls ?? true}
+                onChange={event => onUpdate({ content: { ...block.content, controls: event.target.checked } })}
               />
               Show controls
             </label>
             <label className="setting-group__checkbox">
               <input
                 type="checkbox"
-                checked={block.content.autoplay ?? false}
-                onChange={(event) => onUpdate({ content: { ...block.content, autoplay: event.target.checked } })}
+                checked={(block.content as VideoBlockContent).autoplay ?? false}
+                onChange={event => onUpdate({ content: { ...block.content, autoplay: event.target.checked } })}
               />
               Autoplay
             </label>
             <label className="setting-group__checkbox">
               <input
                 type="checkbox"
-                checked={block.content.loop ?? false}
-                onChange={(event) => onUpdate({ content: { ...block.content, loop: event.target.checked } })}
+                checked={(block.content as VideoBlockContent).loop ?? false}
+                onChange={event => onUpdate({ content: { ...block.content, loop: event.target.checked } })}
               />
               Loop playback
             </label>
             <label className="setting-group__checkbox">
               <input
                 type="checkbox"
-                checked={block.content.muted ?? false}
-                onChange={(event) => onUpdate({ content: { ...block.content, muted: event.target.checked } })}
+                checked={(block.content as VideoBlockContent).muted ?? false}
+                onChange={event => onUpdate({ content: { ...block.content, muted: event.target.checked } })}
               />
               Mute audio
             </label>
@@ -636,136 +1362,326 @@ function BlockSettings({
           <div className="setting-group">
             <label>Caption</label>
             <textarea
-              value={block.content.caption ?? ''}
-              onChange={(event) => onUpdate({ content: { ...block.content, caption: event.target.value } })}
+              value={(block.content as VideoBlockContent).caption ?? ''}
+              onChange={event => onUpdate({ content: { ...block.content, caption: event.target.value } })}
               placeholder="Describe the video context"
             />
           </div>
         </>
       )}
+
+      {block.type === 'metrics' && (
+        <div className="setting-group">
+          <label>Metrics</label>
+          <div className="project-editor__metrics-list">
+            {(block.content as MetricsBlockContent).metrics.map((metric, index) => (
+              <div key={`${metric.label}-${index}`} className="project-editor__metrics-item">
+                <input
+                  value={metric.label}
+                  placeholder="Label"
+                  onChange={event => {
+                    const metricsBlock = block.content as MetricsBlockContent
+                    const nextMetrics = [...metricsBlock.metrics]
+                    nextMetrics[index] = { ...nextMetrics[index], label: event.target.value }
+                    onUpdate({ content: { ...metricsBlock, metrics: nextMetrics } })
+                  }}
+                />
+                <input
+                  value={metric.value}
+                  placeholder="Value"
+                  onChange={event => {
+                    const metricsBlock = block.content as MetricsBlockContent
+                    const nextMetrics = [...metricsBlock.metrics]
+                    nextMetrics[index] = { ...nextMetrics[index], value: event.target.value }
+                    onUpdate({ content: { ...metricsBlock, metrics: nextMetrics } })
+                  }}
+                />
+                <button
+                  type="button"
+                  className="button button--ghost button--danger"
+                  onClick={() => {
+                    const metricsBlock = block.content as MetricsBlockContent
+                    const nextMetrics = metricsBlock.metrics.filter((_, itemIndex) => itemIndex !== index)
+                    onUpdate({ content: { ...metricsBlock, metrics: nextMetrics } })
+                  }}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              className="button button--ghost button--small"
+              onClick={() => {
+                const metricsBlock = block.content as MetricsBlockContent
+                onUpdate({
+                  content: {
+                    ...metricsBlock,
+                    metrics: [...metricsBlock.metrics, { label: 'Metric label', value: 'Value' }],
+                  },
+                })
+              }}
+            >
+              <Plus size={16} />
+              Add metric
+            </button>
+          </div>
+        </div>
+      )}
+
+      {block.type === 'link' && (
+        <div className="setting-group">
+          <label>Links</label>
+          <div className="project-editor__links-list">
+            {(block.content as LinkBlockContent).links.map((link, index) => (
+              <div key={`${link.url}-${index}`} className="project-editor__links-item">
+                <select
+                  value={link.type}
+                  onChange={event => {
+                    const linkBlock = block.content as LinkBlockContent
+                    const nextLinks = [...linkBlock.links]
+                    nextLinks[index] = { ...nextLinks[index], type: event.target.value as ProjectLink['type'] }
+                    onUpdate({ content: { ...linkBlock, links: nextLinks } })
+                  }}
+                >
+                  {LINK_TYPE_OPTIONS.map(option => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  value={link.label ?? ''}
+                  placeholder="Label"
+                  onChange={event => {
+                    const linkBlock = block.content as LinkBlockContent
+                    const nextLinks = [...linkBlock.links]
+                    nextLinks[index] = { ...nextLinks[index], label: event.target.value }
+                    onUpdate({ content: { ...linkBlock, links: nextLinks } })
+                  }}
+                />
+                <input
+                  value={link.url}
+                  placeholder="https://example.com"
+                  onChange={event => {
+                    const linkBlock = block.content as LinkBlockContent
+                    const nextLinks = [...linkBlock.links]
+                    nextLinks[index] = { ...nextLinks[index], url: event.target.value }
+                    onUpdate({ content: { ...linkBlock, links: nextLinks } })
+                  }}
+                />
+                <button
+                  type="button"
+                  className="button button--ghost button--danger"
+                  onClick={() => {
+                    const linkBlock = block.content as LinkBlockContent
+                    const nextLinks = linkBlock.links.filter((_, itemIndex) => itemIndex !== index)
+                    onUpdate({ content: { ...linkBlock, links: nextLinks } })
+                  }}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              className="button button--ghost button--small"
+              onClick={() => {
+                const linkBlock = block.content as LinkBlockContent
+                onUpdate({
+                  content: {
+                    ...linkBlock,
+                    links: [...linkBlock.links, { type: 'website', url: '', label: '' }],
+                  },
+                })
+              }}
+            >
+              <Plus size={16} />
+              Add link
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
 
-function getDefaultContent(type: LayoutBlock['type']) {
-  switch (type) {
-    case 'hero':
-      return { title: 'Project Title', subtitle: 'Project subtitle', imageUrl: null, imageAlt: '' }
-    case 'text':
-      return { title: 'Section Title', text: 'Add your content here...', style: 'section' }
-    case 'image':
-      return { imageUrl: null, alt: '', caption: '' }
-    case 'gallery':
-      return { title: 'Gallery', images: [] }
-    case 'video':
-      return {
-        assetId: null,
-        videoUrl: null,
-        posterUrl: null,
-        caption: '',
-        controls: true,
-        autoplay: false,
-        loop: false,
-        muted: false,
-        mimeType: null,
-      }
-    case 'metrics':
-      return { title: 'Metrics', metrics: [] }
-    case 'link':
-      return { title: 'Links', links: [] }
-    default:
-      return {}
-  }
-}
-
-function generateHTML(blocks: LayoutBlock[], project: ProjectMeta): string {
+function generateHTML(blocks: ProjectLayoutBlock[], project: ProjectMeta, assets: ProjectAsset[]): string {
   const sortedBlocks = [...blocks].sort((a, b) => a.order - b.order)
-  
-  const blockHTML = sortedBlocks.map(block => {
-    const blockClass = `block block--${block.type} block--${block.settings.width} block--align-${block.settings.alignment} block--padding-${block.settings.padding}`
-    const style = block.settings.backgroundColor !== 'transparent' ? `background-color: ${block.settings.backgroundColor};` : ''
-    
-    let content = ''
-    switch (block.type) {
-      case 'hero':
-        content = `
-          <div class="block-hero">
-            ${block.content.imageUrl ? `<img src="${block.content.imageUrl}" alt="${block.content.imageAlt}" class="block-hero__image">` : ''}
-            <div class="block-hero__content">
-              <h1>${block.content.title}</h1>
-              ${block.content.subtitle ? `<p class="block-hero__subtitle">${block.content.subtitle}</p>` : ''}
-            </div>
-          </div>
-        `
-        break
-      case 'text':
-        content = `
-          <div class="block-text">
-            ${block.content.title ? `<h2>${block.content.title}</h2>` : ''}
-            <div class="block-text__content">
-              ${block.content.text.split('\n').map((p: string) => `<p>${p}</p>`).join('')}
-            </div>
-          </div>
-        `
-        break
-      case 'video': {
-        const attributes = [
-          block.content.controls === false ? '' : 'controls',
-          block.content.autoplay ? 'autoplay' : '',
-          block.content.loop ? 'loop' : '',
-          block.content.muted ? 'muted' : '',
-          block.content.posterUrl ? `poster="${block.content.posterUrl}"` : '',
-          'playsinline'
-        ].filter(Boolean).join(' ')
-        const sourceType = block.content.mimeType ? ` type="${block.content.mimeType}"` : ''
-        content = `
-          <div class="block-video">
-            ${block.content.videoUrl ? `
-              <video ${attributes}>
-                <source src="${block.content.videoUrl}"${sourceType} />
-                Your browser does not support the video tag.
-              </video>
-            ` : `
-              <div class="block-video__placeholder">Video placeholder</div>
-            `}
-            ${block.content.caption ? `<p class="block-video__caption">${block.content.caption}</p>` : ''}
-          </div>
-        `
-        break
-      }
-      // Add other block types...
-    }
-    
-    return `<div class="${blockClass}" style="${style}">${content}</div>`
-  }).join('\n')
 
-  return `
-<!DOCTYPE html>
+  const blockHTML = sortedBlocks
+    .map(block => {
+      const settings = ensureSettings(block.settings)
+      const classes = `block block--${block.type} block--${settings.width} block--align-${settings.alignment} block--padding-${settings.padding}`
+      const style = settings.backgroundColor && settings.backgroundColor !== 'transparent'
+        ? ` style="background-color: ${settings.backgroundColor};"`
+        : ''
+
+      const render = () => {
+        switch (block.type) {
+          case 'hero': {
+            const content = block.content as HeroBlockContent
+            const asset = getAssetById(assets, content.assetId)
+            return `
+              <div class="block-hero">
+                ${asset ? `<img src="${asset.dataUrl}" alt="${asset.description ?? asset.name ?? project.title}" class="block-hero__image" />` : ''}
+                <div class="block-hero__content">
+                  <h1>${content.title || project.title}</h1>
+                  ${content.subtitle ? `<p class="block-hero__subtitle">${content.subtitle}</p>` : ''}
+                </div>
+              </div>
+            `
+          }
+          case 'text': {
+            const content = block.content as TextBlockContent
+            const paragraphs = content.text
+              ? content.text.split('\n').map(paragraph => `<p>${paragraph}</p>`).join('')
+              : '<p>Add narrative copy to bring this section to life.</p>'
+            return `
+              <div class="block-text">
+                ${content.title ? `<h2>${content.title}</h2>` : ''}
+                <div class="block-text__content">${paragraphs}</div>
+              </div>
+            `
+          }
+          case 'image': {
+            const content = block.content as ImageBlockContent
+            const asset = getAssetById(assets, content.assetId)
+            return `
+              <div class="block-image">
+                ${asset ? `<img src="${asset.dataUrl}" alt="${content.alt ?? asset.description ?? asset.name}" />` : ''}
+                ${content.caption ? `<p class="block-image__caption">${content.caption}</p>` : ''}
+              </div>
+            `
+          }
+          case 'gallery': {
+            const content = block.content as GalleryBlockContent
+            const items = content.items
+              .map(item => {
+                const asset = getAssetById(assets, item.assetId)
+                if (!asset) {
+                  return ''
+                }
+                return `
+                  <div class="block-gallery__item">
+                    <img src="${asset.dataUrl}" alt="${asset.description ?? asset.name}" />
+                    ${item.caption ? `<p class="block-gallery__caption">${item.caption}</p>` : ''}
+                  </div>
+                `
+              })
+              .join('')
+            return `
+              <div class="block-gallery">
+                ${content.title ? `<h2>${content.title}</h2>` : ''}
+                <div class="block-gallery__grid">${items}</div>
+              </div>
+            `
+          }
+          case 'video': {
+            const content = block.content as VideoBlockContent
+            const asset = getAssetById(assets, content.assetId)
+            const attributes = [
+              (content.controls ?? true) ? 'controls' : '',
+              content.autoplay ? 'autoplay' : '',
+              content.loop ? 'loop' : '',
+              content.muted ? 'muted' : '',
+              'playsinline',
+              asset?.thumbnailUrl ? `poster="${asset.thumbnailUrl}"` : '',
+            ]
+              .filter(Boolean)
+              .join(' ')
+            return `
+              <div class="block-video">
+                ${asset ? `
+                  <video ${attributes}>
+                    <source src="${asset.dataUrl}" type="${asset.mimeType}" />
+                    Your browser does not support the video tag.
+                  </video>
+                ` : ''}
+                ${content.caption ? `<p class="block-video__caption">${content.caption}</p>` : ''}
+              </div>
+            `
+          }
+          case 'metrics': {
+            const content = block.content as MetricsBlockContent
+            const metrics = content.metrics
+              .map(metric => `
+                <div class="block-metrics__item">
+                  <div class="block-metrics__value">${metric.value}</div>
+                  <div class="block-metrics__label">${metric.label}</div>
+                </div>
+              `)
+              .join('')
+            return `
+              <div class="block-metrics">
+                ${content.title ? `<h2>${content.title}</h2>` : ''}
+                <div class="block-metrics__grid">${metrics}</div>
+              </div>
+            `
+          }
+          case 'link': {
+            const content = block.content as LinkBlockContent
+            const links = content.links
+              .map(link => `
+                <a class="block-links__item" href="${link.url}" target="_blank" rel="noopener noreferrer">
+                  ${link.label || link.url}
+                </a>
+              `)
+              .join('')
+            return `
+              <div class="block-links">
+                ${content.title ? `<h2>${content.title}</h2>` : ''}
+                <div class="block-links__list">${links}</div>
+              </div>
+            `
+          }
+          default:
+            return ''
+        }
+      }
+
+      return `<div class="${classes}"${style}>${render()}</div>`
+    })
+    .join('\n')
+
+  return `<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${project.title} - Portfolio</title>
   <style>
-    /* Basic portfolio styles */
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 0; line-height: 1.6; }
-    .block { margin-bottom: 2rem; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 2rem; line-height: 1.6; background: #f3f4f6; }
+    .block { margin-bottom: 2rem; background: #ffffff; border-radius: 12px; padding: 2rem; box-shadow: 0 15px 35px rgba(15, 23, 42, 0.15); }
     .block--full { width: 100%; }
+    .block--two-thirds { width: 66.666%; }
     .block--half { width: 50%; }
-    .block--align-center { text-align: center; }
-    .block-hero { position: relative; }
-    .block-hero__image { width: 100%; height: 400px; object-fit: cover; }
-    .block-hero__content { padding: 2rem; }
-    .block-text__content p { margin-bottom: 1rem; }
-    .block-video { text-align: center; }
-    .block-video video { width: 100%; max-height: 420px; border-radius: 12px; background: #111827; }
-    .block-video__caption { margin-top: 0.75rem; font-size: 0.9rem; color: #4b5563; font-style: italic; }
-    /* Add more styles as needed */
+    .block--third { width: 33.333%; }
+    .block--align-center { margin-left: auto; margin-right: auto; }
+    .block--align-right { margin-left: auto; margin-right: 0; }
+    .block-hero { position: relative; overflow: hidden; border-radius: 12px; }
+    .block-hero__image { width: 100%; height: 360px; object-fit: cover; }
+    .block-hero__content { position: absolute; bottom: 0; left: 0; right: 0; padding: 2rem; background: linear-gradient(transparent, rgba(0,0,0,0.75)); color: white; }
+    .block-hero__content h1 { margin: 0; font-size: 2.75rem; }
+    .block-hero__subtitle { margin: 0.75rem 0 0; font-size: 1.125rem; }
+    .block-text h2, .block-gallery h2, .block-metrics h2, .block-links h2 { margin: 0 0 1rem; font-size: 1.75rem; }
+    .block-text__content p { margin: 0 0 1rem; color: #374151; }
+    .block-image img { max-width: 100%; border-radius: 10px; }
+    .block-image__caption { margin-top: 0.75rem; font-size: 0.9rem; color: #6b7280; font-style: italic; }
+    .block-video video { width: 100%; border-radius: 12px; background: #111827; }
+    .block-video__caption { margin-top: 0.75rem; font-size: 0.9rem; color: #6b7280; }
+    .block-gallery__grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .block-gallery__item img { width: 100%; height: 220px; object-fit: cover; border-radius: 10px; }
+    .block-gallery__caption { margin-top: 0.5rem; font-size: 0.85rem; color: #6b7280; }
+    .block-metrics__grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    .block-metrics__item { background: #f9fafb; padding: 1.5rem; border-radius: 12px; text-align: center; }
+    .block-metrics__value { font-size: 2rem; font-weight: 700; color: #2563eb; margin-bottom: 0.5rem; }
+    .block-links__list { display: flex; flex-wrap: wrap; gap: 1rem; }
+    .block-links__item { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1rem; border-radius: 999px; background: #eff6ff; color: #1d4ed8; text-decoration: none; font-weight: 600; }
   </style>
 </head>
 <body>
   ${blockHTML}
 </body>
-</html>
-  `.trim()
+</html>`
 }

--- a/src/index.css
+++ b/src/index.css
@@ -429,6 +429,16 @@ input, textarea, select {
   display: block;
 }
 
+.editor-page__card--editor {
+  grid-column: 1 / -1;
+  padding: 0;
+  overflow: hidden;
+}
+
+.editor-page__card--editor .project-editor {
+  min-height: 520px;
+}
+
 .editor-page__card--files > .file-explorer {
   background: #ffffff;
   border-radius: 16px;
@@ -2095,9 +2105,29 @@ input, textarea, select {
   border-color: var(--blue-500);
 }
 
-.project-editor__actions {
+.project-editor__toolbar-actions {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
   gap: 0.75rem;
+}
+
+.project-editor__status {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.project-editor__status--success {
+  color: #047857;
+}
+
+.project-editor__status--error {
+  color: var(--red-600);
+}
+
+.project-editor__status--info {
+  color: var(--blue-600);
 }
 
 .project-editor__layout {
@@ -2240,6 +2270,107 @@ input, textarea, select {
 
 .setting-group .setting-group__checkbox input {
   width: auto;
+}
+
+.project-editor__helper {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--gray-500);
+}
+
+.project-editor__inline-field {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.project-editor__gallery-editor {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.project-editor__gallery-item {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 1rem;
+  padding: 0.75rem;
+  background: #ffffff;
+  border: 1px solid var(--gray-200);
+  border-radius: 10px;
+}
+
+.project-editor__gallery-thumb {
+  width: 72px;
+  height: 72px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--gray-100);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.project-editor__gallery-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.project-editor__gallery-thumb--empty {
+  color: var(--gray-400);
+}
+
+.project-editor__gallery-fields {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.project-editor__gallery-fields textarea {
+  min-height: 60px;
+  resize: vertical;
+}
+
+.project-editor__gallery-name {
+  font-weight: 600;
+  color: var(--gray-700);
+}
+
+.project-editor__metrics-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.project-editor__metrics-item {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)) auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.project-editor__links-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.project-editor__links-item {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(140px, 1fr) minmax(160px, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.project-editor__empty-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--gray-600);
+  background: var(--gray-100);
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
 }
 
 /* Project Blocks */

--- a/src/intake/schema.ts
+++ b/src/intake/schema.ts
@@ -10,11 +10,76 @@ export type ProjectAsset = {
   thumbnailUrl?: string | null
 }
 
+export type ProjectBlockWidth = 'full' | 'two-thirds' | 'half' | 'third'
+export type ProjectBlockAlignment = 'left' | 'center' | 'right'
+export type ProjectBlockPadding = 'none' | 'small' | 'medium' | 'large'
+
+export type ProjectBlockSettings = {
+  width?: ProjectBlockWidth
+  alignment?: ProjectBlockAlignment
+  padding?: ProjectBlockPadding
+  backgroundColor?: string
+}
+
+export type HeroBlockContent = {
+  title?: string
+  subtitle?: string
+  assetId?: string | null
+}
+
+export type TextBlockContent = {
+  title?: string
+  text: string
+  style?: 'section' | 'body' | 'quote'
+}
+
+export type ImageBlockContent = {
+  assetId?: string | null
+  alt?: string
+  caption?: string
+}
+
+export type GalleryBlockContent = {
+  title?: string
+  items: Array<{
+    assetId?: string | null
+    caption?: string
+  }>
+}
+
+export type VideoBlockContent = {
+  assetId?: string | null
+  caption?: string
+  controls?: boolean
+  autoplay?: boolean
+  loop?: boolean
+  muted?: boolean
+}
+
+export type MetricsBlockContent = {
+  title?: string
+  metrics: Array<{ label: string; value: string }>
+}
+
+export type LinkBlockContent = {
+  title?: string
+  links: ProjectLink[]
+}
+
+export type ProjectLayoutBlock =
+  | { id: string; type: 'hero'; order: number; settings: ProjectBlockSettings; content: HeroBlockContent }
+  | { id: string; type: 'text'; order: number; settings: ProjectBlockSettings; content: TextBlockContent }
+  | { id: string; type: 'image'; order: number; settings: ProjectBlockSettings; content: ImageBlockContent }
+  | { id: string; type: 'gallery'; order: number; settings: ProjectBlockSettings; content: GalleryBlockContent }
+  | { id: string; type: 'video'; order: number; settings: ProjectBlockSettings; content: VideoBlockContent }
+  | { id: string; type: 'metrics'; order: number; settings: ProjectBlockSettings; content: MetricsBlockContent }
+  | { id: string; type: 'link'; order: number; settings: ProjectBlockSettings; content: LinkBlockContent }
+
 export type ProjectStatus = 'draft' | 'cast' | 'published'
 
-export type ProjectRole = 
-  | 'designer' 
-  | 'developer' 
+export type ProjectRole =
+  | 'designer'
+  | 'developer'
   | 'director' 
   | 'project-manager'
   | 'researcher'
@@ -70,13 +135,14 @@ export type ProjectMeta = {
   
   // Metrics & Impact
   metrics?: ProjectMetrics
-  
+
   // System fields
   cover?: string // Hero image asset ID
   createdAt: string
   updatedAt?: string
   assets: ProjectAsset[]
-  
+  layout?: ProjectLayoutBlock[]
+
   // AI Integration
   autoGenerateNarrative?: boolean
   aiGeneratedSummary?: string
@@ -122,5 +188,6 @@ export const newProject = (title: string): ProjectMeta => ({
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   assets: [],
+  layout: [],
   autoGenerateNarrative: false
 })

--- a/src/utils/fileStore.ts
+++ b/src/utils/fileStore.ts
@@ -1,4 +1,10 @@
-import type { ProjectAsset, ProjectMeta, ProjectRole, ProjectStatus } from '../intake/schema'
+import type {
+  ProjectAsset,
+  ProjectLayoutBlock,
+  ProjectMeta,
+  ProjectRole,
+  ProjectStatus,
+} from '../intake/schema'
 
 const KEY = 'pf-projects-v1'
 
@@ -12,6 +18,25 @@ const isAssetArray = (value: unknown): value is ProjectAsset[] =>
     'id' in asset &&
     typeof (asset as ProjectAsset).id === 'string',
   )
+
+const isLayoutBlock = (value: unknown): value is ProjectLayoutBlock =>
+  Boolean(
+    value &&
+      typeof value === 'object' &&
+      'id' in value &&
+      typeof (value as { id?: unknown }).id === 'string' &&
+      'type' in value &&
+      typeof (value as { type?: unknown }).type === 'string',
+  )
+
+const normaliseLayout = (value: unknown): ProjectLayoutBlock[] | undefined => {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  const blocks = value.filter(isLayoutBlock) as ProjectLayoutBlock[]
+  return blocks.length > 0 ? blocks : []
+}
 
 const normaliseStringArray = (value: unknown): string[] => {
   if (Array.isArray(value)) {
@@ -72,6 +97,7 @@ const readStore = (): Store => {
       createdAt,
       updatedAt,
       assets,
+      layout: normaliseLayout(meta.layout),
       autoGenerateNarrative: typeof meta.autoGenerateNarrative === 'boolean' ? meta.autoGenerateNarrative : false,
       aiGeneratedSummary: typeof meta.aiGeneratedSummary === 'string' ? meta.aiGeneratedSummary : undefined,
     }
@@ -141,6 +167,7 @@ export function saveProject(meta: ProjectMeta) {
       ? meta.technologies.filter(Boolean)
       : undefined,
     assets: Array.isArray(meta.assets) ? meta.assets : [],
+    layout: Array.isArray(meta.layout) ? meta.layout : undefined,
   }
   writeStore(store)
 }


### PR DESCRIPTION
## Summary
- extend the project schema and storage layer with reusable layout block types so projects can persist visual editor structure
- replace the placeholder visual editor with a full block-based builder tied into the asset workspace, including hero, gallery, video and link support plus HTML export
- consolidate EditorPage update flows to keep layout metadata in sync with asset actions and add polished styling for the new editor card and controls

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccd7cc804c832fa6c3fdfcce158206