### PR TITLE
Add OpenAI credentials settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Link, Route, Routes, Navigate } from 'react-router-dom'
 import IntakePage from './pages/IntakePage'
 import EditorPage from './pages/EditorPage'
 import PortfolioForgeAIAnalysis from './pages/PortfolioForgeAIAnalysis'
+import OpenAISettingsPage from './pages/OpenAISettingsPage'
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
             <Link to="/intake" className="app-nav__link">New project</Link>
             <Link to={{ pathname: '/intake', hash: '#saved-projects' }} className="app-nav__link">Saved projects</Link>
             <Link to="/analysis" className="app-nav__link">AI analysis</Link>
+            <Link to="/settings/openai" className="app-nav__link">API keys</Link>
           </nav>
         </div>
       </header>
@@ -28,6 +30,7 @@ function App() {
           <Route path="/intake" element={<IntakePage />} />
           <Route path="/editor/:slug" element={<EditorPage />} />
           <Route path="/analysis" element={<PortfolioForgeAIAnalysis />} />
+          <Route path="/settings/openai" element={<OpenAISettingsPage />} />
         </Routes>
       </main>
     </div>

--- a/src/pages/OpenAISettingsPage.css
+++ b/src/pages/OpenAISettingsPage.css
@@ -1,0 +1,156 @@
+.openai-settings {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.openai-settings__card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.openai-settings__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.openai-settings__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.openai-settings__description {
+  color: #4b5563;
+  max-width: 48rem;
+}
+
+.openai-settings__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.openai-settings__meta-item {
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.openai-settings__meta-item--muted {
+  background: rgba(156, 163, 175, 0.14);
+  color: #4b5563;
+}
+
+.openai-settings__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.openai-settings__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.openai-settings__field label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.openai-settings__field input {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #f9fafb;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.openai-settings__field input:focus {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  outline: none;
+  background: #ffffff;
+}
+
+.openai-settings__visibility-toggle label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #374151;
+}
+
+.openai-settings__alert {
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+}
+
+.openai-settings__alert--success {
+  background: rgba(34, 197, 94, 0.1);
+  color: #15803d;
+}
+
+.openai-settings__alert--error {
+  background: rgba(220, 38, 38, 0.12);
+  color: #b91c1c;
+}
+
+.openai-settings__alert--muted {
+  background: rgba(107, 114, 128, 0.12);
+  color: #374151;
+}
+
+.openai-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.openai-settings__card--info h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.openai-settings__card--info ol {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-left: 1.25rem;
+  color: #374151;
+}
+
+.openai-settings__card--info a {
+  color: #2563eb;
+}
+
+.openai-settings__disclaimer {
+  color: #6b7280;
+}
+
+@media (min-width: 960px) {
+  .openai-settings {
+    flex-direction: row;
+  }
+
+  .openai-settings__card {
+    flex: 1;
+  }
+
+  .openai-settings__card--info {
+    max-width: 320px;
+  }
+}

--- a/src/pages/OpenAISettingsPage.tsx
+++ b/src/pages/OpenAISettingsPage.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  clearOpenAICredentials,
+  loadOpenAICredentials,
+  saveOpenAICredentials,
+  type StoredOpenAICredentials,
+} from '../utils/openAICredentials'
+import './OpenAISettingsPage.css'
+
+type FormState = {
+  apiKey: string
+  apiSecret: string
+}
+
+type FormStatus = 'idle' | 'saved' | 'cleared' | 'error'
+
+const initialState: FormState = {
+  apiKey: '',
+  apiSecret: '',
+}
+
+const formatTimestamp = (timestamp: string | null): string | null => {
+  if (!timestamp) {
+    return null
+  }
+
+  try {
+    const date = new Date(timestamp)
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date)
+  } catch (_error) {
+    return null
+  }
+}
+
+const sanitize = (value: string): string => value.trim()
+
+export default function OpenAISettingsPage() {
+  const [formState, setFormState] = useState<FormState>(initialState)
+  const [status, setStatus] = useState<FormStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [lastSaved, setLastSaved] = useState<string | null>(null)
+  const [showSecrets, setShowSecrets] = useState(false)
+  const [hasLocalChanges, setHasLocalChanges] = useState(false)
+
+  useEffect(() => {
+    const saved = loadOpenAICredentials()
+    if (saved) {
+      applyStoredCredentials(saved)
+    }
+  }, [])
+
+  const applyStoredCredentials = (credentials: StoredOpenAICredentials) => {
+    setFormState({
+      apiKey: credentials.apiKey,
+      apiSecret: credentials.apiSecret,
+    })
+    setLastSaved(credentials.savedAt)
+    setHasLocalChanges(false)
+  }
+
+  const handleInputChange = (field: keyof FormState) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value
+      setFormState(prev => ({
+        ...prev,
+        [field]: value,
+      }))
+      setHasLocalChanges(true)
+      setStatus('idle')
+      setErrorMessage(null)
+    }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setStatus('idle')
+
+    const normalized = {
+      apiKey: sanitize(formState.apiKey),
+      apiSecret: sanitize(formState.apiSecret),
+    }
+
+    if (!normalized.apiKey || !normalized.apiSecret) {
+      setErrorMessage('Please provide both the API key and the API secret before saving.')
+      setStatus('error')
+      return
+    }
+
+    try {
+      const stored = saveOpenAICredentials(normalized)
+      applyStoredCredentials(stored)
+      setStatus('saved')
+    } catch (error) {
+      console.error('Failed to persist OpenAI credentials:', error)
+      setErrorMessage('Something went wrong while saving. Try again or refresh the page.')
+      setStatus('error')
+    }
+  }
+
+  const handleClear = () => {
+    clearOpenAICredentials()
+    setFormState(initialState)
+    setLastSaved(null)
+    setStatus('cleared')
+    setErrorMessage(null)
+    setHasLocalChanges(false)
+  }
+
+  const formattedSavedDate = useMemo(() => formatTimestamp(lastSaved), [lastSaved])
+
+  return (
+    <div className="openai-settings">
+      <section className="openai-settings__card">
+        <header className="openai-settings__header">
+          <div>
+            <p className="openai-settings__eyebrow">Local configuration</p>
+            <h1>OpenAI credentials</h1>
+            <p className="openai-settings__description">
+              Store your OpenAI API key and secret locally so this browser can authenticate requests to the
+              Portfolio Forge tools. These values never leave your device and are only saved to your local storage.
+            </p>
+          </div>
+          <div className="openai-settings__meta">
+            {formattedSavedDate ? (
+              <span className="openai-settings__meta-item">Saved on {formattedSavedDate}</span>
+            ) : (
+              <span className="openai-settings__meta-item openai-settings__meta-item--muted">Not saved yet</span>
+            )}
+          </div>
+        </header>
+
+        <form className="openai-settings__form" onSubmit={handleSubmit}>
+          <div className="openai-settings__field">
+            <label htmlFor="openai-api-key">API key</label>
+            <input
+              id="openai-api-key"
+              name="openai-api-key"
+              type={showSecrets ? 'text' : 'password'}
+              value={formState.apiKey}
+              onChange={handleInputChange('apiKey')}
+              placeholder="sk-..."
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="openai-settings__field">
+            <label htmlFor="openai-api-secret">API secret</label>
+            <input
+              id="openai-api-secret"
+              name="openai-api-secret"
+              type={showSecrets ? 'text' : 'password'}
+              value={formState.apiSecret}
+              onChange={handleInputChange('apiSecret')}
+              placeholder="Enter your secret"
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="openai-settings__visibility-toggle">
+            <label>
+              <input
+                type="checkbox"
+                checked={showSecrets}
+                onChange={event => setShowSecrets(event.target.checked)}
+              />
+              Show values while typing
+            </label>
+          </div>
+
+          {errorMessage && (
+            <div className="openai-settings__alert openai-settings__alert--error">{errorMessage}</div>
+          )}
+
+          {status === 'saved' && !errorMessage && (
+            <div className="openai-settings__alert openai-settings__alert--success">
+              Your credentials have been saved to this browser.
+            </div>
+          )}
+
+          {status === 'cleared' && (
+            <div className="openai-settings__alert openai-settings__alert--muted">
+              Stored credentials cleared from this browser.
+            </div>
+          )}
+
+          <div className="openai-settings__actions">
+            <button
+              type="submit"
+              className="button button--primary"
+              disabled={!hasLocalChanges && status !== 'error'}
+            >
+              Save credentials
+            </button>
+            <button
+              type="button"
+              className="button button--ghost"
+              onClick={handleClear}
+              disabled={!formState.apiKey && !formState.apiSecret}
+            >
+              Clear saved values
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="openai-settings__card openai-settings__card--info">
+        <h2>Need help locating your keys?</h2>
+        <ol>
+          <li>Visit the <a href="https://platform.openai.com/settings/organization/api-keys" target="_blank" rel="noreferrer">OpenAI dashboard</a>.</li>
+          <li>Create a new secret key and copy both the key and secret to this page.</li>
+          <li>Keep the tab open until you confirm the credentials are saved locally.</li>
+        </ol>
+        <p className="openai-settings__disclaimer">
+          Tip: because these values only live in your browser storage, you will need to add them again if you switch
+          devices or clear your browsing data.
+        </p>
+      </section>
+    </div>
+  )
+}

