### PR TITLE
Add filesystem bridge sync service and dashboard integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A monorepo that powers a modern portfolio workflow: a Vite/React intake app for 
 - **Guided project intake.** Responsive React forms help capture problem, solution, impact, evidence, assets, and metadata, then route creators into a rich editor experience.
 - **Hybrid browser storage.** Projects are persisted in localStorage with an automatic IndexedDB upgrade, including migration, quota tracking, and manual cleanup utilities.
 - **AI analysis pipeline.** The Node/Express backend queues uploads for processing with OpenAI, Bull, Prisma, and PostgreSQL/Redis infrastructure, providing confidence metrics and structured insights.
+- **Filesystem bridge.** A sync service keeps Prisma records aligned with the `projects/` directory, exposes APIs for pagination/search, and round-trips metadata or brief edits back to disk.
 - **Repeatable content structure.** A `projects/` directory schema plus a Python scaffolding script keep briefs, metadata, and assets consistent across teammates and automation.
 
 ## Repository structure
@@ -97,6 +98,32 @@ python3 scripts/new_project.py \
 ```
 The script scaffolds folders, metadata, and starter briefs aligned with the UI fields and automation pipelines.
 
+Immediately after creation the script runs `npm run sync -- --project <folder>` inside `server/` so the new project is registered with the database.
+
+### Keeping Prisma in sync with `projects/`
+
+The Node service performs a full filesystem scan on boot and then every five minutes (configurable). You can also trigger a manual sync from the command line or via the REST API:
+
+```bash
+# one-off CLI sync for all projects
+cd server
+npm run sync
+
+# limit the sync to a specific folder created on disk
+npm run sync -- --project 2025_Acme_Redesign
+
+# REST endpoint for automation or dashboards
+curl -X POST http://localhost:3001/api/projects/sync
+```
+
+The dashboard now reads directly from `/api/projects` and surfaces freshness indicators when the filesystem has diverged from the database. Editing metadata or the project brief rewrites `metadata.json` and `brief.md` on disk, updates Prisma, and recalculates checksums to guard against conflicts.
+
+### Importing and exporting project bundles
+
+- **Import:** Upload a zipped project (matching the `projects/` schema) from the dashboard or `POST /api/projects/import`. The archive is extracted into `projects/` with `unzip`/`rsync`, then synced to Prisma.
+- **Export:** Use the dashboard "Export bundle" action or `GET /api/projects/:id/export` to produce a shareable zip assembled from the current filesystem state.
+- **Assets/Deliverables:** The dashboard renders previews directly from the Prisma `project_assets` / `project_deliverables` tables so the UI mirrors the on-disk folder structure (`assets/` and `deliverables/`).
+
 ## Storage architecture
 The `storageManager` service automatically promotes projects from `localStorage` to IndexedDB, handles migrations, and reports usage so authors can diagnose quota issues from the UI. Tests cover IndexedDB fallbacks, migrations, and quota reporting to ensure reliability across browsers.
 
@@ -105,7 +132,7 @@ Run the Node test suites with:
 ```bash
 npm run test
 ```
-The tests focus on the hybrid storage layer and run via Node's built-in test runner with a custom TypeScript loader.
+The suites cover the browser storage manager, filesystem metadata parsing, sync conflict detection, and React rendering of real project data. Tests run via Node's built-in runner with a custom TypeScript loader.
 
 ## Environment variables summary
 | Key | Purpose |
@@ -117,5 +144,14 @@ The tests focus on the hybrid storage layer and run via Node's built-in test run
 | `PORT` | Express server port (defaults to `3001`). |
 | `VITE_API_BASE_URL` | Optional front-end override for the API base URL. |
 | `VITE_ANALYSIS_USER_ID` | Front-end default identifier associated with analysis requests. |
+| `PROJECTS_ROOT` | Absolute path to the on-disk `projects/` directory scanned by the sync service. Defaults to `<repo>/projects`. |
+| `PROJECT_SYNC_INTERVAL_MS` | Interval (in ms) between automated filesystem scans. Set to `0` to disable the scheduler. |
+
+## Production deployment considerations
+
+- **Shared storage:** Mount the canonical `projects/` directory into both the API and any worker containers (see `docker-compose.yml`). In production this is typically an NFS or SMB share so every replica sees the same filesystem state.
+- **Backups:** Schedule backups of both the Postgres database and the `projects/` volume. A simple approach is nightly snapshots of the network share plus database dumps via `pg_dump`.
+- **Conflict monitoring:** Monitor the `/api/projects` freshness indicators or the CLI sync output for `filesystem-updated`/`conflict` statuses. Unexpected conflicts usually signal an out-of-band edit on disk and should be resolved before continuing edits via the dashboard.
+- **Batch imports/exports:** When automating imports use the REST endpoints so each bundle is synced immediately. The same applies to exports for downstream tooling—call `/api/projects/:id/export` instead of zipping folders manually to ensure you get the canonical structure.
 
 With these values configured, the UI, queue workers, and AI analysis endpoints run cohesively for both solo creators and team deployments.

--- a/STARTUP_GUIDE.md
+++ b/STARTUP_GUIDE.md
@@ -32,7 +32,7 @@ The script performs the following steps:
 2. Starts the Postgres, Redis, and backend containers defined in
    `docker-compose.yml` (unless you opt out).
 3. Optionally runs `npx prisma migrate deploy` to apply database migrations.
-4. Launches the backend via `npm run dev` and the front-end via `npm run dev -- --host`.
+4. Launches the backend via `npm run dev` (which bootstraps the filesystem sync service) and the front-end via `npm run dev -- --host`.
 
 When the script completes you will have two services running locally:
 
@@ -74,5 +74,15 @@ See `./scripts/startup.sh --help` for the latest usage text.
 
 Prefer to manage services yourself? The script is optional. You can still
 follow the manual steps documented in `README.md` to bring up each component.
-The script simply wraps those commands so newcomers can boot the stack with one
-line.
+After the backend is running you can use the new filesystem bridge CLI:
+
+```bash
+cd server
+# scan all projects immediately
+npm run sync
+
+# rescan a specific folder after uploading assets
+npm run sync -- --project 2025_Acme_Redesign
+```
+
+The dashboard's "Sync filesystem" button and the `/api/projects` endpoints call the same service, so you can trigger updates from scripts, CI, or scheduled jobs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,11 +25,14 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:password@postgres:5432/portfolioforge
       - REDIS_URL=redis://redis:6379
+      - PROJECTS_ROOT=/app/projects
+      - PROJECT_SYNC_INTERVAL_MS=300000
     depends_on:
       - postgres
       - redis
     volumes:
       - ./uploads:/app/uploads
+      - ./projects:/app/projects
 
 volumes:
   postgres_data:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "node --loader ./scripts/ts-loader.mjs --test tests/storageManager.test.ts",
+    "test": "node --loader ./scripts/ts-loader.mjs --test tests/*.test.ts*",
     "start": "./start-macos.sh",
     "start:frontend": "npm run dev",
     "start:backend": "cd server && npm run dev",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,23 +23,84 @@ model User {
 }
 
 model Project {
-  id           String   @id @default(cuid())
-  name         String
-  description  String?
-  category     String?
-  template     String?
-  color        String   @default("#5a3cf4")
-  visibility   String   @default("private")
-  featured     Boolean  @default(false)
-  userId       String
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  files        ProjectFile[]
-  analysis     ProjectAnalysis?
-  
+  id                String   @id @default(cuid())
+  userId            String?
+  slug              String   @unique
+  folder            String   @unique
+  title             String
+  summary           String?
+  description       String?
+  organization      String?
+  workType          String?
+  year              Int?
+  role              String?
+  seniority         String?
+  categories        String[]
+  skills            String[]
+  tools             String[]
+  tags              String[]
+  highlights        String[]
+  links             Json?
+  nda               Boolean?
+  coverImage        String?
+  caseProblem       String?
+  caseActions       String?
+  caseResults       String?
+  schemaVersion     String?
+  metadataChecksum  String?
+  briefChecksum     String?
+  metadataUpdatedAt DateTime?
+  briefUpdatedAt    DateTime?
+  fsLastModified    DateTime?
+  lastSyncedAt      DateTime?
+  syncStatus        String   @default("clean")
+  syncWarnings      Json?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  user              User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  assets            ProjectAsset[]
+  deliverables      ProjectDeliverable[]
+  files             ProjectFile[]
+  analysis          ProjectAnalysis?
+
   @@map("projects")
+}
+
+model ProjectAsset {
+  id             String   @id @default(cuid())
+  projectId      String
+  relativePath   String
+  label          String?
+  type           String
+  size           Int?
+  checksum       String?
+  lastModifiedAt DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, relativePath])
+  @@map("project_assets")
+}
+
+model ProjectDeliverable {
+  id             String   @id @default(cuid())
+  projectId      String
+  relativePath   String
+  label          String?
+  format         String?
+  size           Int?
+  checksum       String?
+  lastModifiedAt DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@unique([projectId, relativePath])
+  @@map("project_deliverables")
 }
 
 model ProjectFile {

--- a/projects/2025_acme_test-project/brief.md
+++ b/projects/2025_acme_test-project/brief.md
@@ -1,0 +1,14 @@
+# Test Project
+
+**Organization:** Acme  
+**Year:** 2025  
+**Role:** Designer (Lead)
+
+## Problem
+- TBD
+
+## Actions
+- TBD
+
+## Results
+- TBD

--- a/projects/2025_acme_test-project/metadata.json
+++ b/projects/2025_acme_test-project/metadata.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "2.0.0",
+  "title": "Test Project",
+  "organization": "Acme",
+  "work_type": "Exploration",
+  "year": "2025",
+  "role": "Designer",
+  "seniority": "Lead",
+  "categories": ["Design"],
+  "skills": ["Research"],
+  "tools": ["Figma"],
+  "tags": ["demo"],
+  "highlights": ["Initial sample"],
+  "privacy": { "nda": false },
+  "case": { "problem": "", "actions": "", "results": "" }
+}

--- a/scripts/new_project.py
+++ b/scripts/new_project.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import argparse, json, re, shutil
+import argparse, json, re, shutil, subprocess
 from pathlib import Path
 from datetime import datetime
 
@@ -99,6 +99,19 @@ def main():
     write(proj / "brief.md", "\n".join([line for line in brief if line != ""]))
 
     print(f"✅ Created {proj}")
+
+    try:
+        subprocess.run(
+            ["npm", "run", "sync", "--", "--project", folder],
+            cwd=ROOT / "server",
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        print("🔄 Project registered with sync service.")
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        print("⚠️  Unable to register project with sync service:", exc)
+        print("   Run `cd server && npm run sync -- --project", folder, "` manually once dependencies are installed.")
 
 if __name__ == "__main__":
     main()

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/app.js",
-    "dev": "ts-node src/app.ts"
+    "dev": "ts-node src/app.ts",
+    "sync": "ts-node src/cli/syncProjects.ts"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.11.0",

--- a/server/src/cli/syncProjects.ts
+++ b/server/src/cli/syncProjects.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env ts-node
+/* eslint-disable no-console */
+import path from 'path';
+import { PrismaClient } from '@prisma/client';
+import ProjectSyncService from '../services/projectSyncService';
+
+const args = process.argv.slice(2);
+const flags = new Map<string, string | boolean>();
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i]!;
+  if (arg.startsWith('--')) {
+    const key = arg.slice(2);
+    const next = args[i + 1];
+    if (next && !next.startsWith('--')) {
+      flags.set(key, next);
+      i += 1;
+    } else {
+      flags.set(key, true);
+    }
+  }
+}
+
+const prisma = new PrismaClient();
+const projectRoot = process.env.PROJECTS_ROOT ?? path.resolve(__dirname, '../../..', 'projects');
+const service = new ProjectSyncService(prisma, { projectRoot });
+
+const run = async () => {
+  try {
+    const project = flags.get('project');
+    let summary;
+    if (typeof project === 'string' && project.length > 0) {
+      summary = await service.syncProject(project);
+      console.log(`Synced ${project}:`, {
+        created: summary.created,
+        conflicts: summary.conflicts.length,
+        assets: summary.assets.length,
+        deliverables: summary.deliverables.length,
+      });
+    } else {
+      summary = await service.syncAll();
+      console.log(`Synced ${summary.scanned} projects. Created ${summary.created}. Updated ${summary.updated}.`);
+      if (summary.conflicts.length > 0) {
+        console.warn('Conflicts detected:', summary.conflicts);
+      }
+      if (summary.warnings.length > 0) {
+        console.warn('Warnings:', summary.warnings);
+      }
+    }
+  } catch (error) {
+    console.error('Project sync CLI failed', error);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+};
+
+run();

--- a/server/src/jobs/projectSyncScheduler.ts
+++ b/server/src/jobs/projectSyncScheduler.ts
@@ -1,0 +1,36 @@
+import ProjectSyncService from '../services/projectSyncService';
+
+type SchedulerOptions = {
+  service: ProjectSyncService;
+  intervalMs: number;
+};
+
+let timer: NodeJS.Timeout | undefined;
+
+export const registerProjectSyncScheduler = ({ service, intervalMs }: SchedulerOptions) => {
+  if (timer) {
+    clearInterval(timer);
+  }
+
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return;
+  }
+
+  const executeSync = async () => {
+    try {
+      await service.syncAll();
+    } catch (error) {
+      console.error('Scheduled project sync failed:', error);
+    }
+  };
+
+  timer = setInterval(executeSync, intervalMs);
+  executeSync();
+};
+
+export const stopProjectSyncScheduler = () => {
+  if (timer) {
+    clearInterval(timer);
+    timer = undefined;
+  }
+};

--- a/server/src/routes/analysis.ts
+++ b/server/src/routes/analysis.ts
@@ -172,7 +172,10 @@ router.post('/projects/:projectId/analyze', requireAuth, async (req: Authenticat
     const project = await prisma.project.findFirst({
       where: {
         id: projectId,
-        userId: userId
+        OR: [
+          { userId: userId },
+          { userId: null },
+        ]
       },
       include: {
         files: true
@@ -217,7 +220,10 @@ router.get('/projects/:projectId/analysis', requireAuth, async (req: Authenticat
     const project = await prisma.project.findFirst({
       where: {
         id: projectId,
-        userId: userId
+        OR: [
+          { userId: userId },
+          { userId: null },
+        ]
       },
       include: {
         files: {
@@ -278,9 +284,9 @@ router.get('/projects/:projectId/analysis', requireAuth, async (req: Authenticat
     res.json({
       project: {
         id: project.id,
-        name: project.name,
+        name: project.title,
         description: project.description,
-        category: project.category,
+        category: project.workType,
         fileCount: project.files.length,
         updatedAt: project.updatedAt,
       },
@@ -302,7 +308,10 @@ router.get('/projects/:projectId/analysis/results', requireAuth, async (req: Aut
     const project = await prisma.project.findFirst({
       where: {
         id: projectId,
-        userId: userId
+        OR: [
+          { userId: userId },
+          { userId: null },
+        ]
       }
     });
 
@@ -381,8 +390,8 @@ router.post('/projects/:projectId/analysis/apply', requireAuth, async (req: Auth
 
     const updateData: Record<string, unknown> = {};
     
-    if (suggestions?.title) updateData.name = suggestions.title;
-    if (suggestions?.category) updateData.category = suggestions.category;
+    if (suggestions?.title) updateData.title = suggestions.title;
+    if (suggestions?.category) updateData.workType = suggestions.category;
     if (suggestions?.description) updateData.description = suggestions.description;
 
     await prisma.project.update({

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -1,0 +1,239 @@
+import express from 'express';
+import type multer from 'multer';
+import { PrismaClient } from '@prisma/client';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth';
+import ProjectSyncService from '../services/projectSyncService';
+
+type AppLocals = {
+  projectSyncService?: ProjectSyncService;
+  prisma?: PrismaClient;
+};
+
+const resolveDependencies = (req: express.Request) => {
+  const locals = req.app.locals as AppLocals;
+  if (!locals.projectSyncService || !locals.prisma) {
+    throw new Error('Project sync service has not been initialised');
+  }
+  return {
+    service: locals.projectSyncService,
+    prisma: locals.prisma,
+  };
+};
+
+const routerFactory = (upload: multer.Multer) => {
+  const router = express.Router();
+
+  router.get('/', requireAuth, async (req: AuthenticatedRequest, res) => {
+    try {
+      const { prisma } = resolveDependencies(req);
+      const page = Math.max(Number(req.query.page) || 1, 1);
+      const pageSize = Math.min(Math.max(Number(req.query.pageSize) || 12, 1), 50);
+      const search = typeof req.query.search === 'string' ? req.query.search.trim() : '';
+
+      const where: Parameters<typeof prisma.project.findMany>[0]['where'] = {
+        OR: search
+          ? [
+              { title: { contains: search, mode: 'insensitive' } },
+              { organization: { contains: search, mode: 'insensitive' } },
+              { tags: { has: search.toLowerCase() } },
+            ]
+          : undefined,
+      };
+
+      const [projects, total] = await prisma.$transaction([
+        prisma.project.findMany({
+          where,
+          orderBy: { updatedAt: 'desc' },
+          include: {
+            assets: { orderBy: { updatedAt: 'desc' }, take: 4 },
+            deliverables: { orderBy: { updatedAt: 'desc' }, take: 3 },
+            _count: { select: { assets: true, deliverables: true } },
+          },
+          skip: (page - 1) * pageSize,
+          take: pageSize,
+        }),
+        prisma.project.count({ where }),
+      ]);
+
+      res.json({
+        data: projects.map(project => ({
+          id: project.id,
+          slug: project.slug,
+          title: project.title,
+          summary: project.summary,
+          organization: project.organization,
+          workType: project.workType,
+          year: project.year,
+          tags: project.tags,
+          highlights: project.highlights,
+          syncStatus: project.syncStatus,
+          lastSyncedAt: project.lastSyncedAt,
+          fsLastModified: project.fsLastModified,
+          metadataUpdatedAt: project.metadataUpdatedAt,
+          briefUpdatedAt: project.briefUpdatedAt,
+          assetCount: project._count.assets,
+          deliverableCount: project._count.deliverables,
+          assetPreviews: project.assets.map(asset => ({
+            id: asset.id,
+            label: asset.label,
+            relativePath: asset.relativePath,
+            type: asset.type,
+            updatedAt: asset.updatedAt,
+          })),
+          deliverablePreviews: project.deliverables.map(deliverable => ({
+            id: deliverable.id,
+            label: deliverable.label,
+            relativePath: deliverable.relativePath,
+            format: deliverable.format,
+            updatedAt: deliverable.updatedAt,
+          })),
+        })),
+        pagination: {
+          page,
+          pageSize,
+          total,
+          totalPages: Math.max(Math.ceil(total / pageSize), 1),
+        },
+      });
+    } catch (error) {
+      console.error('Failed to list projects', error);
+      res.status(500).json({ error: 'Failed to list projects' });
+    }
+  });
+
+  router.post('/sync', requireAuth, async (req: AuthenticatedRequest, res) => {
+    try {
+      const { service } = resolveDependencies(req);
+      const result = await service.syncAll();
+      res.json(result);
+    } catch (error) {
+      console.error('Project sync failed', error);
+      res.status(500).json({ error: 'Project sync failed' });
+    }
+  });
+
+  router.post('/import', requireAuth, upload.single('archive'), async (req: AuthenticatedRequest, res) => {
+    try {
+      const { service } = resolveDependencies(req);
+      if (!req.file?.buffer) {
+        res.status(400).json({ error: 'Missing archive upload' });
+        return;
+      }
+      const results = await service.importFromZip(req.file.buffer);
+      res.status(201).json({ imported: results.length, results });
+    } catch (error) {
+      console.error('Import failed', error);
+      res.status(500).json({ error: 'Import failed' });
+    }
+  });
+
+  router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res) => {
+    try {
+      const { prisma, service } = resolveDependencies(req);
+      const { projectId } = req.params;
+
+      const project = await prisma.project.findUnique({
+        where: { id: projectId },
+        include: { assets: true, deliverables: true },
+      });
+
+      if (!project) {
+        res.status(404).json({ error: 'Project not found' });
+        return;
+      }
+
+      const brief = await service.readBrief(projectId);
+      res.json({
+        project,
+        metadata: service.metadataFromProject(project),
+        brief,
+      });
+    } catch (error) {
+      console.error('Failed to fetch project', error);
+      res.status(500).json({ error: 'Failed to fetch project' });
+    }
+  });
+
+  router.patch('/:projectId/metadata', requireAuth, async (req: AuthenticatedRequest, res) => {
+    try {
+      const { service } = resolveDependencies(req);
+      const { projectId } = req.params;
+      const { metadata, expectedChecksum } = req.body ?? {};
+
+      if (!metadata || typeof metadata !== 'object') {
+        res.status(400).json({ error: 'Metadata payload missing' });
+        return;
+      }
+
+      try {
+        const updated = await service.updateMetadata({
+          projectId,
+          metadata,
+          expectedChecksum,
+        });
+        res.json({ project: updated });
+      } catch (error: unknown) {
+        const conflict = (error as { conflict?: unknown }).conflict;
+        if (conflict) {
+          res.status(409).json({ error: 'conflict', details: conflict });
+          return;
+        }
+        throw error;
+      }
+    } catch (error) {
+      console.error('Failed to update metadata', error);
+      res.status(500).json({ error: 'Failed to update metadata' });
+    }
+  });
+
+  router.patch('/:projectId/brief', requireAuth, async (req: AuthenticatedRequest, res) => {
+    try {
+      const { service } = resolveDependencies(req);
+      const { projectId } = req.params;
+      const { content, expectedChecksum } = req.body ?? {};
+
+      if (typeof content !== 'string') {
+        res.status(400).json({ error: 'Brief content missing' });
+        return;
+      }
+
+      try {
+        const updated = await service.updateBrief({
+          projectId,
+          content,
+          expectedChecksum,
+        });
+        res.json({ project: updated });
+      } catch (error: unknown) {
+        const conflict = (error as { conflict?: unknown }).conflict;
+        if (conflict) {
+          res.status(409).json({ error: 'conflict', details: conflict });
+          return;
+        }
+        throw error;
+      }
+    } catch (error) {
+      console.error('Failed to update brief', error);
+      res.status(500).json({ error: 'Failed to update brief' });
+    }
+  });
+
+  router.get('/:projectId/export', requireAuth, async (req: AuthenticatedRequest, res) => {
+    try {
+      const { service } = resolveDependencies(req);
+      const { projectId } = req.params;
+
+      const archive = await service.exportToZip(projectId);
+      res.setHeader('Content-Type', 'application/zip');
+      res.setHeader('Content-Disposition', `attachment; filename="${archive.filename}"`);
+      res.send(archive.buffer);
+    } catch (error) {
+      console.error('Export failed', error);
+      res.status(500).json({ error: 'Export failed' });
+    }
+  });
+
+  return router;
+};
+
+export default routerFactory;

--- a/server/src/services/aiAnalysis.ts
+++ b/server/src/services/aiAnalysis.ts
@@ -4,9 +4,9 @@ import { AnalysisResult, AnalysisInsight } from '../types/analysis';
 
 type ProjectWithFiles = {
   id: string;
-  name: string;
-  description: string | null;
-  category: string | null;
+  title: string;
+  summary: string | null;
+  workType: string | null;
   files: Array<{
     id: string;
     name: string;
@@ -154,9 +154,9 @@ export class AIAnalysisService {
     }
 
     return {
-      projectName: project.name,
-      projectDescription: project.description,
-      projectCategory: project.category,
+      projectName: project.title,
+      projectDescription: project.summary,
+      projectCategory: project.workType,
       allInsights,
       extractedTexts,
       fileMetadata,

--- a/server/src/services/projectSyncService.ts
+++ b/server/src/services/projectSyncService.ts
@@ -1,0 +1,655 @@
+import fs from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import os from 'os';
+import { promisify } from 'util';
+import { execFile } from 'child_process';
+import { PrismaClient, Prisma, Project as ProjectModel } from '@prisma/client';
+import {
+  FilesystemAsset,
+  FilesystemDeliverable,
+  FilesystemProject,
+  ParsedMetadata,
+  SyncConflict,
+  SyncProjectResult,
+  SyncSummary,
+  UpdateBriefPayload,
+  UpdateMetadataPayload,
+} from '../types/projectSync';
+
+const execFileAsync = promisify(execFile);
+
+const METADATA_FILE = 'metadata.json';
+const BRIEF_FILE = 'brief.md';
+
+const ASSET_DIR = 'assets';
+const DELIVERABLE_DIR = 'deliverables';
+
+type SyncOptions = {
+  projectRoot: string;
+};
+
+export const slugify = (value: string): string => {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-_]+/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64) || 'untitled-project';
+};
+
+export const computeChecksum = (input: Buffer | string): string => {
+  const hash = crypto.createHash('sha1');
+  hash.update(input);
+  return hash.digest('hex');
+};
+
+const readJsonFile = async <T>(filePath: string): Promise<T> => {
+  const data = await fs.readFile(filePath, 'utf-8');
+  return JSON.parse(data) as T;
+};
+
+const readOptionalText = async (filePath: string): Promise<{ content: string; checksum: string; mtime: Date } | null> => {
+  try {
+    const stats = await fs.stat(filePath);
+    if (!stats.isFile()) {
+      return null;
+    }
+    const buffer = await fs.readFile(filePath);
+    return {
+      content: buffer.toString('utf-8'),
+      checksum: computeChecksum(buffer),
+      mtime: stats.mtime,
+    };
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+};
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const normalizeOptionalString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+export const parseMetadata = (metadata: Record<string, unknown>): ParsedMetadata => {
+  const caseData = typeof metadata.case === 'object' && metadata.case !== null ? metadata.case as Record<string, unknown> : {};
+  return {
+    schemaVersion: typeof metadata.schema_version === 'string' ? metadata.schema_version : undefined,
+    title: typeof metadata.title === 'string' && metadata.title.trim().length > 0 ? metadata.title.trim() : 'Untitled Project',
+    summary: normalizeOptionalString(metadata.summary),
+    organization: normalizeOptionalString(metadata.organization),
+    workType: normalizeOptionalString(metadata.work_type),
+    year: typeof metadata.year === 'number'
+      ? metadata.year
+      : typeof metadata.year === 'string' && /^\d{4}$/.test(metadata.year)
+        ? Number(metadata.year)
+        : undefined,
+    role: normalizeOptionalString(metadata.role),
+    seniority: normalizeOptionalString(metadata.seniority),
+    categories: normalizeStringArray(metadata.categories),
+    skills: normalizeStringArray(metadata.skills),
+    tools: normalizeStringArray(metadata.tools),
+    tags: normalizeStringArray(metadata.tags),
+    highlights: normalizeStringArray(metadata.highlights),
+    links: typeof metadata.links === 'object' && metadata.links !== null ? metadata.links as Record<string, unknown> : null,
+    nda: typeof metadata === 'object' && metadata !== null
+      ? Boolean((metadata.privacy as Record<string, unknown> | undefined)?.nda)
+      : undefined,
+    coverImage: normalizeOptionalString(metadata.cover_image),
+    case: {
+      problem: normalizeOptionalString(caseData.problem),
+      actions: normalizeOptionalString(caseData.actions),
+      results: normalizeOptionalString(caseData.results),
+    },
+  };
+};
+
+const inferAssetType = (relativePath: string): string => {
+  const directoryPart = relativePath.split(path.sep)[1] ?? '';
+  if (directoryPart.includes('image')) return 'image';
+  if (directoryPart.includes('video')) return 'video';
+  if (directoryPart.includes('doc')) return 'document';
+  return 'asset';
+};
+
+const inferDeliverableFormat = (relativePath: string): string | undefined => {
+  const ext = path.extname(relativePath).slice(1).toLowerCase();
+  return ext || undefined;
+};
+
+const listFiles = async (baseDir: string): Promise<string[]> => {
+  const entries = await fs.readdir(baseDir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(baseDir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await listFiles(entryPath);
+      files.push(...nested);
+    } else if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+};
+
+const mapAssets = async (projectPath: string, folderName: string): Promise<FilesystemAsset[]> => {
+  const basePath = path.join(projectPath, ASSET_DIR);
+  const exists = await fs.stat(basePath).then(stat => stat.isDirectory()).catch(() => false);
+  if (!exists) {
+    return [];
+  }
+  const allFiles = await listFiles(basePath);
+  const assets: FilesystemAsset[] = [];
+  for (const file of allFiles) {
+    const stats = await fs.stat(file);
+    const buffer = await fs.readFile(file);
+    const relativePath = path.relative(projectPath, file);
+    assets.push({
+      relativePath,
+      type: inferAssetType(relativePath),
+      size: stats.size,
+      checksum: computeChecksum(buffer),
+      lastModifiedAt: stats.mtime,
+      label: path.basename(file),
+    });
+  }
+  return assets;
+};
+
+const mapDeliverables = async (projectPath: string): Promise<FilesystemDeliverable[]> => {
+  const basePath = path.join(projectPath, DELIVERABLE_DIR);
+  const exists = await fs.stat(basePath).then(stat => stat.isDirectory()).catch(() => false);
+  if (!exists) {
+    return [];
+  }
+  const allFiles = await listFiles(basePath);
+  const deliverables: FilesystemDeliverable[] = [];
+  for (const file of allFiles) {
+    const stats = await fs.stat(file);
+    const buffer = await fs.readFile(file);
+    const relativePath = path.relative(projectPath, file);
+    deliverables.push({
+      relativePath,
+      format: inferDeliverableFormat(relativePath),
+      size: stats.size,
+      checksum: computeChecksum(buffer),
+      lastModifiedAt: stats.mtime,
+      label: path.basename(file),
+    });
+  }
+  return deliverables;
+};
+
+export class ProjectSyncService {
+  private prisma: PrismaClient;
+  private projectRoot: string;
+
+  constructor(prisma: PrismaClient, options: SyncOptions) {
+    this.prisma = prisma;
+    this.projectRoot = options.projectRoot;
+  }
+
+  async syncAll(): Promise<SyncSummary> {
+    const entries = await fs.readdir(this.projectRoot).catch(() => [] as string[]);
+    const folders = entries.filter(entry => !entry.startsWith('.'));
+    const results: SyncProjectResult[] = [];
+    for (const folder of folders) {
+      const stat = await fs.stat(path.join(this.projectRoot, folder)).catch(() => null);
+      if (!stat?.isDirectory()) {
+        continue;
+      }
+      const result = await this.syncProject(folder);
+      results.push(result);
+    }
+
+    const created = results.filter(result => result.created).length;
+    const updated = results.length - created;
+    const conflicts = results.flatMap(result => result.conflicts);
+    const warnings = results.flatMap(result => result.warnings);
+
+    return {
+      scanned: results.length,
+      created,
+      updated,
+      conflicts,
+      warnings,
+      projects: results,
+    };
+  }
+
+  async syncProject(folder: string): Promise<SyncProjectResult> {
+    const projectPath = path.join(this.projectRoot, folder);
+    const metadataPath = path.join(projectPath, METADATA_FILE);
+    const briefPath = path.join(projectPath, BRIEF_FILE);
+
+    const metadataStats = await fs.stat(metadataPath).catch(() => null);
+    if (!metadataStats?.isFile()) {
+      throw new Error(`Project ${folder} is missing ${METADATA_FILE}`);
+    }
+
+    const rawMetadata = await readJsonFile<Record<string, unknown>>(metadataPath);
+    const parsedMetadata = parseMetadata(rawMetadata);
+    const metadataBuffer = await fs.readFile(metadataPath);
+
+    const briefData = await readOptionalText(briefPath);
+
+    const assets = await mapAssets(projectPath, folder);
+    const deliverables = await mapDeliverables(projectPath);
+
+    const fsLastModifiedCandidates = [metadataStats.mtime, ...assets.map(a => a.lastModifiedAt).filter(Boolean) as Date[]];
+    if (briefData?.mtime) {
+      fsLastModifiedCandidates.push(briefData.mtime);
+    }
+    if (deliverables.length > 0) {
+      fsLastModifiedCandidates.push(...deliverables.map(item => item.lastModifiedAt).filter(Boolean) as Date[]);
+    }
+    const fsLastModified = fsLastModifiedCandidates.length > 0
+      ? new Date(Math.max(...fsLastModifiedCandidates.map(date => date.getTime())))
+      : new Date();
+
+    const slug = slugify(parsedMetadata.title || folder);
+
+    const fsProject: FilesystemProject = {
+      folder,
+      slug,
+      metadataPath,
+      briefPath: briefData ? briefPath : null,
+      metadata: parsedMetadata,
+      brief: briefData?.content ?? null,
+      metadataChecksum: computeChecksum(metadataBuffer),
+      briefChecksum: briefData?.checksum ?? null,
+      metadataUpdatedAt: metadataStats.mtime,
+      briefUpdatedAt: briefData?.mtime,
+      fsLastModified,
+      assets,
+      deliverables,
+    };
+
+    return this.persistProject(fsProject);
+  }
+
+  private async persistProject(project: FilesystemProject): Promise<SyncProjectResult> {
+    const existing = await this.prisma.project.findUnique({
+      where: { folder: project.folder },
+      include: { assets: true, deliverables: true },
+    });
+
+    const now = new Date();
+    const warnings: string[] = [];
+    const conflicts: SyncConflict[] = [];
+
+    const baseData: Prisma.ProjectUpsertArgs['create'] = {
+      slug: project.slug,
+      folder: project.folder,
+      title: project.metadata.title,
+      summary: project.metadata.summary,
+      description: project.metadata.summary ?? project.brief ?? null,
+      organization: project.metadata.organization,
+      workType: project.metadata.workType,
+      year: project.metadata.year,
+      role: project.metadata.role,
+      seniority: project.metadata.seniority,
+      categories: project.metadata.categories,
+      skills: project.metadata.skills,
+      tools: project.metadata.tools,
+      tags: project.metadata.tags,
+      highlights: project.metadata.highlights,
+      links: project.metadata.links,
+      nda: project.metadata.nda,
+      coverImage: project.metadata.coverImage,
+      caseProblem: project.metadata.case?.problem ?? null,
+      caseActions: project.metadata.case?.actions ?? null,
+      caseResults: project.metadata.case?.results ?? null,
+      schemaVersion: project.metadata.schemaVersion,
+      metadataChecksum: project.metadataChecksum,
+      briefChecksum: project.briefChecksum,
+      metadataUpdatedAt: project.metadataUpdatedAt,
+      briefUpdatedAt: project.briefUpdatedAt,
+      fsLastModified: project.fsLastModified,
+      lastSyncedAt: now,
+      syncStatus: 'clean',
+      syncWarnings: warnings.length > 0 ? warnings : null,
+    };
+
+    let persisted = existing;
+    if (!existing) {
+      persisted = await this.prisma.project.create({ data: baseData });
+    } else {
+      const isMetadataChanged = existing.metadataChecksum !== project.metadataChecksum;
+      const isBriefChanged = existing.briefChecksum !== project.briefChecksum;
+
+      let syncStatus = 'clean';
+      if (isMetadataChanged || isBriefChanged) {
+        syncStatus = 'filesystem-updated';
+      }
+
+      persisted = await this.prisma.project.update({
+        where: { id: existing.id },
+        data: {
+          ...baseData,
+          syncStatus,
+        },
+      });
+    }
+
+    await this.syncAssets(persisted.id, project.assets);
+    await this.syncDeliverables(persisted.id, project.deliverables);
+
+    const refreshed = await this.prisma.project.findUnique({
+      where: { id: persisted!.id },
+      include: { assets: true, deliverables: true },
+    });
+
+    return {
+      project: refreshed!,
+      created: !existing,
+      conflicts,
+      warnings,
+      assets: refreshed!.assets,
+      deliverables: refreshed!.deliverables,
+    };
+  }
+
+  private async syncAssets(projectId: string, assets: FilesystemAsset[]) {
+    const paths = assets.map(asset => asset.relativePath);
+
+    await this.prisma.projectAsset.deleteMany({
+      where: {
+        projectId,
+        NOT: { relativePath: { in: paths.length > 0 ? paths : ['__none__'] } },
+      },
+    });
+
+    for (const asset of assets) {
+      await this.prisma.projectAsset.upsert({
+        where: { projectId_relativePath: { projectId, relativePath: asset.relativePath } },
+        create: {
+          projectId,
+          relativePath: asset.relativePath,
+          label: asset.label,
+          type: asset.type,
+          size: asset.size ?? null,
+          checksum: asset.checksum ?? null,
+          lastModifiedAt: asset.lastModifiedAt ?? null,
+        },
+        update: {
+          label: asset.label,
+          type: asset.type,
+          size: asset.size ?? null,
+          checksum: asset.checksum ?? null,
+          lastModifiedAt: asset.lastModifiedAt ?? null,
+        },
+      });
+    }
+  }
+
+  private async syncDeliverables(projectId: string, deliverables: FilesystemDeliverable[]) {
+    const paths = deliverables.map(item => item.relativePath);
+
+    await this.prisma.projectDeliverable.deleteMany({
+      where: {
+        projectId,
+        NOT: { relativePath: { in: paths.length > 0 ? paths : ['__none__'] } },
+      },
+    });
+
+    for (const deliverable of deliverables) {
+      await this.prisma.projectDeliverable.upsert({
+        where: { projectId_relativePath: { projectId, relativePath: deliverable.relativePath } },
+        create: {
+          projectId,
+          relativePath: deliverable.relativePath,
+          label: deliverable.label,
+          format: deliverable.format ?? null,
+          size: deliverable.size ?? null,
+          checksum: deliverable.checksum ?? null,
+          lastModifiedAt: deliverable.lastModifiedAt ?? null,
+        },
+        update: {
+          label: deliverable.label,
+          format: deliverable.format ?? null,
+          size: deliverable.size ?? null,
+          checksum: deliverable.checksum ?? null,
+          lastModifiedAt: deliverable.lastModifiedAt ?? null,
+        },
+      });
+    }
+  }
+
+  async updateMetadata({ projectId, metadata, expectedChecksum }: UpdateMetadataPayload) {
+    const project = await this.prisma.project.findUnique({ where: { id: projectId } });
+    if (!project) {
+      throw new Error('Project not found');
+    }
+
+    if (expectedChecksum && project.metadataChecksum && project.metadataChecksum !== expectedChecksum) {
+      const conflict: SyncConflict = {
+        field: 'metadata',
+        reason: 'Metadata file changed since last fetch',
+        expectedChecksum,
+        actualChecksum: project.metadataChecksum,
+      };
+      const error = new Error('Metadata conflict detected');
+      (error as any).conflict = conflict;
+      throw error;
+    }
+
+    const metadataPath = path.join(this.projectRoot, project.folder, METADATA_FILE);
+    const payload = {
+      schema_version: metadata.schemaVersion,
+      title: metadata.title,
+      summary: metadata.summary,
+      organization: metadata.organization,
+      work_type: metadata.workType,
+      year: metadata.year,
+      role: metadata.role,
+      seniority: metadata.seniority,
+      categories: metadata.categories,
+      skills: metadata.skills,
+      tools: metadata.tools,
+      tags: metadata.tags,
+      highlights: metadata.highlights,
+      links: metadata.links ?? {},
+      privacy: { nda: metadata.nda ?? false },
+      case: {
+        problem: metadata.case?.problem ?? '',
+        actions: metadata.case?.actions ?? '',
+        results: metadata.case?.results ?? '',
+      },
+      cover_image: metadata.coverImage ?? '',
+    };
+
+    const buffer = Buffer.from(JSON.stringify(payload, null, 2), 'utf-8');
+    await fs.writeFile(metadataPath, buffer);
+    const stats = await fs.stat(metadataPath);
+    const checksum = computeChecksum(buffer);
+
+    const updated = await this.prisma.project.update({
+      where: { id: projectId },
+      data: {
+        title: metadata.title,
+        summary: metadata.summary,
+        description: metadata.summary ?? project.description,
+        organization: metadata.organization,
+        workType: metadata.workType,
+        year: metadata.year,
+        role: metadata.role,
+        seniority: metadata.seniority,
+        categories: metadata.categories,
+        skills: metadata.skills,
+        tools: metadata.tools,
+        tags: metadata.tags,
+        highlights: metadata.highlights,
+        links: metadata.links,
+        nda: metadata.nda,
+        coverImage: metadata.coverImage,
+        caseProblem: metadata.case?.problem ?? null,
+        caseActions: metadata.case?.actions ?? null,
+        caseResults: metadata.case?.results ?? null,
+        metadataChecksum: checksum,
+        metadataUpdatedAt: stats.mtime,
+        fsLastModified: stats.mtime,
+        lastSyncedAt: new Date(),
+        syncStatus: 'clean',
+      },
+    });
+
+    return updated;
+  }
+
+  async updateBrief({ projectId, content, expectedChecksum }: UpdateBriefPayload) {
+    const project = await this.prisma.project.findUnique({ where: { id: projectId } });
+    if (!project) {
+      throw new Error('Project not found');
+    }
+
+    if (expectedChecksum && project.briefChecksum && project.briefChecksum !== expectedChecksum) {
+      const conflict: SyncConflict = {
+        field: 'brief',
+        reason: 'Brief changed since last fetch',
+        expectedChecksum,
+        actualChecksum: project.briefChecksum,
+      };
+      const error = new Error('Brief conflict detected');
+      (error as any).conflict = conflict;
+      throw error;
+    }
+
+    const briefPath = path.join(this.projectRoot, project.folder, BRIEF_FILE);
+    await fs.writeFile(briefPath, content, 'utf-8');
+    const stats = await fs.stat(briefPath);
+    const checksum = computeChecksum(content);
+
+    const updated = await this.prisma.project.update({
+      where: { id: projectId },
+      data: {
+        briefChecksum: checksum,
+        briefUpdatedAt: stats.mtime,
+        description: project.description ?? content,
+        fsLastModified: stats.mtime,
+        lastSyncedAt: new Date(),
+        syncStatus: 'clean',
+      },
+    });
+
+    return updated;
+  }
+
+  async readBrief(projectId: string) {
+    const project = await this.prisma.project.findUnique({ where: { id: projectId } });
+    if (!project) {
+      throw new Error('Project not found');
+    }
+    const briefPath = path.join(this.projectRoot, project.folder, BRIEF_FILE);
+    const brief = await readOptionalText(briefPath);
+    return {
+      content: brief?.content ?? null,
+      checksum: brief?.checksum ?? null,
+    };
+  }
+
+  metadataFromProject(project: ProjectModel): ParsedMetadata {
+    return {
+      schemaVersion: project.schemaVersion ?? undefined,
+      title: project.title,
+      summary: project.summary ?? undefined,
+      organization: project.organization ?? undefined,
+      workType: project.workType ?? undefined,
+      year: project.year ?? undefined,
+      role: project.role ?? undefined,
+      seniority: project.seniority ?? undefined,
+      categories: project.categories ?? [],
+      skills: project.skills ?? [],
+      tools: project.tools ?? [],
+      tags: project.tags ?? [],
+      highlights: project.highlights ?? [],
+      links: (project.links as Record<string, unknown> | null) ?? null,
+      nda: project.nda ?? undefined,
+      coverImage: project.coverImage ?? undefined,
+      case: {
+        problem: project.caseProblem ?? undefined,
+        actions: project.caseActions ?? undefined,
+        results: project.caseResults ?? undefined,
+      },
+    };
+  }
+
+  async importFromZip(buffer: Buffer): Promise<SyncProjectResult[]> {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'portfolio-import-'));
+    const archivePath = path.join(tmpDir, 'project.zip');
+    await fs.writeFile(archivePath, buffer);
+
+    await execFileAsync('unzip', ['-o', archivePath, '-d', tmpDir]);
+
+    const entries = await fs.readdir(tmpDir, { withFileTypes: true });
+    const projectFolders = entries
+      .filter(entry => entry.isDirectory() && entry.name !== path.basename(archivePath))
+      .map(entry => entry.name);
+
+    if (projectFolders.length === 0) {
+      throw new Error('Archive does not contain a project folder');
+    }
+
+    const results: SyncProjectResult[] = [];
+    for (const folder of projectFolders) {
+      const source = path.join(tmpDir, folder);
+      const destination = path.join(this.projectRoot, folder);
+      await fs.mkdir(destination, { recursive: true });
+      await execFileAsync('rsync', ['-a', `${source}/`, `${destination}/`]);
+      const result = await this.syncProject(folder);
+      results.push(result);
+    }
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+
+    return results;
+  }
+
+  async exportToZip(projectId: string): Promise<{ filename: string; buffer: Buffer }> {
+    const project = await this.prisma.project.findUnique({ where: { id: projectId } });
+    if (!project) {
+      throw new Error('Project not found');
+    }
+
+    const projectPath = path.join(this.projectRoot, project.folder);
+    const stats = await fs.stat(projectPath).catch(() => null);
+    if (!stats?.isDirectory()) {
+      throw new Error('Project directory missing');
+    }
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'portfolio-export-'));
+    const archivePath = path.join(tmpDir, `${project.slug || project.folder}.zip`);
+
+    await execFileAsync('zip', ['-r', archivePath, project.folder], { cwd: this.projectRoot });
+    const buffer = await fs.readFile(archivePath);
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+
+    return {
+      filename: path.basename(archivePath),
+      buffer,
+    };
+  }
+}
+
+export default ProjectSyncService;

--- a/server/src/types/projectSync.ts
+++ b/server/src/types/projectSync.ts
@@ -1,0 +1,96 @@
+import { Project, ProjectAsset, ProjectDeliverable } from '@prisma/client';
+
+export type ParsedMetadata = {
+  schemaVersion?: string;
+  title: string;
+  summary?: string;
+  organization?: string;
+  workType?: string;
+  year?: number;
+  role?: string;
+  seniority?: string;
+  categories: string[];
+  skills: string[];
+  tools: string[];
+  tags: string[];
+  highlights: string[];
+  links?: Record<string, unknown> | null;
+  nda?: boolean;
+  coverImage?: string | null;
+  case?: {
+    problem?: string | null;
+    actions?: string | null;
+    results?: string | null;
+  } | null;
+};
+
+export type FilesystemAsset = {
+  relativePath: string;
+  type: string;
+  label?: string;
+  size?: number;
+  checksum?: string;
+  lastModifiedAt?: Date;
+};
+
+export type FilesystemDeliverable = {
+  relativePath: string;
+  format?: string;
+  label?: string;
+  size?: number;
+  checksum?: string;
+  lastModifiedAt?: Date;
+};
+
+export type FilesystemProject = {
+  folder: string;
+  slug: string;
+  metadataPath: string;
+  briefPath: string | null;
+  metadata: ParsedMetadata;
+  brief: string | null;
+  metadataChecksum: string;
+  briefChecksum: string | null;
+  metadataUpdatedAt?: Date;
+  briefUpdatedAt?: Date;
+  fsLastModified?: Date;
+  assets: FilesystemAsset[];
+  deliverables: FilesystemDeliverable[];
+};
+
+export type SyncConflict = {
+  field: 'metadata' | 'brief';
+  reason: string;
+  expectedChecksum?: string | null;
+  actualChecksum?: string | null;
+};
+
+export type SyncProjectResult = {
+  project: Project;
+  created: boolean;
+  conflicts: SyncConflict[];
+  warnings: string[];
+  assets: ProjectAsset[];
+  deliverables: ProjectDeliverable[];
+};
+
+export type SyncSummary = {
+  scanned: number;
+  created: number;
+  updated: number;
+  conflicts: SyncConflict[];
+  warnings: string[];
+  projects: SyncProjectResult[];
+};
+
+export type UpdateMetadataPayload = {
+  projectId: string;
+  metadata: ParsedMetadata;
+  expectedChecksum?: string;
+};
+
+export type UpdateBriefPayload = {
+  projectId: string;
+  content: string;
+  expectedChecksum?: string | null;
+};

--- a/tests/dashboardComponents.test.tsx
+++ b/tests/dashboardComponents.test.tsx
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  AssetPreviewList,
+  DeliverablePreviewList,
+  FreshnessBadge,
+  computeFreshness,
+  type ApiAssetPreview,
+  type ApiDeliverablePreview,
+  type ApiProject,
+} from '../src/pages/DashboardPage.tsx';
+
+describe('dashboard UI building blocks', () => {
+  it('renders asset previews from data returned by the API', () => {
+    const assets: ApiAssetPreview[] = [
+      {
+        id: 'asset-1',
+        label: 'hero.png',
+        relativePath: 'assets/images/hero.png',
+        type: 'image',
+        updatedAt: new Date('2024-06-01T10:00:00Z').toISOString(),
+      },
+      {
+        id: 'asset-2',
+        label: 'case-study.pdf',
+        relativePath: 'assets/docs/case-study.pdf',
+        type: 'document',
+        updatedAt: new Date('2024-06-02T12:00:00Z').toISOString(),
+      },
+    ];
+
+    const markup = renderToStaticMarkup(
+      <AssetPreviewList assets={assets} title="Assets (2)" />,
+    );
+
+    assert.match(markup, /hero\.png/);
+    assert.match(markup, /case-study\.pdf/);
+  });
+
+  it('renders deliverables and freshness indicators', () => {
+    const deliverables: ApiDeliverablePreview[] = [
+      {
+        id: 'del-1',
+        label: 'final.zip',
+        relativePath: 'deliverables/final.zip',
+        format: 'zip',
+        updatedAt: new Date('2024-07-01T08:00:00Z').toISOString(),
+      },
+    ];
+
+    const project: ApiProject = {
+      id: 'proj-1',
+      slug: 'proj-1',
+      title: 'Filesystem bridge',
+      summary: 'Sync demo',
+      organization: 'Acme',
+      workType: 'Design',
+      year: 2024,
+      tags: ['sync'],
+      highlights: ['bridge'],
+      syncStatus: 'clean',
+      lastSyncedAt: new Date('2024-07-04T10:00:00Z').toISOString(),
+      fsLastModified: new Date('2024-07-05T12:00:00Z').toISOString(),
+      metadataUpdatedAt: null,
+      briefUpdatedAt: null,
+      assetCount: 2,
+      deliverableCount: 1,
+      assetPreviews: [],
+      deliverablePreviews: [],
+    };
+
+    const freshness = computeFreshness(project);
+    assert.strictEqual(freshness, 'filesystem-updated');
+
+    const badge = renderToStaticMarkup(<FreshnessBadge project={project} />);
+    assert.match(badge, /Filesystem newer/);
+
+    const listMarkup = renderToStaticMarkup(
+      <DeliverablePreviewList deliverables={deliverables} />,
+    );
+    assert.match(listMarkup, /final\.zip/);
+  });
+});

--- a/tests/projectSyncService.test.ts
+++ b/tests/projectSyncService.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  computeChecksum,
+  parseMetadata,
+  slugify,
+} from '../server/src/services/projectSyncService.ts';
+import ProjectSyncService from '../server/src/services/projectSyncService.ts';
+import type { ParsedMetadata as MetadataResponse } from '../server/src/types/projectSync.ts';
+
+type MutableProject = {
+  id: string;
+  folder: string;
+  title: string;
+  summary: string | null;
+  description: string | null;
+  organization: string | null;
+  workType: string | null;
+  year: number | null;
+  role: string | null;
+  seniority: string | null;
+  categories: string[];
+  skills: string[];
+  tools: string[];
+  tags: string[];
+  highlights: string[];
+  links: Record<string, unknown> | null;
+  nda: boolean | null;
+  coverImage: string | null;
+  caseProblem: string | null;
+  caseActions: string | null;
+  caseResults: string | null;
+  schemaVersion: string | null;
+  metadataChecksum: string | null;
+  briefChecksum: string | null;
+  metadataUpdatedAt: Date | null;
+  briefUpdatedAt: Date | null;
+  fsLastModified: Date | null;
+  lastSyncedAt: Date | null;
+  syncStatus: string;
+};
+
+describe('projectSyncService helpers', () => {
+  it('normalises metadata correctly', () => {
+    const result = parseMetadata({
+      title: '  Demo Project  ',
+      year: '2024',
+      categories: [' design ', '', 'ops'],
+      skills: 'ignored',
+      tags: ['UI', ''],
+      privacy: { nda: 1 },
+      case: { problem: ' Why? ', actions: 'How', results: '' },
+    } as unknown as Record<string, unknown>);
+
+    assert.strictEqual(result.title, 'Demo Project');
+    assert.strictEqual(result.year, 2024);
+    assert.deepEqual(result.categories, ['design', 'ops']);
+    assert.deepEqual(result.tags, ['UI']);
+    assert.strictEqual(result.nda, true);
+    assert.strictEqual(result.case?.problem, 'Why?');
+    assert.strictEqual(result.case?.results, undefined);
+  });
+
+  it('slugifies titles safely', () => {
+    assert.strictEqual(slugify('Hello World'), 'hello-world');
+    assert.strictEqual(slugify('  🚀 Launch Plan!  '), 'launch-plan');
+  });
+});
+
+describe('projectSyncService metadata updates', () => {
+  let tmpDir: string;
+  let projectDir: string;
+  let project: MutableProject;
+  let service: ProjectSyncService;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'portfolio-sync-test-'));
+    projectDir = path.join(tmpDir, 'demo-project');
+    await fs.mkdir(projectDir, { recursive: true });
+
+    const originalMetadata = {
+      schema_version: '2.0.0',
+      title: 'Demo Project',
+      categories: ['design'],
+      skills: ['research'],
+      tools: ['figma'],
+      tags: ['ux'],
+      highlights: ['shipped v1'],
+      privacy: { nda: false },
+      case: { problem: 'Slow funnel', actions: 'Redesign', results: 'Faster' },
+    };
+    await fs.writeFile(path.join(projectDir, 'metadata.json'), JSON.stringify(originalMetadata, null, 2));
+
+    const checksum = computeChecksum(JSON.stringify(originalMetadata, null, 2));
+
+    project = {
+      id: 'project-123',
+      folder: 'demo-project',
+      title: 'Demo Project',
+      summary: 'Summary',
+      description: 'Summary',
+      organization: 'Acme',
+      workType: 'Design',
+      year: 2024,
+      role: 'Lead',
+      seniority: 'Senior',
+      categories: ['design'],
+      skills: ['research'],
+      tools: ['figma'],
+      tags: ['ux'],
+      highlights: ['shipped v1'],
+      links: {},
+      nda: false,
+      coverImage: null,
+      caseProblem: 'Slow funnel',
+      caseActions: 'Redesign',
+      caseResults: 'Faster',
+      schemaVersion: '2.0.0',
+      metadataChecksum: checksum,
+      briefChecksum: null,
+      metadataUpdatedAt: null,
+      briefUpdatedAt: null,
+      fsLastModified: null,
+      lastSyncedAt: null,
+      syncStatus: 'clean',
+    };
+
+    const fakePrisma = {
+      project: {
+        findUnique: async () => ({ ...project }),
+        update: async ({ data }: { data: Partial<MutableProject> }) => {
+          project = { ...project, ...data };
+          return { ...project };
+        },
+      },
+    } as const;
+
+    service = new ProjectSyncService(fakePrisma as any, { projectRoot: tmpDir });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects metadata checksum conflicts', async () => {
+    await assert.rejects(
+      service.updateMetadata({
+        projectId: project.id,
+        metadata: {
+          title: 'Updated title',
+          summary: 'Updated summary',
+          categories: ['design'],
+          skills: [],
+          tools: [],
+          tags: [],
+          highlights: [],
+        } as MetadataResponse,
+        expectedChecksum: 'different-checksum',
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /conflict/i);
+        assert.ok((error as { conflict?: unknown }).conflict);
+        return true;
+      },
+    );
+  });
+
+  it('writes metadata changes to disk and updates checksum', async () => {
+    const updated = await service.updateMetadata({
+      projectId: project.id,
+      metadata: {
+        title: 'Updated project',
+        summary: 'New summary',
+        categories: ['design', 'ux'],
+        skills: ['leadership'],
+        tools: ['figma'],
+        tags: ['ux'],
+        highlights: ['launched beta'],
+        case: { problem: 'Old problem', actions: 'New actions', results: 'New results' },
+      } as MetadataResponse,
+      expectedChecksum: project.metadataChecksum ?? undefined,
+    });
+
+    const disk = await fs.readFile(path.join(projectDir, 'metadata.json'), 'utf8');
+    assert.match(disk, /"Updated project"/);
+    assert.match(disk, /"launched beta"/);
+
+    assert.strictEqual(updated.title, 'Updated project');
+    assert.deepStrictEqual(project.categories, ['design', 'ux']);
+    assert.ok(project.metadataChecksum);
+    assert.notStrictEqual(project.metadataChecksum, null);
+  });
+});

--- a/tests/projectsTree.test.ts
+++ b/tests/projectsTree.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+describe('projects/ directory health', () => {
+  it('ensures every project folder contains metadata.json and brief.md', async () => {
+    const projectsRoot = path.resolve('projects');
+    const entries = await fs.readdir(projectsRoot, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) {
+        continue;
+      }
+
+      const metadataPath = path.join(projectsRoot, entry.name, 'metadata.json');
+      const briefPath = path.join(projectsRoot, entry.name, 'brief.md');
+
+      try {
+        await fs.access(metadataPath);
+      } catch {
+        assert.fail(`Missing metadata.json in projects/${entry.name}`);
+      }
+
+      try {
+        await fs.access(briefPath);
+      } catch {
+        assert.fail(`Missing brief.md in projects/${entry.name}`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Prisma models and a filesystem sync service with CLI, scheduler, and REST endpoints for projects/assets/deliverables
- replace the dashboard with API-driven data, asset previews, metadata/brief editors, and zip import/export utilities
- document the workflow, mount the projects volume in docker-compose, and add tests validating parsing, conflicts, UI rendering, and tree health

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6a4d5b10832fae06195ee305e2e9