### PR TITLE
Add Awesome Go adoption research view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import IntakePage from './pages/IntakePage'
 import EditorPage from './pages/EditorPage'
 import PortfolioForgeAIAnalysis from './pages/PortfolioForgeAIAnalysis'
 import OpenAISettingsPage from './pages/OpenAISettingsPage'
+import AwesomeGoPage from './pages/AwesomeGoPage'
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
             <Link to="/intake" className="app-nav__link">New project</Link>
             <Link to={{ pathname: '/intake', hash: '#saved-projects' }} className="app-nav__link">Saved projects</Link>
             <Link to="/analysis" className="app-nav__link">AI analysis</Link>
+            <Link to="/awesome-go" className="app-nav__link">Go libraries</Link>
             <Link to="/settings/openai" className="app-nav__link">API keys</Link>
           </nav>
         </div>
@@ -30,6 +32,7 @@ function App() {
           <Route path="/intake" element={<IntakePage />} />
           <Route path="/editor/:slug" element={<EditorPage />} />
           <Route path="/analysis" element={<PortfolioForgeAIAnalysis />} />
+          <Route path="/awesome-go" element={<AwesomeGoPage />} />
           <Route path="/settings/openai" element={<OpenAISettingsPage />} />
         </Routes>
       </main>

--- a/src/data/awesomeGoResources.ts
+++ b/src/data/awesomeGoResources.ts
@@ -1,0 +1,365 @@
+export type AwesomeGoStage = 'mature' | 'growing' | 'emerging'
+
+export type AwesomeGoEntry = {
+  name: string
+  description: string
+  url: string
+  docsUrl?: string
+  category: string
+  stage: AwesomeGoStage
+  stars: number
+  tags: string[]
+  features: string[]
+  adoption?: string
+}
+
+export const awesomeGoEntries: AwesomeGoEntry[] = [
+  {
+    name: 'Gin',
+    description:
+      'High-performance HTTP web framework with a Martini-like API, strong middleware story, and excellent request binding.',
+    url: 'https://github.com/gin-gonic/gin',
+    docsUrl: 'https://gin-gonic.com/docs/',
+    category: 'Web frameworks',
+    stage: 'mature',
+    stars: 72000,
+    tags: ['http', 'router', 'rest', 'middleware'],
+    features: [
+      'Leverages net/http while optimising routing for extreme throughput',
+      'First-class JSON binding and validation helpers',
+      'Vibrant ecosystem of authentication, metrics, and tracing middleware',
+    ],
+    adoption: 'A go-to choice for latency-sensitive APIs and microservices.',
+  },
+  {
+    name: 'Fiber',
+    description:
+      'Express-inspired web framework powered by Fasthttp that prioritises developer ergonomics without sacrificing speed.',
+    url: 'https://github.com/gofiber/fiber',
+    docsUrl: 'https://docs.gofiber.io',
+    category: 'Web frameworks',
+    stage: 'growing',
+    stars: 32000,
+    tags: ['http', 'fasthttp', 'routing', 'middleware'],
+    features: [
+      'Minimal boilerplate to stand up APIs and SSR applications',
+      'Built-in rate limiting, caching, and WebSocket support',
+      'Middleware signature mirrors popular Node.js frameworks to ease migration',
+    ],
+    adoption: 'Adopted by teams modernising Express/Koa services into Go.',
+  },
+  {
+    name: 'Chi',
+    description:
+      'Lightweight, idiomatic router that emphasises composable middlewares and modular HTTP services.',
+    url: 'https://github.com/go-chi/chi',
+    docsUrl: 'https://go-chi.io',
+    category: 'Web frameworks',
+    stage: 'mature',
+    stars: 15000,
+    tags: ['router', 'http', 'middleware'],
+    features: [
+      'Tiny core with fully idiomatic net/http handlers',
+      'Powerful route mounting and grouping for large services',
+      'Ships with middlewares for request logging, timeouts, CSRF, and more',
+    ],
+    adoption: 'Favoured for standard-library purity in enterprise APIs.',
+  },
+  {
+    name: 'Buffalo',
+    description:
+      'Rapid web development toolkit that bundles routing, ORM, front-end build tooling, and generators.',
+    url: 'https://github.com/gobuffalo/buffalo',
+    docsUrl: 'https://gobuffalo.io/en/docs',
+    category: 'Web frameworks',
+    stage: 'growing',
+    stars: 7900,
+    tags: ['full-stack', 'scaffolding', 'generators'],
+    features: [
+      '`buffalo new` scaffolds opinionated services with database + front-end wiring',
+      'Hot reloading via `buffalo dev` accelerates feedback loops',
+      'Pluggable pop ORM and task runner streamline end-to-end delivery',
+    ],
+    adoption: 'Ideal for teams wanting Rails-like productivity in Go.',
+  },
+  {
+    name: 'Cobra',
+    description:
+      'Commander style CLI framework used by Kubernetes, Helm, Hugo, and countless internal toolchains.',
+    url: 'https://github.com/spf13/cobra',
+    docsUrl: 'https://cobra.dev/',
+    category: 'CLI tooling',
+    stage: 'mature',
+    stars: 36000,
+    tags: ['cli', 'commands', 'flags'],
+    features: [
+      'Declarative command trees with automatic help and docs generation',
+      'POSIX-compliant flag parsing with viper integration',
+      'Provides shell completion, man pages, and templated scaffolding',
+    ],
+    adoption: 'The de facto framework for complex enterprise CLIs.',
+  },
+  {
+    name: 'urfave/cli',
+    description:
+      'Simple yet powerful CLI framework focusing on rapid authoring of single-binary tools and utilities.',
+    url: 'https://github.com/urfave/cli',
+    category: 'CLI tooling',
+    stage: 'mature',
+    stars: 21000,
+    tags: ['cli', 'flags', 'productivity'],
+    features: [
+      'Context-aware command execution keeps configuration tidy',
+      'Supports rich flag types, subcommands, and before/after hooks',
+      'Tiny binary footprint makes it perfect for serverless and container tooling',
+    ],
+    adoption: 'Excellent for developer-experience focused automation scripts.',
+  },
+  {
+    name: 'Viper',
+    description:
+      'Configuration system that reads from files, environment variables, flags, and remote key/value stores.',
+    url: 'https://github.com/spf13/viper',
+    category: 'Configuration & settings',
+    stage: 'mature',
+    stars: 25000,
+    tags: ['config', 'environment', 'flags'],
+    features: [
+      'Supports JSON, YAML, TOML, HCL, envfile, and Java properties formats',
+      'Live watching and reloading for zero-downtime config changes',
+      'Seamless binding to Cobra flags for unified CLIs and services',
+    ],
+    adoption: 'Powers configuration layers in countless SaaS platforms.',
+  },
+  {
+    name: 'Koanf',
+    description:
+      'Modular configuration loader that merges multiple providers with minimal dependencies.',
+    url: 'https://github.com/knadh/koanf',
+    category: 'Configuration & settings',
+    stage: 'growing',
+    stars: 2100,
+    tags: ['config', 'modular', 'providers'],
+    features: [
+      'Providers for files, environment variables, SSM, Consul, Vault, and more',
+      'Lightweight with zero reflection; works cleanly in serverless contexts',
+      'Schema validation and default handling keep configs robust',
+    ],
+    adoption: 'Popular with platform teams that need pluggable sources.',
+  },
+  {
+    name: 'GORM',
+    description:
+      'Full-featured ORM with associations, hooks, transactions, and schema migrations.',
+    url: 'https://github.com/go-gorm/gorm',
+    docsUrl: 'https://gorm.io',
+    category: 'Database & ORM',
+    stage: 'mature',
+    stars: 34000,
+    tags: ['orm', 'database', 'sql'],
+    features: [
+      'Chainable query builder with eager loading and polymorphic associations',
+      'Auto migration keeps schemas in sync across environments',
+      'Plugin ecosystem for soft delete, audit trails, Prometheus metrics, and more',
+    ],
+    adoption: 'Trusted in production across fintech, SaaS, and gaming products.',
+  },
+  {
+    name: 'Ent',
+    description:
+      'Entity framework from Meta that generates type-safe Go code from a declarative schema.',
+    url: 'https://github.com/ent/ent',
+    docsUrl: 'https://entgo.io',
+    category: 'Database & ORM',
+    stage: 'growing',
+    stars: 14000,
+    tags: ['orm', 'codegen', 'graph'],
+    features: [
+      'Schema-as-code approach unlocks rich editor tooling and refactoring safety',
+      'Edge definition models complex graph relationships with ease',
+      'Integrations for GraphQL, gRPC, SQL/NoSQL, and privacy policies',
+    ],
+    adoption: 'Great for domain-driven services needing strict data contracts.',
+  },
+  {
+    name: 'sqlc',
+    description:
+      'Generates type-safe Go code from raw SQL queries while preserving performance and control.',
+    url: 'https://github.com/sqlc-dev/sqlc',
+    docsUrl: 'https://docs.sqlc.dev',
+    category: 'SQL tooling',
+    stage: 'growing',
+    stars: 14000,
+    tags: ['sql', 'codegen', 'database'],
+    features: [
+      'Author SQL once and get strongly typed Go methods for queries and commands',
+      'Supports PostgreSQL, MySQL, SQLite, SQL Server, and planetscale flavours',
+      'Integrates with migrations via Atlas, Flyway, or Goose for end-to-end workflows',
+    ],
+    adoption: 'Ideal when teams want SQL-first ergonomics with compile-time safety.',
+  },
+  {
+    name: 'Atlas',
+    description:
+      'Modern database schema tooling with declarative migrations, linting, and drift detection.',
+    url: 'https://github.com/ariga/atlas',
+    docsUrl: 'https://atlasgo.io',
+    category: 'SQL tooling',
+    stage: 'growing',
+    stars: 7000,
+    tags: ['migrations', 'schema', 'database'],
+    features: [
+      'Visual diffing and linting prevent risky schema changes before rollout',
+      'Database driver support spans Postgres, MySQL, MariaDB, SQLite, and SQL Server',
+      'Works hand-in-hand with sqlc and Prisma-style workflows',
+    ],
+    adoption: 'Adopted by data-heavy teams enforcing rigorous migration gates.',
+  },
+  {
+    name: 'Testify',
+    description:
+      'Battle-tested testing toolkit providing assertions, suites, and mocking utilities.',
+    url: 'https://github.com/stretchr/testify',
+    category: 'Testing & QA',
+    stage: 'mature',
+    stars: 21000,
+    tags: ['testing', 'assertions', 'mocking'],
+    features: [
+      'Rich assertion library covering errors, JSON, time, and HTTP',
+      'Suite runner keeps setup/teardown logic organised',
+      'Mock package simplifies behavioural testing with expectations',
+    ],
+    adoption: 'Default choice for unit tests in the majority of Go repos.',
+  },
+  {
+    name: 'Ginkgo',
+    description:
+      'BDD-style testing framework powering Kubernetes, CloudFoundry, and distributed systems suites.',
+    url: 'https://github.com/onsi/ginkgo',
+    docsUrl: 'https://onsi.github.io/ginkgo/',
+    category: 'Testing & QA',
+    stage: 'mature',
+    stars: 7500,
+    tags: ['testing', 'bdd', 'parallel'],
+    features: [
+      'Expressive DSL for acceptance and integration test scenarios',
+      'Built-in parallelism for speeding up large suites in CI',
+      'Tight integration with Gomega matchers for readable expectations',
+    ],
+    adoption: 'Great for large teams writing narrative-style acceptance tests.',
+  },
+  {
+    name: 'GoMock',
+    description:
+      'Official Go mocking framework from Google using interface generation for strict type checking.',
+    url: 'https://github.com/golang/mock',
+    category: 'Testing & QA',
+    stage: 'mature',
+    stars: 9700,
+    tags: ['testing', 'mocking', 'codegen'],
+    features: [
+      'Generates mocks directly from Go interfaces for zero runtime reflection',
+      'Expectation API keeps behaviour-driven tests concise',
+      'Seamless integration with go test and testify assertions',
+    ],
+    adoption: 'Used heavily in cloud infrastructure and SDK teams.',
+  },
+  {
+    name: 'Zap',
+    description:
+      'Blazing fast, structured logging from Uber with zero-allocation logging paths.',
+    url: 'https://github.com/uber-go/zap',
+    docsUrl: 'https://pkg.go.dev/go.uber.org/zap',
+    category: 'Observability & logging',
+    stage: 'mature',
+    stars: 20000,
+    tags: ['logging', 'structured', 'performance'],
+    features: [
+      'Sugared and structured loggers suit prototypes and production equally',
+      'Sampling, level enablers, and context propagation baked in',
+      'Integrations for OpenTelemetry, gRPC interceptors, and HTTP middleware',
+    ],
+    adoption: 'High-throughput services rely on zap for dependable logging.',
+  },
+  {
+    name: 'Zerolog',
+    description:
+      'Zero-allocation JSON logger designed for low-latency services and embedded systems.',
+    url: 'https://github.com/rs/zerolog',
+    category: 'Observability & logging',
+    stage: 'mature',
+    stars: 9000,
+    tags: ['logging', 'structured', 'json'],
+    features: [
+      'JSON output with deterministic field ordering and minimal size',
+      'Context enrichment APIs for request-scoped metadata',
+      'Extensible writers allow piping logs to Kafka, Loki, or stdout',
+    ],
+    adoption: 'Popular for edge workloads and telemetry pipelines.',
+  },
+  {
+    name: 'Prometheus Client',
+    description:
+      'Official Prometheus instrumentation library exposing metrics, histograms, and exemplars.',
+    url: 'https://github.com/prometheus/client_golang',
+    category: 'Observability & logging',
+    stage: 'mature',
+    stars: 5200,
+    tags: ['metrics', 'observability', 'monitoring'],
+    features: [
+      'Native counters, gauges, histograms, and summaries for instrumentation',
+      'Automated collection of Go runtime metrics',
+      'Integrates smoothly with Grafana, Alertmanager, and OpenTelemetry bridges',
+    ],
+    adoption: 'Standard metrics backbone for cloud-native Go services.',
+  },
+  {
+    name: 'Go kit',
+    description:
+      'Toolkit for microservices that emphasises clean architecture, transports, and instrumentation.',
+    url: 'https://github.com/go-kit/kit',
+    category: 'Microservices & RPC',
+    stage: 'mature',
+    stars: 25000,
+    tags: ['microservices', 'transport', 'toolkit'],
+    features: [
+      'Opinionated service abstraction with pluggable transports (HTTP, gRPC, NATS)',
+      'Instrumentation adapters for Prometheus, OpenTracing, Zipkin, and StatsD',
+      'Middleware stack for logging, rate limiting, circuit breaking, and more',
+    ],
+    adoption: 'Designed for large-scale distributed systems with strict SLAs.',
+  },
+  {
+    name: 'gRPC-Go',
+    description:
+      'Official Go implementation of gRPC supporting HTTP/2, streaming, and contract-first APIs.',
+    url: 'https://github.com/grpc/grpc-go',
+    category: 'Microservices & RPC',
+    stage: 'mature',
+    stars: 20000,
+    tags: ['grpc', 'rpc', 'microservices'],
+    features: [
+      'Bidirectional streaming with flow control and deadlines',
+      'Protocol buffer code generation for clients and servers',
+      'Advanced load balancing, health checking, and interceptors',
+    ],
+    adoption: 'Backbone for service-to-service communication at Google-scale.',
+  },
+  {
+    name: 'Connect',
+    description:
+      'Protocol-agnostic toolkit from Buf enabling gRPC, gRPC-Web, and JSON over HTTP with one implementation.',
+    url: 'https://github.com/connectrpc/connect-go',
+    category: 'Microservices & RPC',
+    stage: 'growing',
+    stars: 4100,
+    tags: ['rpc', 'grpc', 'http'],
+    features: [
+      'Generates idiomatic clients and servers for gRPC and Connect protocols',
+      'Built-in interceptors for observability, retries, and authentication',
+      'Plays nicely with Envoy, API gateways, and browser-based RPC consumers',
+    ],
+    adoption: 'Great for teams standardising APIs across microservices and web clients.',
+  },
+]
+

--- a/src/pages/AwesomeGoPage.css
+++ b/src/pages/AwesomeGoPage.css
@@ -1,0 +1,382 @@
+.awesome-go-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.awesome-go-panel {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 2.25rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+}
+
+.awesome-go-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.awesome-go-intro__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #2563eb;
+  margin-bottom: 0.35rem;
+}
+
+.awesome-go-intro__lead {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #4b5563;
+  max-width: 760px;
+}
+
+.awesome-go-intro__lead a {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.awesome-go-insights {
+  margin-top: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.awesome-go-insight {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(59, 130, 246, 0.04));
+  border: 1px solid rgba(37, 99, 235, 0.15);
+}
+
+.awesome-go-insight span {
+  display: block;
+  color: #1f2937;
+  font-size: 0.8rem;
+}
+
+.awesome-go-insight strong {
+  display: block;
+  font-size: 1.35rem;
+  color: #111827;
+  line-height: 1.2;
+}
+
+.awesome-go-filters__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.awesome-go-filters__header h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.awesome-go-reset {
+  border: none;
+  background: none;
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.awesome-go-reset:hover {
+  text-decoration: underline;
+}
+
+.awesome-go-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.awesome-go-search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 14px;
+  background: #f9fafb;
+}
+
+.awesome-go-search input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  outline: none;
+}
+
+.awesome-go-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.awesome-go-filter-group__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.awesome-go-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.awesome-go-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  font-size: 0.85rem;
+  color: #1f2937;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.awesome-go-chip:hover {
+  border-color: #2563eb;
+}
+
+.awesome-go-chip.is-active {
+  border-color: rgba(37, 99, 235, 0.6);
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+}
+
+.awesome-go-chip__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.8rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 0.75rem;
+}
+
+.awesome-go-stage-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.awesome-go-stage-option {
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px dashed #cbd5f5;
+  background: rgba(99, 102, 241, 0.08);
+  color: #312e81;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.awesome-go-stage-option.is-active {
+  background: rgba(99, 102, 241, 0.18);
+  border-style: solid;
+  border-color: rgba(79, 70, 229, 0.6);
+  color: #3730a3;
+}
+
+.awesome-go-results__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.awesome-go-results__header h2 {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.awesome-go-results__meta {
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.awesome-go-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
+  gap: 1.5rem;
+}
+
+.awesome-go-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  border-radius: 16px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.9));
+  box-shadow: 0 14px 24px rgba(15, 23, 42, 0.06);
+}
+
+.awesome-go-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.awesome-go-card__category {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2563eb;
+  margin-bottom: 0.25rem;
+}
+
+.awesome-go-card h3 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.awesome-go-card__stage {
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.awesome-go-card__stage--mature {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+
+.awesome-go-card__stage--growing {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.awesome-go-card__stage--emerging {
+  background: rgba(244, 114, 182, 0.15);
+  color: #be185d;
+}
+
+.awesome-go-card__description {
+  color: #1f2937;
+  line-height: 1.55;
+}
+
+.awesome-go-card__features {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: #374151;
+}
+
+.awesome-go-card__features li {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.awesome-go-card__features svg {
+  color: #10b981;
+}
+
+.awesome-go-card__adoption {
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  color: #065f46;
+  font-size: 0.9rem;
+}
+
+.awesome-go-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.awesome-go-card__tags span {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 118, 110, 0.1);
+  color: #0f766e;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.awesome-go-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.awesome-go-card__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.awesome-go-card__links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.awesome-go-card__links a:hover {
+  text-decoration: underline;
+}
+
+.awesome-go-card__stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #f59e0b;
+  font-weight: 600;
+}
+
+.awesome-go-empty {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(217, 119, 6, 0.2);
+  color: #92400e;
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .awesome-go-panel {
+    padding: 1.75rem;
+  }
+
+  .awesome-go-results__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}
+

--- a/src/pages/AwesomeGoPage.tsx
+++ b/src/pages/AwesomeGoPage.tsx
@@ -1,0 +1,309 @@
+import React, { useMemo, useState } from 'react'
+import {
+  BookOpen,
+  CheckCircle2,
+  ExternalLink,
+  Filter,
+  Github,
+  Layers,
+  Search,
+  Sparkles,
+  Star,
+} from 'lucide-react'
+
+import './AwesomeGoPage.css'
+import { awesomeGoEntries, type AwesomeGoEntry, type AwesomeGoStage } from '../data/awesomeGoResources'
+
+type StageFilterValue = 'all' | AwesomeGoStage
+
+const stageLabels: Record<AwesomeGoStage, string> = {
+  mature: 'Mature & battle-tested',
+  growing: 'Growing adoption',
+  emerging: 'Emerging & experimental',
+}
+
+const stageFilterOptions: Array<{ value: StageFilterValue; label: string }> = [
+  { value: 'all', label: 'All maturity levels' },
+  { value: 'mature', label: stageLabels.mature },
+  { value: 'growing', label: stageLabels.growing },
+  { value: 'emerging', label: stageLabels.emerging },
+]
+
+const normalise = (value: string): string => value.trim().toLowerCase()
+
+const formatStars = (value: number): string => value.toLocaleString('en-US')
+
+const StageBadge = ({ stage }: { stage: AwesomeGoStage }) => (
+  <span className={`awesome-go-card__stage awesome-go-card__stage--${stage}`}>
+    {stageLabels[stage]}
+  </span>
+)
+
+const buildSearchHaystack = (entry: AwesomeGoEntry): string =>
+  [entry.name, entry.description, entry.category, entry.tags.join(' '), entry.features.join(' '), entry.adoption ?? '']
+    .join(' ')
+    .toLowerCase()
+
+export default function AwesomeGoPage() {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set())
+  const [stageFilter, setStageFilter] = useState<StageFilterValue>('all')
+
+  const categories = useMemo(() => {
+    const unique = new Set<string>()
+    for (const entry of awesomeGoEntries) {
+      unique.add(entry.category)
+    }
+    return Array.from(unique).sort((a, b) => a.localeCompare(b))
+  }, [])
+
+  const categorySummaries = useMemo(
+    () =>
+      categories.map(category => ({
+        category,
+        count: awesomeGoEntries.filter(entry => entry.category === category).length,
+      })),
+    [categories],
+  )
+
+  const stageCounts = useMemo(() => {
+    const counts: Record<AwesomeGoStage, number> = {
+      mature: 0,
+      growing: 0,
+      emerging: 0,
+    }
+
+    for (const entry of awesomeGoEntries) {
+      counts[entry.stage] += 1
+    }
+
+    return counts
+  }, [])
+
+  const filteredEntries = useMemo(() => {
+    const query = normalise(searchQuery)
+    const activeCategories = selectedCategories
+
+    return awesomeGoEntries.filter(entry => {
+      if (stageFilter !== 'all' && entry.stage !== stageFilter) {
+        return false
+      }
+
+      if (activeCategories.size > 0 && !activeCategories.has(entry.category)) {
+        return false
+      }
+
+      if (!query) {
+        return true
+      }
+
+      return buildSearchHaystack(entry).includes(query)
+    })
+  }, [searchQuery, selectedCategories, stageFilter])
+
+  const toggleCategory = (category: string) => {
+    setSelectedCategories(current => {
+      const next = new Set(current)
+      if (next.has(category)) {
+        next.delete(category)
+      } else {
+        next.add(category)
+      }
+      return next
+    })
+  }
+
+  const resetFilters = () => {
+    setSelectedCategories(new Set())
+    setStageFilter('all')
+    setSearchQuery('')
+  }
+
+  return (
+    <div className="awesome-go-page">
+      <section className="awesome-go-panel">
+        <header className="awesome-go-intro">
+          <div>
+            <p className="awesome-go-intro__eyebrow">Research</p>
+            <h1>Awesome Go adoption guide</h1>
+          </div>
+          <p className="awesome-go-intro__lead">
+            Curated highlights from the <a href="https://github.com/avelino/awesome-go">Awesome Go</a> community list
+            to help plan production-ready stacks. Explore frameworks, tooling, and observability picks with maturity
+            signals.
+          </p>
+        </header>
+
+        <div className="awesome-go-insights">
+          <div className="awesome-go-insight">
+            <Sparkles size={20} />
+            <div>
+              <span>Total libraries</span>
+              <strong>{awesomeGoEntries.length}</strong>
+            </div>
+          </div>
+          <div className="awesome-go-insight">
+            <Layers size={20} />
+            <div>
+              <span>Categories covered</span>
+              <strong>{categories.length}</strong>
+            </div>
+          </div>
+          <div className="awesome-go-insight">
+            <BookOpen size={20} />
+            <div>
+              <span>Mature picks</span>
+              <strong>{stageCounts.mature}</strong>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="awesome-go-panel">
+        <header className="awesome-go-filters__header">
+          <h2>Filter the landscape</h2>
+          <button type="button" className="awesome-go-reset" onClick={resetFilters}>
+            Reset filters
+          </button>
+        </header>
+
+        <div className="awesome-go-filters">
+          <div className="awesome-go-search">
+            <Search size={18} />
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={event => setSearchQuery(event.target.value)}
+              placeholder="Search by name, description, or capability"
+              aria-label="Search Awesome Go libraries"
+            />
+          </div>
+
+          <div className="awesome-go-filter-group">
+            <div className="awesome-go-filter-group__label">
+              <Filter size={16} />
+              <span>Categories</span>
+            </div>
+            <div className="awesome-go-filter-chips">
+              {categories.map(category => {
+                const isActive = selectedCategories.has(category)
+                return (
+                  <button
+                    key={category}
+                    type="button"
+                    className={`awesome-go-chip${isActive ? ' is-active' : ''}`}
+                    onClick={() => toggleCategory(category)}
+                  >
+                    {category}
+                    <span className="awesome-go-chip__count">
+                      {categorySummaries.find(summary => summary.category === category)?.count ?? 0}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <div className="awesome-go-filter-group">
+            <div className="awesome-go-filter-group__label">
+              <Sparkles size={16} />
+              <span>Maturity</span>
+            </div>
+            <div className="awesome-go-stage-options">
+              {stageFilterOptions.map(option => {
+                const isActive = stageFilter === option.value
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={`awesome-go-stage-option${isActive ? ' is-active' : ''}`}
+                    onClick={() => setStageFilter(option.value)}
+                  >
+                    {option.label}
+                    {option.value !== 'all' ? (
+                      <span className="awesome-go-chip__count">
+                        {stageCounts[option.value as AwesomeGoStage] ?? 0}
+                      </span>
+                    ) : null}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="awesome-go-panel">
+        <header className="awesome-go-results__header">
+          <div>
+            <h2>Adoption-ready libraries</h2>
+            <p className="awesome-go-results__meta">
+              Showing {filteredEntries.length} of {awesomeGoEntries.length} curated picks
+            </p>
+          </div>
+        </header>
+
+        <div className="awesome-go-grid">
+          {filteredEntries.map(entry => (
+            <article key={entry.name} className="awesome-go-card">
+              <header className="awesome-go-card__header">
+                <div>
+                  <p className="awesome-go-card__category">{entry.category}</p>
+                  <h3>{entry.name}</h3>
+                </div>
+                <StageBadge stage={entry.stage} />
+              </header>
+
+              <p className="awesome-go-card__description">{entry.description}</p>
+
+              <ul className="awesome-go-card__features">
+                {entry.features.map(feature => (
+                  <li key={feature}>
+                    <CheckCircle2 size={16} />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+
+              {entry.adoption ? <p className="awesome-go-card__adoption">{entry.adoption}</p> : null}
+
+              <div className="awesome-go-card__tags">
+                {entry.tags.map(tag => (
+                  <span key={tag}>{tag}</span>
+                ))}
+              </div>
+
+              <footer className="awesome-go-card__footer">
+                <div className="awesome-go-card__links">
+                  <a href={entry.url} target="_blank" rel="noreferrer">
+                    <Github size={16} />
+                    <span>Repository</span>
+                    <ExternalLink size={14} />
+                  </a>
+                  {entry.docsUrl ? (
+                    <a href={entry.docsUrl} target="_blank" rel="noreferrer">
+                      <BookOpen size={16} />
+                      <span>Docs</span>
+                      <ExternalLink size={14} />
+                    </a>
+                  ) : null}
+                </div>
+                <div className="awesome-go-card__stars">
+                  <Star size={16} />
+                  <span>{formatStars(entry.stars)} stars</span>
+                </div>
+              </footer>
+            </article>
+          ))}
+        </div>
+
+        {filteredEntries.length === 0 ? (
+          <div className="awesome-go-empty">
+            <p>No libraries match the current filters. Try widening your search.</p>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add a curated Awesome Go dataset that captures categories, maturity, star counts, and adoption notes
- build an Awesome Go adoption guide page with search, category chips, and maturity filters plus detailed cards
- wire the page into the app shell and apply dedicated styling to match the portfolio aesthetic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd45f31c50832fa1df51c1c16d05c1