--- a/src/utils/openAICredentials.ts
+++ b/src/utils/openAICredentials.ts
@@ -1,0 +1,102 @@
+const STORAGE_KEY = 'openai.credentials'
+
+export type OpenAICredentialsInput = {
+  apiKey: string
+  apiSecret: string
+}
+
+export type StoredOpenAICredentials = OpenAICredentialsInput & {
+  savedAt: string
+}
+
+let memoryStore: StoredOpenAICredentials | null = null
+
+type StorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+
+const resolveLocalStorage = (): StorageLike | null => {
+  try {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage
+    }
+  } catch (_error) {
+    // Accessing window.localStorage can throw in some sandboxed environments.
+  }
+
+  if (typeof globalThis !== 'undefined') {
+    const candidate = (globalThis as unknown as { localStorage?: StorageLike }).localStorage
+    if (candidate && typeof candidate.getItem === 'function') {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+const parseStoredValue = (raw: string | null): StoredOpenAICredentials | null => {
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredOpenAICredentials>
+    if (typeof parsed.apiKey === 'string' && typeof parsed.apiSecret === 'string') {
+      return {
+        apiKey: parsed.apiKey,
+        apiSecret: parsed.apiSecret,
+        savedAt: typeof parsed.savedAt === 'string' ? parsed.savedAt : new Date().toISOString(),
+      }
+    }
+  } catch (_error) {
+    // Ignore malformed entries and treat them as missing credentials.
+  }
+
+  return null
+}
+
+export const loadOpenAICredentials = (): StoredOpenAICredentials | null => {
+  const storage = resolveLocalStorage()
+
+  if (storage) {
+    const raw = storage.getItem(STORAGE_KEY)
+    const parsed = parseStoredValue(raw)
+    if (parsed) {
+      memoryStore = parsed
+      return parsed
+    }
+  }
+
+  return memoryStore
+}
+
+export const saveOpenAICredentials = (
+  credentials: OpenAICredentialsInput,
+): StoredOpenAICredentials => {
+  const normalized: StoredOpenAICredentials = {
+    apiKey: credentials.apiKey,
+    apiSecret: credentials.apiSecret,
+    savedAt: new Date().toISOString(),
+  }
+
+  const storage = resolveLocalStorage()
+
+  if (storage) {
+    storage.setItem(STORAGE_KEY, JSON.stringify(normalized))
+  }
+
+  memoryStore = normalized
+  return normalized
+}
+
+export const clearOpenAICredentials = (): void => {
+  const storage = resolveLocalStorage()
+
+  if (storage) {
+    storage.removeItem(STORAGE_KEY)
+  }
+
+  memoryStore = null
+}
+
+export const hasOpenAICredentials = (): boolean => {
+  return loadOpenAICredentials() !== null
+}


### PR DESCRIPTION
## Summary
- add a dedicated OpenAI credentials page with local-only storage messaging and guidance
- create storage helper for persisting keys in localStorage with safe fallbacks
- expose the new page via navigation and include tailored styling

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ccde36c6dc832fbd4c960a87dd19d1