### PR TITLE
Add startup helper script and documentation

### DIFF
--- a/STARTUP_GUIDE.md
+++ b/STARTUP_GUIDE.md
@@ -1,0 +1,78 @@
+# Startup Guide
+
+This guide walks you through launching the full portfolio workspace with a single
+command. The `scripts/startup.sh` helper script installs dependencies, brings up
+the backing services, and runs both the Express API and Vite front-end so you
+can get to work immediately.
+
+## Prerequisites
+
+Before running the script ensure the following tools are available locally:
+
+- **Node.js 20+** and **npm** for building and serving the apps.
+- **Docker** with the **docker compose** plugin if you want the script to start
+  Postgres and Redis automatically. (Optional when working front-end only.)
+- **Python 3** if you plan to use the optional project scaffolding tools in
+  `scripts/`, though it is not required for the startup script itself.
+
+> **Tip:** If Docker is unavailable the script will continue without starting
+> containers and you can connect to your own Postgres/Redis instances instead.
+
+## Quick start
+
+From the repository root run:
+
+```bash
+./scripts/startup.sh
+```
+
+The script performs the following steps:
+
+1. Installs npm dependencies for both the Vite front-end and Express backend.
+2. Starts the Postgres, Redis, and backend containers defined in
+   `docker-compose.yml` (unless you opt out).
+3. Optionally runs `npx prisma migrate deploy` to apply database migrations.
+4. Launches the backend via `npm run dev` and the front-end via `npm run dev -- --host`.
+
+When the script completes you will have two services running locally:
+
+- **Front-end:** <http://localhost:5173>
+- **Backend API:** <http://localhost:3001>
+
+Stop everything with `Ctrl+C`. Docker services continue running in the
+background so you can restart quickly. Run `docker compose down` when you want
+those containers to stop as well.
+
+## Environment variables
+
+The script exports a default `VITE_API_BASE_URL=http://localhost:3001` so the
+front-end talks to the locally running backend. Override it before launching if
+you need to target a different API endpoint:
+
+```bash
+VITE_API_BASE_URL=https://staging.example.com ./scripts/startup.sh --no-docker
+```
+
+For backend-only configuration (OpenAI keys, database URLs, etc.) create or
+update `server/.env` as described in the main `README.md`. The script does not
+modify your environment files.
+
+## Useful flags
+
+Pass any of the following options to customise the startup process:
+
+| Flag | Purpose |
+| ---- | ------- |
+| `--frontend-only` | Skip Docker, Prisma, and the backend server—only the Vite dev server runs. |
+| `--skip-install` | Skip dependency installation (useful on repeat launches once `node_modules/` is ready). |
+| `--no-docker` | Prevent the script from running `docker compose up -d`. Use this when infrastructure is managed elsewhere. |
+| `--prisma-deploy` | Run `npx prisma migrate deploy` inside `server/` before launching the backend. |
+
+See `./scripts/startup.sh --help` for the latest usage text.
+
+## Manual control
+
+Prefer to manage services yourself? The script is optional. You can still
+follow the manual steps documented in `README.md` to bring up each component.
+The script simply wraps those commands so newcomers can boot the stack with one
+line.

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FRONTEND_ONLY=0
+SKIP_INSTALL=0
+USE_DOCKER=1
+RUN_PRISMA=0
+VITE_API_BASE_URL_DEFAULT="http://localhost:3001"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/startup.sh [options]
+
+Bootstraps the portfolio workspace by installing dependencies, starting
+supporting services, and launching both the backend API and the React front-end.
+
+Options:
+  --frontend-only     Skip backend, Prisma, and Docker setup.
+  --skip-install      Assume dependencies are already installed.
+  --no-docker         Do not attempt to start Docker Compose services.
+  --prisma-deploy     Run `prisma migrate deploy` before starting the backend.
+  -h, --help          Show this help message.
+
+Press Ctrl+C at any time to stop the dev servers. Docker services started by
+this script stay running so you can restart quickly (use `docker compose down`
+when you want to stop them).
+USAGE
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' is required but was not found in PATH." >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --frontend-only)
+      FRONTEND_ONLY=1
+      USE_DOCKER=0
+      ;;
+    --skip-install)
+      SKIP_INSTALL=1
+      ;;
+    --no-docker)
+      USE_DOCKER=0
+      ;;
+    --prisma-deploy)
+      RUN_PRISMA=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_command npm
+
+if [[ "$SKIP_INSTALL" -ne 1 ]]; then
+  echo "Installing front-end dependencies..."
+  (cd "$ROOT_DIR" && npm install)
+
+  if [[ "$FRONTEND_ONLY" -ne 1 ]]; then
+    echo "Installing backend dependencies..."
+    (cd "$ROOT_DIR/server" && npm install)
+  fi
+fi
+
+if [[ "$FRONTEND_ONLY" -ne 1 ]]; then
+  export VITE_API_BASE_URL="${VITE_API_BASE_URL:-$VITE_API_BASE_URL_DEFAULT}"
+
+  if [[ "$USE_DOCKER" -eq 1 ]]; then
+    if command -v docker >/dev/null 2>&1; then
+      if docker compose version >/dev/null 2>&1; then
+        echo "Starting Docker services (Postgres, Redis, backend image)..."
+        (cd "$ROOT_DIR" && docker compose up -d)
+      else
+        echo "Warning: docker compose is not available. Skip Docker startup." >&2
+      fi
+    else
+      echo "Warning: docker command is not available. Skip Docker startup." >&2
+    fi
+  fi
+
+  if [[ "$RUN_PRISMA" -eq 1 ]]; then
+    echo "Running Prisma migrations..."
+    (cd "$ROOT_DIR/server" && npx prisma migrate deploy)
+  fi
+fi
+
+cleanup() {
+  if [[ -n "${BACKEND_PID:-}" ]] && ps -p "$BACKEND_PID" >/dev/null 2>&1; then
+    echo "Stopping backend (PID $BACKEND_PID)..."
+    kill "$BACKEND_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+if [[ "$FRONTEND_ONLY" -ne 1 ]]; then
+  echo "Starting backend on http://localhost:3001 ..."
+  (cd "$ROOT_DIR/server" && npm run dev) &
+  BACKEND_PID=$!
+  sleep 2
+fi
+
+echo "Starting front-end on http://localhost:5173 ..."
+cd "$ROOT_DIR"
+npm run dev -- --host 0.0.0.0
+
+if [[ "$FRONTEND_ONLY" -ne 1 && -n "${BACKEND_PID:-}" ]]; then
+  wait "$BACKEND_PID"
+fi


### PR DESCRIPTION
## Summary
- add a `startup.sh` helper for dependency installation and launching the dev servers
- allow optional docker/prisma setup and cleanup handling to simplify onboarding
- document prerequisites, usage, and flags in a dedicated STARTUP_GUIDE

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ccdda94760832fb470bc30450c60d6