### PR TITLE
Integrate GrapesJS editors for case studies and portfolio

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import NewEditorPage from './pages/NewEditorPage'
 import SettingsPage from './pages/SettingsPage'
 import PortfolioForgeAIAnalysis from './pages/PortfolioForgeAIAnalysis'
 import OpenAISettingsPage from './pages/OpenAISettingsPage'
+import PortfolioEditorPage from './pages/PortfolioEditorPage'
+import PortfolioPage from './pages/PortfolioPage'
 // Legacy pages for backward compatibility
 import IntakePage from './pages/IntakePage'
 import EditorPage from './pages/EditorPage'
@@ -24,6 +26,8 @@ function App() {
           <Route path="/create" element={<NewIntakePage />} />
           <Route path="/editor/:projectId" element={<NewEditorPage />} />
           <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/portfolio" element={<PortfolioPage />} />
+          <Route path="/portfolio/editor" element={<PortfolioEditorPage />} />
 
           {/* AI Analysis route */}
           <Route path="/analysis" element={<PortfolioForgeAIAnalysis />} />

--- a/src/components/GrapesJSEditor.tsx
+++ b/src/components/GrapesJSEditor.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useRef, useState } from 'react'
+import type { GrapesBlockDefinition, GrapesEditor } from '../types/grapes'
+import { ensureGrapesJS } from '../utils/grapesLoader'
+
+type GrapesDocument = {
+  html: string
+  css: string
+}
+
+type GrapesJSEditorProps = {
+  initialHtml: string
+  initialCss: string
+  blocks?: GrapesBlockDefinition[]
+  onChange?: (document: GrapesDocument) => void
+  onEditorReady?: (editor: GrapesEditor) => void
+  height?: string
+  className?: string
+}
+
+const DEFAULT_DEVICES = [
+  { name: 'Desktop', width: '' },
+  { name: 'Tablet', width: '768px' },
+  { name: 'Mobile', width: '375px' },
+]
+
+const GrapesJSEditor: React.FC<GrapesJSEditorProps> = ({
+  initialHtml,
+  initialCss,
+  blocks,
+  onChange,
+  onEditorReady,
+  height = '100%',
+  className,
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const editorRef = useRef<GrapesEditor | null>(null)
+  const changeHandlerRef = useRef(onChange)
+
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    changeHandlerRef.current = onChange
+  }, [onChange])
+
+  useEffect(() => {
+    let cancelled = false
+    let editorInstance: GrapesEditor | null = null
+
+    const initialise = async () => {
+      if (!containerRef.current) {
+        return
+      }
+
+      try {
+        const grapes = await ensureGrapesJS()
+        if (cancelled || !containerRef.current) {
+          return
+        }
+
+        editorInstance = grapes.init({
+          container: containerRef.current,
+          height,
+          width: 'auto',
+          fromElement: false,
+          storageManager: { type: null },
+          deviceManager: {
+            devices: DEFAULT_DEVICES,
+          },
+        })
+
+        editorRef.current = editorInstance
+        editorInstance.setComponents(initialHtml)
+        editorInstance.setStyle(initialCss)
+
+        if (blocks && blocks.length > 0) {
+          blocks.forEach(block => {
+            if (!editorInstance!.BlockManager.get(block.id)) {
+              editorInstance!.BlockManager.add(block.id, {
+                label: block.label,
+                content: block.content,
+                category: block.category,
+                media: block.media,
+              })
+            }
+          })
+        }
+
+        onEditorReady?.(editorInstance)
+
+        const handleUpdate = () => {
+          const handler = changeHandlerRef.current
+          if (!handler) {
+            return
+          }
+          handler({
+            html: editorInstance!.getHtml(),
+            css: editorInstance!.getCss(),
+          })
+        }
+
+        editorInstance.on('update', handleUpdate)
+        handleUpdate()
+      } catch (err) {
+        console.error('Failed to initialise GrapesJS', err)
+        setError(err instanceof Error ? err.message : 'Failed to load editor')
+      }
+    }
+
+    void initialise()
+
+    return () => {
+      cancelled = true
+      if (editorInstance) {
+        editorInstance.destroy()
+      } else if (editorRef.current) {
+        editorRef.current.destroy()
+        editorRef.current = null
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor || !blocks || blocks.length === 0) {
+      return
+    }
+
+    blocks.forEach(block => {
+      if (!editor.BlockManager.get(block.id)) {
+        editor.BlockManager.add(block.id, {
+          label: block.label,
+          content: block.content,
+          category: block.category,
+          media: block.media,
+        })
+      }
+    })
+  }, [blocks])
+
+  if (error) {
+    return (
+      <div
+        className={`flex h-full items-center justify-center rounded-xl border border-dashed border-red-300 bg-red-50 p-6 text-sm text-red-600 ${
+          className ?? ''
+        }`}
+      >
+        {error}
+      </div>
+    )
+  }
+
+  return <div ref={containerRef} className={className} style={{ height, width: '100%' }} />
+}
+
+export default GrapesJSEditor

--- a/src/intake/schema.ts
+++ b/src/intake/schema.ts
@@ -142,6 +142,8 @@ export type ProjectMeta = {
   updatedAt?: string
   assets: ProjectAsset[]
   layout?: ProjectLayoutBlock[]
+  caseStudyHtml?: string
+  caseStudyCss?: string
 
   // AI Integration
   autoGenerateNarrative?: boolean

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -595,6 +595,18 @@ const DashboardPage: React.FC = () => {
               >
                 Settings
               </Link>
+              <Link
+                to="/portfolio"
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+              >
+                Portfolio
+              </Link>
+              <Link
+                to="/portfolio/editor"
+                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-purple-700"
+              >
+                Portfolio editor
+              </Link>
             </div>
           </div>
           {(importMessage || importError) && (

--- a/src/pages/NewEditorPage.tsx
+++ b/src/pages/NewEditorPage.tsx
@@ -1,777 +1,286 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react';
-import {
-  Plus, Trash2, Move, Type, Image, Grid, Layout, Palette, Save, Eye, Undo, Redo,
-  Settings, Copy, AlignLeft, AlignCenter, AlignRight, Bold, Italic, Underline,
-  Upload, RotateCw, Crop, ZoomIn, ZoomOut, GripVertical, ChevronUp, ChevronDown,
-  Edit3, List, ListOrdered, MousePointer, Square, Menu, X, Smartphone,
-  Monitor, Tablet, Play, Camera, Video, Share2, Heart, MessageCircle, Send,
-  Bookmark, Globe, Code, Layers, Maximize, Info, FileText, Book, Printer,
-  ChevronLeft, ChevronRight, Download, Folder, PanelLeftOpen, RefreshCw,
-  Paintbrush, Sliders, Zap, ArrowLeft
-} from 'lucide-react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ArrowLeft, Loader2, RefreshCw, Save } from 'lucide-react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import GrapesJSEditor from '../components/GrapesJSEditor'
+import type { GrapesEditor } from '../types/grapes'
+import type { CaseStudyDocument } from '../utils/caseStudyTemplates'
+import { buildCaseStudyTemplate, createCaseStudyBlocks } from '../utils/caseStudyTemplates'
+import { loadProject, saveProject } from '../utils/storageManager'
+import type { ProjectMeta } from '../intake/schema'
+import { newProject, projectRoleLabels } from '../intake/schema'
 
-// Block Types
-const BLOCK_TYPES = {
-  TEXT: 'text',
-  IMAGE: 'image',
-  GRID: 'grid',
-  SPACER: 'spacer',
-  BUTTON: 'button',
-  HEADING: 'heading',
-  GALLERY: 'gallery',
-  HERO: 'hero',
-  QUOTE: 'quote',
-  SOCIAL_POST: 'social_post',
-  SOCIAL_STORY: 'social_story',
-  SOCIAL_CAROUSEL: 'social_carousel',
-  WEBSITE_DESKTOP: 'website_desktop',
-  WEBSITE_MOBILE: 'website_mobile',
-  APP_MOBILE: 'app_mobile',
-  APP_DESKTOP: 'app_desktop',
-  PRINT_TRIFOLD: 'print_trifold',
-  PRINT_CATALOG: 'print_catalog',
-  PRINT_BOOK: 'print_book',
-  PRINT_POSTER: 'print_poster'
-};
+const formatTitleFromSlug = (slug: string): string =>
+  slug
+    .split(/[-_]+/)
+    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ')
 
-const NewEditorPage = () => {
-  const { projectId } = useParams();
-  const navigate = useNavigate();
-  const [isDarkMode, setIsDarkMode] = useState(false);
-  const [selectedBlock, setSelectedBlock] = useState(null);
-  const [isAddingBlock, setIsAddingBlock] = useState(false);
-  const [previewMode, setPreviewMode] = useState(false);
-  const [showMobileView, setShowMobileView] = useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const [propertiesPanelCollapsed, setPropertiesPanelCollapsed] = useState(false);
+const joinList = (values?: string[]): string =>
+  values && values.length > 0 ? values.join(', ') : 'Add details in project settings'
 
-  // Panel visibility states
-  const [showElementsPanel, setShowElementsPanel] = useState(true);
-  const [showStylePanel, setShowStylePanel] = useState(true);
-  const [showLayersPanel, setShowLayersPanel] = useState(true);
-  const [showAssetsPanel, setShowAssetsPanel] = useState(false);
-  const [showExportPanel, setShowExportPanel] = useState(false);
+type StatusMessage = { type: 'success' | 'error'; message: string }
 
-  const [blocks, setBlocks] = useState([
-    {
-      id: '1',
-      type: BLOCK_TYPES.HERO,
-      content: {
-        title: 'Portfolio Project',
-        subtitle: 'Showcase your best work',
-        backgroundImage: '',
-        textColor: '#ffffff'
-      },
-      style: {
-        backgroundColor: '#5a3cf4',
-        minHeight: '400px',
-        padding: '80px 40px'
+const buildInitialDocument = (project: ProjectMeta): { initial: CaseStudyDocument; template: CaseStudyDocument } => {
+  const template = buildCaseStudyTemplate(project)
+  const initial: CaseStudyDocument = {
+    html: project.caseStudyHtml ?? template.html,
+    css: project.caseStudyCss ?? template.css,
+  }
+  return { initial, template }
+}
+
+const NewEditorPage: React.FC = () => {
+  const { projectId } = useParams<{ projectId: string }>()
+  const navigate = useNavigate()
+
+  const editorRef = useRef<GrapesEditor | null>(null)
+
+  const [project, setProject] = useState<ProjectMeta | null>(null)
+  const [initialDoc, setInitialDoc] = useState<CaseStudyDocument | null>(null)
+  const [caseStudyDoc, setCaseStudyDoc] = useState<CaseStudyDocument | null>(null)
+  const [templateDoc, setTemplateDoc] = useState<CaseStudyDocument | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [status, setStatus] = useState<StatusMessage | null>(null)
+
+  const loadProjectData = useCallback(async () => {
+    if (!projectId) {
+      setIsLoading(false)
+      setProject(null)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      let existing = await loadProject(projectId)
+      if (!existing) {
+        const title = formatTitleFromSlug(projectId)
+        const created = newProject(title)
+        created.slug = projectId
+        created.title = title
+        const { template } = buildInitialDocument(created)
+        created.caseStudyHtml = template.html
+        created.caseStudyCss = template.css
+        await saveProject(created)
+        existing = created
       }
-    },
-    {
-      id: '2',
-      type: BLOCK_TYPES.TEXT,
-      content: {
-        text: 'This is a sample text block. You can edit this content and style it however you like.',
-        fontSize: '16px',
-        fontWeight: 'normal',
-        textAlign: 'left'
-      },
-      style: {
-        padding: '40px'
+
+      const { initial, template } = buildInitialDocument(existing)
+      setProject(existing)
+      setInitialDoc(initial)
+      setCaseStudyDoc(initial)
+      setTemplateDoc(template)
+    } catch (error) {
+      console.error('Failed to load project for editor', error)
+      setStatus({ type: 'error', message: 'Unable to load project data. Return to the dashboard and try again.' })
+    } finally {
+      setIsLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => {
+    void loadProjectData()
+  }, [loadProjectData])
+
+  useEffect(() => {
+    if (!status) {
+      return
+    }
+    const timeout = window.setTimeout(() => setStatus(null), 3600)
+    return () => window.clearTimeout(timeout)
+  }, [status])
+
+  const blocks = useMemo(() => (project ? createCaseStudyBlocks(project) : []), [project])
+
+  const handleEditorReady = useCallback((editor: GrapesEditor) => {
+    editorRef.current = editor
+  }, [])
+
+  const handleEditorChange = useCallback((doc: CaseStudyDocument) => {
+    setCaseStudyDoc(doc)
+  }, [])
+
+  const handleReset = useCallback(() => {
+    if (!templateDoc) {
+      return
+    }
+    if (editorRef.current) {
+      editorRef.current.setComponents(templateDoc.html)
+      editorRef.current.setStyle(templateDoc.css)
+    }
+    setCaseStudyDoc(templateDoc)
+    setStatus({ type: 'success', message: 'Case study reset to the starter template.' })
+  }, [templateDoc])
+
+  const handleSave = useCallback(async () => {
+    if (!project || !caseStudyDoc) {
+      return
+    }
+    setIsSaving(true)
+    try {
+      const updated: ProjectMeta = {
+        ...project,
+        caseStudyHtml: caseStudyDoc.html,
+        caseStudyCss: caseStudyDoc.css,
+        updatedAt: new Date().toISOString(),
       }
+      await saveProject(updated)
+      setProject(updated)
+      setStatus({ type: 'success', message: 'Case study saved locally.' })
+    } catch (error) {
+      console.error('Failed to save case study', error)
+      setStatus({ type: 'error', message: 'Save failed. Check storage quota or try again.' })
+    } finally {
+      setIsSaving(false)
     }
-  ]);
+  }, [caseStudyDoc, project])
 
-  const blockCategories = [
-    {
-      name: 'Basic',
-      blocks: [
-        { type: BLOCK_TYPES.TEXT, icon: Type, name: 'Text', description: 'Paragraph text' },
-        { type: BLOCK_TYPES.HEADING, icon: Type, name: 'Heading', description: 'Section heading' },
-        { type: BLOCK_TYPES.IMAGE, icon: Image, name: 'Image', description: 'Single image' },
-        { type: BLOCK_TYPES.BUTTON, icon: Square, name: 'Button', description: 'Call to action' },
-        { type: BLOCK_TYPES.SPACER, icon: Menu, name: 'Spacer', description: 'Empty space' }
-      ]
-    },
-    {
-      name: 'Layout',
-      blocks: [
-        { type: BLOCK_TYPES.GRID, icon: Grid, name: 'Grid', description: 'Multi-column layout' },
-        { type: BLOCK_TYPES.GALLERY, icon: Image, name: 'Gallery', description: 'Image gallery' },
-        { type: BLOCK_TYPES.HERO, icon: Maximize, name: 'Hero', description: 'Large banner section' }
-      ]
-    },
-    {
-      name: 'Social Media',
-      blocks: [
-        { type: BLOCK_TYPES.SOCIAL_POST, icon: MessageCircle, name: 'Social Post', description: 'Instagram/Twitter post' },
-        { type: BLOCK_TYPES.SOCIAL_STORY, icon: Smartphone, name: 'Story', description: 'Instagram story' },
-        { type: BLOCK_TYPES.SOCIAL_CAROUSEL, icon: ChevronRight, name: 'Carousel', description: 'Swipeable content' }
-      ]
-    },
-    {
-      name: 'Mockups',
-      blocks: [
-        { type: BLOCK_TYPES.WEBSITE_DESKTOP, icon: Monitor, name: 'Desktop Website', description: 'Desktop browser mockup' },
-        { type: BLOCK_TYPES.WEBSITE_MOBILE, icon: Smartphone, name: 'Mobile Website', description: 'Mobile browser mockup' },
-        { type: BLOCK_TYPES.APP_MOBILE, icon: Smartphone, name: 'Mobile App', description: 'Mobile app mockup' },
-        { type: BLOCK_TYPES.APP_DESKTOP, icon: Monitor, name: 'Desktop App', description: 'Desktop app mockup' }
-      ]
-    },
-    {
-      name: 'Print',
-      blocks: [
-        { type: BLOCK_TYPES.PRINT_POSTER, icon: FileText, name: 'Poster', description: 'Print poster layout' },
-        { type: BLOCK_TYPES.PRINT_TRIFOLD, icon: Book, name: 'Trifold', description: 'Trifold brochure' },
-        { type: BLOCK_TYPES.PRINT_CATALOG, icon: Book, name: 'Catalog', description: 'Product catalog' },
-        { type: BLOCK_TYPES.PRINT_BOOK, icon: Book, name: 'Book', description: 'Book/magazine layout' }
-      ]
+  const previewMarkup = useMemo(() => {
+    if (!caseStudyDoc) {
+      return ''
     }
-  ];
+    return `<style>${caseStudyDoc.css}</style>${caseStudyDoc.html}`
+  }, [caseStudyDoc])
 
-  const addBlock = (blockType) => {
-    const newBlock = {
-      id: Date.now().toString(),
-      type: blockType,
-      content: getDefaultContent(blockType),
-      style: getDefaultStyle(blockType)
-    };
-    setBlocks(prev => [...prev, newBlock]);
-    setSelectedBlock(newBlock.id);
-    setIsAddingBlock(false);
-  };
-
-  const getDefaultContent = (blockType) => {
-    switch (blockType) {
-      case BLOCK_TYPES.TEXT:
-        return { text: 'Enter your text here...', fontSize: '16px', fontWeight: 'normal', textAlign: 'left' };
-      case BLOCK_TYPES.HEADING:
-        return { text: 'Heading Text', fontSize: '32px', fontWeight: 'bold', textAlign: 'left' };
-      case BLOCK_TYPES.IMAGE:
-        return { src: '', alt: '', caption: '' };
-      case BLOCK_TYPES.BUTTON:
-        return { text: 'Click me', link: '', style: 'primary' };
-      case BLOCK_TYPES.HERO:
-        return { title: 'Hero Title', subtitle: 'Hero subtitle', backgroundImage: '', textColor: '#ffffff' };
-      default:
-        return {};
-    }
-  };
-
-  const getDefaultStyle = (blockType) => {
-    switch (blockType) {
-      case BLOCK_TYPES.HERO:
-        return { backgroundColor: '#5a3cf4', minHeight: '400px', padding: '80px 40px' };
-      case BLOCK_TYPES.SPACER:
-        return { height: '60px' };
-      default:
-        return { padding: '20px' };
-    }
-  };
-
-  const deleteBlock = (blockId) => {
-    setBlocks(prev => prev.filter(block => block.id !== blockId));
-    setSelectedBlock(null);
-  };
-
-  const duplicateBlock = (blockId) => {
-    const block = blocks.find(b => b.id === blockId);
-    if (block) {
-      const newBlock = {
-        ...block,
-        id: Date.now().toString()
-      };
-      const blockIndex = blocks.findIndex(b => b.id === blockId);
-      setBlocks(prev => [...prev.slice(0, blockIndex + 1), newBlock, ...prev.slice(blockIndex + 1)]);
-    }
-  };
-
-  const moveBlock = (blockId, direction) => {
-    const blockIndex = blocks.findIndex(b => b.id === blockId);
-    if (blockIndex === -1) return;
-
-    const newBlocks = [...blocks];
-    if (direction === 'up' && blockIndex > 0) {
-      [newBlocks[blockIndex], newBlocks[blockIndex - 1]] = [newBlocks[blockIndex - 1], newBlocks[blockIndex]];
-    } else if (direction === 'down' && blockIndex < blocks.length - 1) {
-      [newBlocks[blockIndex], newBlocks[blockIndex + 1]] = [newBlocks[blockIndex + 1], newBlocks[blockIndex]];
-    }
-    setBlocks(newBlocks);
-  };
-
-  const renderBlock = (block) => {
-    switch (block.type) {
-      case BLOCK_TYPES.HERO:
-        return (
-          <div
-            className="hero-block"
-            style={{
-              ...block.style,
-              backgroundImage: block.content.backgroundImage ? `url(${block.content.backgroundImage})` : 'none',
-              backgroundSize: 'cover',
-              backgroundPosition: 'center',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'center',
-              textAlign: 'center',
-              color: block.content.textColor
-            }}
-          >
-            <h1 style={{ fontSize: '48px', fontWeight: 'bold', marginBottom: '16px' }}>
-              {block.content.title}
-            </h1>
-            <p style={{ fontSize: '20px', opacity: 0.9 }}>
-              {block.content.subtitle}
-            </p>
-          </div>
-        );
-
-      case BLOCK_TYPES.TEXT:
-        return (
-          <div style={block.style}>
-            <p style={{
-              fontSize: block.content.fontSize,
-              fontWeight: block.content.fontWeight,
-              textAlign: block.content.textAlign,
-              margin: 0
-            }}>
-              {block.content.text}
-            </p>
-          </div>
-        );
-
-      case BLOCK_TYPES.HEADING:
-        return (
-          <div style={block.style}>
-            <h2 style={{
-              fontSize: block.content.fontSize,
-              fontWeight: block.content.fontWeight,
-              textAlign: block.content.textAlign,
-              margin: 0
-            }}>
-              {block.content.text}
-            </h2>
-          </div>
-        );
-
-      case BLOCK_TYPES.IMAGE:
-        return (
-          <div style={block.style}>
-            {block.content.src ? (
-              <img
-                src={block.content.src}
-                alt={block.content.alt}
-                style={{ width: '100%', height: 'auto', borderRadius: '8px' }}
-              />
-            ) : (
-              <div className={`flex items-center justify-center h-48 rounded-lg border-2 border-dashed ${
-                isDarkMode ? 'border-gray-600 bg-gray-800' : 'border-gray-300 bg-gray-100'
-              }`}>
-                <div className="text-center">
-                  <Image size={48} className="mx-auto mb-2 text-gray-400" />
-                  <p className="text-gray-500">Click to add image</p>
-                </div>
-              </div>
-            )}
-            {block.content.caption && (
-              <p className="text-sm text-gray-600 mt-2 text-center">{block.content.caption}</p>
-            )}
-          </div>
-        );
-
-      case BLOCK_TYPES.BUTTON:
-        return (
-          <div style={block.style}>
-            <button className={`px-6 py-3 rounded-lg font-medium ${
-              block.content.style === 'primary'
-                ? 'bg-purple-600 text-white hover:bg-purple-700'
-                : 'border border-purple-600 text-purple-600 hover:bg-purple-50'
-            }`}>
-              {block.content.text}
-            </button>
-          </div>
-        );
-
-      case BLOCK_TYPES.SPACER:
-        return <div style={block.style}></div>;
-
-      default:
-        return (
-          <div style={block.style} className={`border-2 border-dashed ${
-            isDarkMode ? 'border-gray-600 bg-gray-800' : 'border-gray-300 bg-gray-100'
-          } flex items-center justify-center min-h-[120px]`}>
-            <p className="text-gray-500">Block type: {block.type}</p>
-          </div>
-        );
-    }
-  };
+  const handleBack = () => {
+    navigate('/dashboard')
+  }
 
   return (
-    <div className={`h-screen flex transition-colors duration-200 ${
-      isDarkMode ? 'dark bg-gray-900 text-white' : 'bg-gray-50 text-gray-900'
-    }`}>
-      {/* Left Sidebar - Elements and Tools */}
-      <div className={`transition-all duration-300 ${sidebarCollapsed ? 'w-16' : 'w-80'} ${
-        isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
-      } border-r flex flex-col`}>
-        {/* Sidebar Header */}
-        <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex items-center justify-between">
-            {!sidebarCollapsed && (
-              <div className="flex items-center gap-3">
-                <Link
-                  to="/dashboard"
-                  className={`p-2 rounded-lg transition-colors ${
-                    isDarkMode
-                      ? 'hover:bg-gray-700 text-gray-400 hover:text-white'
-                      : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                  }`}
-                >
-                  <ArrowLeft size={16} />
-                </Link>
-                <div>
-                  <h2 className="font-semibold">Project Editor</h2>
-                  <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                    {projectId}
-                  </p>
-                </div>
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <header className="border-b bg-white">
+        <div className="mx-auto max-w-7xl px-6 py-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={handleBack}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to dashboard
+              </button>
+              <div>
+                <h1 className="text-xl font-semibold">Case study editor</h1>
+                <p className="text-sm text-gray-500">
+                  Craft a narrative for <span className="font-medium text-gray-700">{project?.title ?? 'your project'}</span> using the visual builder.
+                </p>
               </div>
-            )}
-            <button
-              onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-              className={`p-2 rounded-lg transition-colors ${
-                isDarkMode
-                  ? 'hover:bg-gray-700 text-gray-400 hover:text-white'
-                  : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Link
+                to="/portfolio"
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+              >
+                View portfolio
+              </Link>
+              <Link
+                to="/portfolio/editor"
+                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-purple-700"
+              >
+                Portfolio editor
+              </Link>
+              <button
+                type="button"
+                onClick={handleReset}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+                disabled={!templateDoc}
+              >
+                <RefreshCw className="h-4 w-4" />
+                Reset template
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-700 disabled:opacity-50"
+                disabled={isSaving || !caseStudyDoc}
+              >
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                Save case study
+              </button>
+            </div>
+          </div>
+          {status && (
+            <div
+              className={`mt-4 rounded-lg border px-4 py-3 text-sm ${
+                status.type === 'error'
+                  ? 'border-red-200 bg-red-50 text-red-600'
+                  : 'border-emerald-200 bg-emerald-50 text-emerald-700'
               }`}
             >
-              <PanelLeftOpen size={16} className={sidebarCollapsed ? 'rotate-180' : ''} />
-            </button>
-          </div>
-        </div>
-
-        {!sidebarCollapsed && (
-          <div className="flex-1 overflow-hidden">
-            {/* Tab Navigation */}
-            <div className="flex border-b border-gray-200 dark:border-gray-700">
-              {[
-                { key: 'elements', icon: Plus, label: 'Elements' },
-                { key: 'layers', icon: Layers, label: 'Layers' },
-                { key: 'assets', icon: Folder, label: 'Assets' }
-              ].map(({ key, icon: Icon, label }) => (
-                <button
-                  key={key}
-                  onClick={() => {
-                    setShowElementsPanel(key === 'elements');
-                    setShowLayersPanel(key === 'layers');
-                    setShowAssetsPanel(key === 'assets');
-                  }}
-                  className={`flex-1 px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
-                    (key === 'elements' && showElementsPanel) ||
-                    (key === 'layers' && showLayersPanel) ||
-                    (key === 'assets' && showAssetsPanel)
-                      ? 'border-purple-500 text-purple-600 dark:text-purple-400'
-                      : 'border-transparent hover:text-gray-900 dark:hover:text-white'
-                  }`}
-                >
-                  <Icon size={16} className="mx-auto mb-1" />
-                  <div>{label}</div>
-                </button>
-              ))}
+              {status.message}
             </div>
+          )}
+        </div>
+      </header>
 
-            {/* Panel Content */}
-            <div className="flex-1 overflow-y-auto p-4">
-              {/* Elements Panel */}
-              {showElementsPanel && (
-                <div className="space-y-6">
-                  {blockCategories.map((category) => (
-                    <div key={category.name}>
-                      <h3 className="text-sm font-semibold mb-3 text-gray-700 dark:text-gray-300">
-                        {category.name}
-                      </h3>
-                      <div className="grid grid-cols-2 gap-2">
-                        {category.blocks.map((block) => {
-                          const IconComponent = block.icon;
-                          return (
-                            <button
-                              key={block.type}
-                              onClick={() => addBlock(block.type)}
-                              className={`p-3 rounded-lg border transition-all hover:shadow-sm group ${
-                                isDarkMode
-                                  ? 'border-gray-700 bg-gray-750 hover:bg-gray-700'
-                                  : 'border-gray-200 bg-white hover:bg-gray-50'
-                              }`}
-                            >
-                              <IconComponent size={20} className="mx-auto mb-2 text-purple-600 dark:text-purple-400" />
-                              <div className="text-xs font-medium">{block.name}</div>
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {/* Layers Panel */}
-              {showLayersPanel && (
-                <div className="space-y-2">
-                  <h3 className="text-sm font-semibold mb-3 text-gray-700 dark:text-gray-300">
-                    Page Layers
-                  </h3>
-                  {blocks.map((block, index) => (
+      <main className="mx-auto max-w-7xl px-6 py-6 lg:py-10">
+        {isLoading || !project || !initialDoc ? (
+          <div className="flex h-[70vh] items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white">
+            <div className="flex items-center gap-2 text-sm text-gray-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading editor…
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+            <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+              <GrapesJSEditor
+                key={project.slug}
+                initialHtml={initialDoc.html}
+                initialCss={initialDoc.css}
+                blocks={blocks}
+                onChange={handleEditorChange}
+                onEditorReady={handleEditorReady}
+                height="calc(100vh - 240px)"
+              />
+            </section>
+            <aside className="flex flex-col gap-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+              <div className="space-y-3">
+                <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Live preview</h2>
+                <div className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+                  {caseStudyDoc ? (
                     <div
-                      key={block.id}
-                      className={`p-3 rounded-lg border cursor-pointer transition-all group ${
-                        selectedBlock === block.id
-                          ? 'border-purple-500 bg-purple-50 dark:bg-purple-950'
-                          : isDarkMode
-                            ? 'border-gray-700 bg-gray-750 hover:bg-gray-700'
-                            : 'border-gray-200 bg-white hover:bg-gray-50'
-                      }`}
-                      onClick={() => setSelectedBlock(block.id)}
-                    >
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <GripVertical size={14} className="text-gray-400" />
-                          <div className="text-sm font-medium">{block.type}</div>
-                        </div>
-                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              duplicateBlock(block.id);
-                            }}
-                            className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded"
-                          >
-                            <Copy size={12} />
-                          </button>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              deleteBlock(block.id);
-                            }}
-                            className="p-1 hover:bg-red-100 dark:hover:bg-red-900 text-red-600 rounded"
-                          >
-                            <Trash2 size={12} />
-                          </button>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-
-              {/* Assets Panel */}
-              {showAssetsPanel && (
-                <div className="space-y-4">
-                  <h3 className="text-sm font-semibold mb-3 text-gray-700 dark:text-gray-300">
-                    Project Assets
-                  </h3>
-
-                  <button className={`w-full p-4 border-2 border-dashed rounded-lg transition-colors ${
-                    isDarkMode
-                      ? 'border-gray-600 hover:border-gray-500 bg-gray-800'
-                      : 'border-gray-300 hover:border-gray-400 bg-gray-50'
-                  }`}>
-                    <Upload size={24} className="mx-auto mb-2 text-gray-400" />
-                    <div className="text-sm text-gray-600 dark:text-gray-400">Upload Assets</div>
-                  </button>
-
-                  <div className="grid grid-cols-2 gap-2">
-                    <div className={`aspect-square rounded-lg border ${
-                      isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'
-                    } flex items-center justify-center`}>
-                      <Image size={24} className="text-gray-400" />
-                    </div>
-                    <div className={`aspect-square rounded-lg border ${
-                      isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'
-                    } flex items-center justify-center`}>
-                      <Video size={24} className="text-gray-400" />
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Main Editor Area */}
-      <div className="flex-1 flex flex-col">
-        {/* Top Toolbar */}
-        <div className={`border-b ${
-          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
-        } px-6 py-3`}>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2">
-                <button className={`p-2 rounded-lg transition-colors ${
-                  isDarkMode
-                    ? 'hover:bg-gray-700 text-gray-400 hover:text-white'
-                    : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                }`}>
-                  <Undo size={16} />
-                </button>
-                <button className={`p-2 rounded-lg transition-colors ${
-                  isDarkMode
-                    ? 'hover:bg-gray-700 text-gray-400 hover:text-white'
-                    : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                }`}>
-                  <Redo size={16} />
-                </button>
-              </div>
-
-              <div className="h-6 w-px bg-gray-300 dark:bg-gray-600"></div>
-
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => setShowMobileView(false)}
-                  className={`p-2 rounded-lg transition-colors ${
-                    !showMobileView
-                      ? 'bg-purple-100 text-purple-600 dark:bg-purple-900 dark:text-purple-400'
-                      : isDarkMode
-                        ? 'hover:bg-gray-700 text-gray-400 hover:text-white'
-                        : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                  }`}
-                >
-                  <Monitor size={16} />
-                </button>
-                <button
-                  onClick={() => setShowMobileView(true)}
-                  className={`p-2 rounded-lg transition-colors ${
-                    showMobileView
-                      ? 'bg-purple-100 text-purple-600 dark:bg-purple-900 dark:text-purple-400'
-                      : isDarkMode
-                        ? 'hover:bg-gray-700 text-gray-400 hover:text-white'
-                        : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                  }`}
-                >
-                  <Smartphone size={16} />
-                </button>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setPreviewMode(!previewMode)}
-                className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                  previewMode
-                    ? 'bg-purple-600 text-white hover:bg-purple-700'
-                    : isDarkMode
-                      ? 'border border-gray-600 hover:bg-gray-700'
-                      : 'border border-gray-200 hover:bg-gray-50'
-                }`}
-              >
-                <Eye size={16} className="inline mr-2" />
-                {previewMode ? 'Exit Preview' : 'Preview'}
-              </button>
-
-              <button className="bg-purple-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-purple-700 transition-colors">
-                <Save size={16} className="inline mr-2" />
-                Save
-              </button>
-
-              <button className={`p-2 rounded-lg transition-colors ${
-                isDarkMode
-                  ? 'hover:bg-gray-700 text-gray-400 hover:text-white'
-                  : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-              }`}>
-                <Share2 size={16} />
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {/* Canvas Area */}
-        <div className="flex-1 overflow-auto p-8">
-          <div className="flex justify-center">
-            <div
-              className={`transition-all duration-300 ${
-                showMobileView ? 'max-w-sm' : 'max-w-4xl'
-              } w-full ${
-                isDarkMode ? 'bg-gray-800' : 'bg-white'
-              } shadow-xl rounded-lg overflow-hidden`}
-            >
-              {blocks.map((block) => (
-                <div
-                  key={block.id}
-                  className={`relative group ${
-                    selectedBlock === block.id && !previewMode
-                      ? 'ring-2 ring-purple-500 ring-inset'
-                      : ''
-                  }`}
-                  onClick={() => !previewMode && setSelectedBlock(block.id)}
-                >
-                  {renderBlock(block)}
-
-                  {selectedBlock === block.id && !previewMode && (
-                    <div className="absolute top-2 right-2 flex items-center gap-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-1 shadow-lg">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          moveBlock(block.id, 'up');
-                        }}
-                        className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-                      >
-                        <ChevronUp size={14} />
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          moveBlock(block.id, 'down');
-                        }}
-                        className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-                      >
-                        <ChevronDown size={14} />
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          duplicateBlock(block.id);
-                        }}
-                        className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
-                      >
-                        <Copy size={14} />
-                      </button>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          deleteBlock(block.id);
-                        }}
-                        className="p-1 hover:bg-red-100 dark:hover:bg-red-900 text-red-600 rounded"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </div>
+                      className="case-study-preview max-h-[60vh] overflow-y-auto rounded-lg bg-white p-4"
+                      dangerouslySetInnerHTML={{ __html: previewMarkup }}
+                    />
+                  ) : (
+                    <p className="text-sm text-gray-500">Begin editing to see the rendered case study.</p>
                   )}
                 </div>
-              ))}
-
-              {!previewMode && (
-                <div className="p-8 text-center border-t border-dashed border-gray-300 dark:border-gray-600">
-                  <button
-                    onClick={() => setIsAddingBlock(true)}
-                    className={`inline-flex items-center gap-2 px-6 py-3 rounded-lg border-2 border-dashed transition-colors ${
-                      isDarkMode
-                        ? 'border-gray-600 hover:border-gray-500 text-gray-400 hover:text-white'
-                        : 'border-gray-300 hover:border-gray-400 text-gray-600 hover:text-gray-900'
-                    }`}
-                  >
-                    <Plus size={20} />
-                    Add Block
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Right Properties Panel */}
-      {selectedBlock && !previewMode && !propertiesPanelCollapsed && (
-        <div className={`w-80 ${
-          isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-white border-gray-200'
-        } border-l flex flex-col`}>
-          <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold">Properties</h3>
-              <button
-                onClick={() => setPropertiesPanelCollapsed(true)}
-                className={`p-2 rounded-lg transition-colors ${
-                  isDarkMode
-                    ? 'hover:bg-gray-700 text-gray-400 hover:text-white'
-                    : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                <X size={16} />
-              </button>
-            </div>
-          </div>
-
-          <div className="flex-1 overflow-y-auto p-4">
-            <div className="space-y-6">
-              {/* Style Panel */}
-              <div>
-                <h4 className="text-sm font-semibold mb-3 text-gray-700 dark:text-gray-300">
-                  Styling
-                </h4>
-                <div className="space-y-4">
-                  <div>
-                    <label className="block text-sm font-medium mb-2">Padding</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="100"
-                      className="w-full"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-sm font-medium mb-2">Background Color</label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="color"
-                        className="w-8 h-8 rounded border"
-                        defaultValue="#ffffff"
-                      />
-                      <input
-                        type="text"
-                        className={`flex-1 px-3 py-2 rounded-lg border text-sm ${
-                          isDarkMode
-                            ? 'border-gray-600 bg-gray-700'
-                            : 'border-gray-200 bg-white'
-                        }`}
-                        defaultValue="#ffffff"
-                      />
-                    </div>
-                  </div>
-                </div>
               </div>
 
-              {/* Content Panel */}
-              <div>
-                <h4 className="text-sm font-semibold mb-3 text-gray-700 dark:text-gray-300">
-                  Content
-                </h4>
-                <div className="space-y-4">
-                  <div>
-                    <label className="block text-sm font-medium mb-2">Text Content</label>
-                    <textarea
-                      className={`w-full px-3 py-2 rounded-lg border text-sm resize-none ${
-                        isDarkMode
-                          ? 'border-gray-600 bg-gray-700'
-                          : 'border-gray-200 bg-white'
-                      }`}
-                      rows={3}
-                      placeholder="Enter text content..."
-                    />
+              <div className="space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Project details</h3>
+                <dl className="space-y-3 text-sm text-gray-600">
+                  <div className="flex justify-between gap-3">
+                    <dt className="text-gray-500">Project</dt>
+                    <dd className="text-right font-medium text-gray-700">{project.title}</dd>
                   </div>
-                </div>
+                  <div className="flex justify-between gap-3">
+                    <dt className="text-gray-500">Role</dt>
+                    <dd className="text-right text-gray-700">{projectRoleLabels[project.role] ?? project.role}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-gray-500">Summary</dt>
+                    <dd className="mt-1 text-gray-700">{project.summary || 'Add a summary in the project dashboard.'}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-gray-500">Tags</dt>
+                    <dd className="mt-1 text-gray-700">{joinList(project.tags)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-gray-500">Technologies</dt>
+                    <dd className="mt-1 text-gray-700">{joinList(project.technologies)}</dd>
+                  </div>
+                </dl>
               </div>
-            </div>
+            </aside>
           </div>
-        </div>
-      )}
-
-      {/* Collapsed Properties Panel Button */}
-      {propertiesPanelCollapsed && selectedBlock && !previewMode && (
-        <button
-          onClick={() => setPropertiesPanelCollapsed(false)}
-          className={`fixed right-4 top-1/2 transform -translate-y-1/2 p-3 rounded-lg shadow-lg transition-colors ${
-            isDarkMode
-              ? 'bg-gray-800 border border-gray-700 hover:bg-gray-700'
-              : 'bg-white border border-gray-200 hover:bg-gray-50'
-          }`}
-        >
-          <Settings size={20} />
-        </button>
-      )}
+        )}
+      </main>
     </div>
-  );
-};
+  )
+}
 
-export default NewEditorPage;
+export default NewEditorPage

--- a/src/pages/NewIntakePage.tsx
+++ b/src/pages/NewIntakePage.tsx
@@ -7,6 +7,9 @@ import {
   HelpCircle, BookOpen, Layout
 } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
+import { newProject } from '../intake/schema';
+import { buildCaseStudyTemplate } from '../utils/caseStudyTemplates';
+import { saveProject } from '../utils/storageManager';
 
 const NewIntakePage = () => {
   const navigate = useNavigate();
@@ -90,10 +93,25 @@ const NewIntakePage = () => {
     setActiveStep(3);
   };
 
-  const handleProjectSubmit = () => {
-    // Handle project creation and navigate to editor
-    console.log('Creating project:', formData);
-    navigate(`/editor/${formData.projectName.toLowerCase().replace(/\s+/g, '-')}`);
+  const handleProjectSubmit = async () => {
+    const title = formData.projectName.trim();
+    if (!title) {
+      return;
+    }
+
+    const project = newProject(title);
+    project.summary = formData.description.trim() || undefined;
+    project.problem = formData.description.trim();
+    project.solution = 'Use the editor to describe the approach, process, and collaboration.';
+    project.outcomes = 'Add measurable impact or learnings from the project in the editor.';
+    project.tags = Array.isArray(formData.tags) ? formData.tags : [];
+
+    const template = buildCaseStudyTemplate(project);
+    project.caseStudyHtml = template.html;
+    project.caseStudyCss = template.css;
+
+    await saveProject(project);
+    navigate(`/editor/${project.slug}`);
   };
 
   const selectedCategory = projectCategories.find(cat => cat.id === formData.category);

--- a/src/pages/PortfolioEditorPage.tsx
+++ b/src/pages/PortfolioEditorPage.tsx
@@ -1,0 +1,258 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ArrowLeft, Loader2, RefreshCw, Save } from 'lucide-react'
+import { Link, useNavigate } from 'react-router-dom'
+import GrapesJSEditor from '../components/GrapesJSEditor'
+import type { GrapesEditor } from '../types/grapes'
+import type { PortfolioDocument } from '../utils/portfolioTemplates'
+import { buildPortfolioTemplate, createPortfolioBlocks } from '../utils/portfolioTemplates'
+import { loadPortfolioDocument, savePortfolioDocument } from '../utils/portfolioStorage'
+import { listProjects } from '../utils/storageManager'
+import type { ProjectMeta } from '../intake/schema'
+
+type StatusMessage = { type: 'success' | 'error'; message: string }
+
+type StoredPortfolioDocument = NonNullable<ReturnType<typeof loadPortfolioDocument>>
+
+const PortfolioEditorPage: React.FC = () => {
+  const navigate = useNavigate()
+  const editorRef = useRef<GrapesEditor | null>(null)
+
+  const [projects, setProjects] = useState<ProjectMeta[]>([])
+  const [initialDoc, setInitialDoc] = useState<PortfolioDocument | null>(null)
+  const [templateDoc, setTemplateDoc] = useState<PortfolioDocument | null>(null)
+  const [document, setDocument] = useState<PortfolioDocument | null>(null)
+  const [storedDoc, setStoredDoc] = useState<StoredPortfolioDocument | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [status, setStatus] = useState<StatusMessage | null>(null)
+
+  const refreshProjects = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const loaded = await listProjects()
+      setProjects(loaded)
+      const template = buildPortfolioTemplate(loaded)
+      const saved = loadPortfolioDocument()
+      const initial = saved ? { html: saved.html, css: saved.css } : template
+      setTemplateDoc(template)
+      setInitialDoc(initial)
+      setDocument(initial)
+      setStoredDoc(saved ?? null)
+    } catch (error) {
+      console.error('Failed to load projects for portfolio editor', error)
+      setStatus({ type: 'error', message: 'Unable to load projects. Ensure projects are saved locally before editing the portfolio.' })
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshProjects()
+  }, [refreshProjects])
+
+  useEffect(() => {
+    if (!status) {
+      return
+    }
+    const timeout = window.setTimeout(() => setStatus(null), 3600)
+    return () => window.clearTimeout(timeout)
+  }, [status])
+
+  const blocks = useMemo(() => createPortfolioBlocks(projects), [projects])
+
+  const editorKey = useMemo(() => {
+    if (!initialDoc) {
+      return 'portfolio-editor'
+    }
+    return `portfolio-editor-${initialDoc.html.length}-${initialDoc.css.length}`
+  }, [initialDoc])
+
+  const handleEditorReady = useCallback((editor: GrapesEditor) => {
+    editorRef.current = editor
+  }, [])
+
+  const handleEditorChange = useCallback((doc: PortfolioDocument) => {
+    setDocument(doc)
+  }, [])
+
+  const handleSave = useCallback(() => {
+    if (!document) {
+      return
+    }
+    setIsSaving(true)
+    try {
+      savePortfolioDocument(document)
+      setStoredDoc({ html: document.html, css: document.css, updatedAt: new Date().toISOString() })
+      setStatus({ type: 'success', message: 'Portfolio saved locally.' })
+    } catch (error) {
+      console.error('Failed to save portfolio document', error)
+      setStatus({ type: 'error', message: 'Save failed. Ensure your browser allows local storage.' })
+    } finally {
+      setIsSaving(false)
+    }
+  }, [document])
+
+  const handleReset = useCallback(() => {
+    if (!templateDoc) {
+      return
+    }
+    if (editorRef.current) {
+      editorRef.current.setComponents(templateDoc.html)
+      editorRef.current.setStyle(templateDoc.css)
+    }
+    setDocument(templateDoc)
+    setStatus({ type: 'success', message: 'Portfolio reset to the generated template.' })
+  }, [templateDoc])
+
+  const projectStats = useMemo(() => {
+    const total = projects.length
+    const withCaseStudy = projects.filter(project => Boolean(project.caseStudyHtml)).length
+    return { total, withCaseStudy }
+  }, [projects])
+
+  const caseStudyList = useMemo(() => (
+    <ul className="divide-y divide-gray-200 border border-gray-200 rounded-xl">
+      {projects.length === 0 ? (
+        <li className="p-4 text-sm text-gray-500">No local projects found yet. Create a project to start building your portfolio.</li>
+      ) : (
+        projects.map(project => (
+          <li key={project.slug} className="flex flex-col gap-1 p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-semibold text-gray-800">{project.title}</span>
+              <span className={`text-xs font-medium uppercase tracking-[0.18em] ${
+                project.caseStudyHtml ? 'text-emerald-600' : 'text-orange-600'
+              }`}>
+                {project.caseStudyHtml ? 'Case study ready' : 'Needs narrative'}
+              </span>
+            </div>
+            <p className="text-sm text-gray-500">{project.summary || project.problem || 'Add a summary to this project.'}</p>
+          </li>
+        ))
+      )}
+    </ul>
+  ), [projects])
+
+  return (
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      <header className="border-b bg-white">
+        <div className="mx-auto max-w-7xl px-6 py-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={() => navigate('/dashboard')}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back to dashboard
+              </button>
+              <div>
+                <h1 className="text-xl font-semibold">Portfolio editor</h1>
+                <p className="text-sm text-gray-500">
+                  Arrange case studies into a shareable portfolio layout and publish when ready.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Link
+                to="/portfolio"
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+              >
+                View live portfolio
+              </Link>
+              <button
+                type="button"
+                onClick={handleReset}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+                disabled={!templateDoc}
+              >
+                <RefreshCw className="h-4 w-4" />
+                Reset layout
+              </button>
+              <button
+                type="button"
+                onClick={refreshProjects}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Refresh projects
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-700 disabled:opacity-50"
+                disabled={isSaving || !document}
+              >
+                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                Save portfolio
+              </button>
+            </div>
+          </div>
+          {status && (
+            <div
+              className={`mt-4 rounded-lg border px-4 py-3 text-sm ${
+                status.type === 'error'
+                  ? 'border-red-200 bg-red-50 text-red-600'
+                  : 'border-emerald-200 bg-emerald-50 text-emerald-700'
+              }`}
+            >
+              {status.message}
+            </div>
+          )}
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-6 py-6 lg:py-10">
+        {isLoading || !initialDoc ? (
+          <div className="flex h-[70vh] items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white">
+            <div className="flex items-center gap-2 text-sm text-gray-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading portfolio editor…
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+            <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+              <GrapesJSEditor
+                key={editorKey}
+                initialHtml={initialDoc.html}
+                initialCss={initialDoc.css}
+                blocks={blocks}
+                onChange={handleEditorChange}
+                onEditorReady={handleEditorReady}
+                height="calc(100vh - 240px)"
+              />
+            </section>
+            <aside className="flex flex-col gap-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+              <div className="space-y-2">
+                <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Portfolio health</h2>
+                <div className="grid grid-cols-2 gap-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-gray-500">Projects</p>
+                    <p className="text-xl font-semibold text-gray-800">{projectStats.total}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-gray-500">Case studies ready</p>
+                    <p className="text-xl font-semibold text-gray-800">{projectStats.withCaseStudy}</p>
+                  </div>
+                </div>
+                {storedDoc && (
+                  <p className="text-xs text-gray-500">
+                    Last saved {new Date(storedDoc.updatedAt).toLocaleString()}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-3">
+                <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Case studies</h3>
+                {caseStudyList}
+              </div>
+            </aside>
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default PortfolioEditorPage

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, Loader2, Pencil } from 'lucide-react'
+import { Link, useNavigate } from 'react-router-dom'
+import { buildPortfolioTemplate } from '../utils/portfolioTemplates'
+import { loadPortfolioDocument } from '../utils/portfolioStorage'
+import { listProjects } from '../utils/storageManager'
+import type { ProjectMeta } from '../intake/schema'
+
+type PortfolioViewDocument = { html: string; css: string }
+
+const PortfolioPage: React.FC = () => {
+  const navigate = useNavigate()
+  const [projects, setProjects] = useState<ProjectMeta[]>([])
+  const [document, setDocument] = useState<PortfolioViewDocument | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true)
+      try {
+        const loadedProjects = await listProjects()
+        setProjects(loadedProjects)
+        const saved = loadPortfolioDocument()
+        if (saved) {
+          setDocument({ html: saved.html, css: saved.css })
+        } else {
+          const generated = buildPortfolioTemplate(loadedProjects)
+          setDocument(generated)
+        }
+      } catch (err) {
+        console.error('Failed to load portfolio view', err)
+        setError('Unable to load portfolio content. Ensure projects are available locally.')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    void load()
+  }, [])
+
+  const markup = useMemo(() => {
+    if (!document) {
+      return ''
+    }
+    return `<style>${document.css}</style>${document.html}`
+  }, [document])
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-4">
+            <button
+              type="button"
+              onClick={() => navigate('/dashboard')}
+              className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-200 transition hover:bg-slate-800"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Dashboard
+            </button>
+            <div>
+              <h1 className="text-xl font-semibold text-white">Portfolio</h1>
+              <p className="text-sm text-slate-400">A generated view of your saved projects and case studies.</p>
+            </div>
+          </div>
+          <Link
+            to="/portfolio/editor"
+            className="inline-flex items-center gap-2 rounded-lg bg-purple-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-600"
+          >
+            <Pencil className="h-4 w-4" />
+            Edit portfolio
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-4 py-10">
+        {isLoading ? (
+          <div className="flex h-[60vh] items-center justify-center rounded-2xl border border-dashed border-slate-700 bg-slate-900/40">
+            <div className="flex items-center gap-2 text-sm text-slate-400">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Preparing portfolio…
+            </div>
+          </div>
+        ) : error ? (
+          <div className="rounded-2xl border border-red-400 bg-red-500/10 p-6 text-red-200">
+            {error}
+          </div>
+        ) : document ? (
+          <div
+            className="portfolio-render rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-2xl"
+            dangerouslySetInnerHTML={{ __html: markup }}
+          />
+        ) : (
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-6 text-sm text-slate-300">
+            No portfolio content yet. Create a project and craft a case study to populate this page.
+          </div>
+        )}
+
+        {!isLoading && projects.length === 0 && (
+          <div className="mt-6 rounded-xl border border-slate-800 bg-slate-900/60 p-5 text-sm text-slate-300">
+            Tip: Start by creating a project from the dashboard. The editor will generate a starter case study for you.
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default PortfolioPage

--- a/src/types/grapes.ts
+++ b/src/types/grapes.ts
@@ -1,0 +1,71 @@
+export type GrapesBlockDefinition = {
+  id: string;
+  label: string;
+  category?: string;
+  content: string;
+  media?: string;
+};
+
+export type GrapesEditorCommand = {
+  run?: (editor: GrapesEditor) => void;
+  stop?: (editor: GrapesEditor) => void;
+};
+
+export type GrapesPanelButton = {
+  id: string;
+  label?: string;
+  command?: string;
+  className?: string;
+  togglable?: boolean;
+  active?: boolean;
+  attributes?: Record<string, string>;
+};
+
+export interface GrapesEditor {
+  getHtml(): string;
+  getCss(): string;
+  setComponents(html: string): void;
+  setStyle(css: string): void;
+  on(event: string, callback: () => void): void;
+  destroy(): void;
+  BlockManager: {
+    add(id: string, options: {
+      label: string;
+      content: string;
+      category?: string;
+      media?: string;
+      attributes?: Record<string, string>;
+    }): void;
+    get(id: string): unknown;
+  };
+  Panels: {
+    addButton(panelId: string, button: GrapesPanelButton): void;
+  };
+  Commands: {
+    add(commandId: string, command: GrapesEditorCommand): void;
+  };
+  DeviceManager: {
+    add(name: string, options: { name: string; width: string }): void;
+    select(name: string): void;
+  };
+}
+
+export interface GrapesNamespace {
+  init(config: {
+    container: HTMLElement;
+    height?: string;
+    width?: string;
+    fromElement?: boolean;
+    storageManager?: false | { type?: null };
+    deviceManager?: { devices?: Array<{ name: string; width: string }> };
+    canvas?: { styles?: string[]; scripts?: string[] };
+  }): GrapesEditor;
+}
+
+declare global {
+  interface Window {
+    grapesjs?: GrapesNamespace;
+  }
+}
+
+export {}

--- a/src/utils/caseStudyTemplates.ts
+++ b/src/utils/caseStudyTemplates.ts
@@ -1,0 +1,577 @@
+import type { ProjectAsset, ProjectMeta } from '../intake/schema'
+import { projectRoleLabels } from '../intake/schema'
+import type { GrapesBlockDefinition } from '../types/grapes'
+
+export type CaseStudyDocument = {
+  html: string
+  css: string
+}
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+const formatParagraphs = (value: string, fallback: string): string => {
+  const content = value && value.trim().length > 0 ? value : fallback
+  return content
+    .split(/\n+/)
+    .map(paragraph => `<p>${escapeHtml(paragraph.trim())}</p>`)
+    .join('')
+}
+
+const findHeroAsset = (project: ProjectMeta): ProjectAsset | null => {
+  if (!project.cover) {
+    return null
+  }
+  return project.assets.find(asset => asset.id === project.cover) ?? null
+}
+
+const buildMetaItems = (project: ProjectMeta): string => {
+  const items: string[] = []
+  if (project.role) {
+    items.push(projectRoleLabels[project.role] ?? project.role)
+  }
+  if (project.timeframe?.duration) {
+    items.push(project.timeframe.duration)
+  } else if (project.timeframe?.start || project.timeframe?.end) {
+    const start = project.timeframe.start?.replace(/T.*/, '') ?? 'Start'
+    const end = project.timeframe.end?.replace(/T.*/, '') ?? 'Present'
+    items.push(`${start} – ${end}`)
+  }
+  if (project.technologies?.length) {
+    items.push(project.technologies.join(', '))
+  }
+  return items
+    .map(item => `<span class="case-hero__meta-item">${escapeHtml(item)}</span>`)
+    .join('')
+}
+
+const buildTagBadges = (project: ProjectMeta): string => {
+  const tags = project.tags?.length ? project.tags : ['Case Study']
+  return tags
+    .slice(0, 6)
+    .map(tag => `<span class="case-hero__tag">${escapeHtml(tag)}</span>`)
+    .join('')
+}
+
+const buildMetrics = (project: ProjectMeta): string => {
+  const metrics: Array<{ label: string; value: string }> = []
+  if (project.metrics?.sales) {
+    metrics.push({ label: 'Business Impact', value: project.metrics.sales })
+  }
+  if (project.metrics?.engagement) {
+    metrics.push({ label: 'Engagement', value: project.metrics.engagement })
+  }
+  if (project.metrics?.awards?.length) {
+    metrics.push({ label: 'Recognition', value: project.metrics.awards.join(', ') })
+  }
+  if (project.metrics?.other) {
+    metrics.push({ label: 'Additional Impact', value: project.metrics.other })
+  }
+
+  if (metrics.length === 0) {
+    return ''
+  }
+
+  const items = metrics
+    .map(
+      metric => `
+        <div class="case-metrics__item">
+          <span class="case-metrics__label">${escapeHtml(metric.label)}</span>
+          <span class="case-metrics__value">${escapeHtml(metric.value)}</span>
+        </div>
+      `,
+    )
+    .join('')
+
+  return `
+    <section class="case-section case-section--metrics">
+      <h2 class="case-section__title">Impact metrics</h2>
+      <div class="case-metrics__grid">
+        ${items}
+      </div>
+    </section>
+  `
+}
+
+const buildGallery = (project: ProjectMeta): string => {
+  const images = project.assets.filter(asset => asset.mimeType.startsWith('image/'))
+  if (images.length === 0) {
+    return ''
+  }
+
+  const items = images
+    .slice(0, 6)
+    .map(asset => {
+      const alt = escapeHtml(asset.description ?? asset.name ?? project.title)
+      return `
+        <figure class="case-gallery__item">
+          <img src="${asset.dataUrl}" alt="${alt}" />
+          ${asset.description ? `<figcaption>${escapeHtml(asset.description)}</figcaption>` : ''}
+        </figure>
+      `
+    })
+    .join('')
+
+  return `
+    <section class="case-section case-section--media">
+      <h2 class="case-section__title">Visual highlights</h2>
+      <div class="case-gallery">
+        ${items}
+      </div>
+    </section>
+  `
+}
+
+const baseCss = `
+:root {
+  color-scheme: light;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --case-bg: #f6f5ff;
+  --case-surface: #ffffff;
+  --case-primary: #5a3cf4;
+  --case-primary-soft: rgba(90, 60, 244, 0.12);
+  --case-muted: #6b7280;
+  --case-text: #111827;
+  --case-border: rgba(17, 24, 39, 0.08);
+}
+
+body {
+  margin: 0;
+  background: var(--case-bg);
+  color: var(--case-text);
+  font-family: inherit;
+}
+
+.case-study {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 48px 24px 96px;
+}
+
+.case-hero {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  gap: 32px;
+  padding: 48px;
+  border-radius: 32px;
+  background: radial-gradient(circle at top left, rgba(90,60,244,0.12), transparent 45%),
+              linear-gradient(135deg, #5a3cf4, #4c1d95);
+  color: white;
+  box-shadow: 0 32px 80px -40px rgba(76, 29, 149, 0.5);
+}
+
+.case-hero__media {
+  width: 100%;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  object-fit: cover;
+  max-height: 360px;
+}
+
+.case-hero__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+  opacity: 0.75;
+}
+
+.case-hero__title {
+  margin: 12px 0 16px;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+.case-hero__description {
+  font-size: 1.1rem;
+  max-width: 640px;
+  opacity: 0.95;
+}
+
+.case-hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.case-hero__meta-item {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.14);
+  font-size: 0.85rem;
+}
+
+.case-hero__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.case-hero__tag {
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+}
+
+.case-section {
+  margin-top: 56px;
+  padding: 36px;
+  border-radius: 28px;
+  background: var(--case-surface);
+  border: 1px solid var(--case-border);
+  box-shadow: 0 20px 60px -40px rgba(17, 24, 39, 0.35);
+}
+
+.case-section__title {
+  font-size: 1.5rem;
+  margin-bottom: 16px;
+  font-weight: 600;
+}
+
+.case-section__body p {
+  margin: 0 0 16px;
+  font-size: 1rem;
+  color: var(--case-muted);
+}
+
+.case-metrics__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.case-metrics__item {
+  padding: 20px;
+  border-radius: 20px;
+  background: var(--case-primary-soft);
+  display: grid;
+  gap: 6px;
+}
+
+.case-metrics__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--case-muted);
+}
+
+.case-metrics__value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--case-primary);
+}
+
+.case-gallery {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 24px;
+}
+
+.case-gallery__item {
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid var(--case-border);
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.case-gallery__item--placeholder {
+  aspect-ratio: 4 / 3;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(90, 60, 244, 0.1),
+    rgba(90, 60, 244, 0.1) 12px,
+    rgba(90, 60, 244, 0.2) 12px,
+    rgba(90, 60, 244, 0.2) 24px
+  );
+  border: 1px dashed rgba(90, 60, 244, 0.4);
+}
+
+.case-gallery__item img {
+  width: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.case-gallery__item figcaption {
+  padding: 0 16px 16px;
+  font-size: 0.85rem;
+  color: var(--case-muted);
+}
+
+.case-quote {
+  border-left: 4px solid var(--case-primary);
+  padding-left: 24px;
+  font-size: 1.25rem;
+  color: var(--case-text);
+  line-height: 1.6;
+}
+
+.case-cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  padding: 36px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(90, 60, 244, 0.08), rgba(90, 60, 244, 0.28));
+  border: 1px solid rgba(90, 60, 244, 0.24);
+}
+
+.case-cta__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.case-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+}
+
+.case-button--primary {
+  background: var(--case-primary);
+  color: white;
+  box-shadow: 0 15px 40px -20px rgba(90, 60, 244, 0.6);
+}
+
+.case-button--secondary {
+  background: white;
+  color: var(--case-primary);
+  border: 1px solid rgba(90, 60, 244, 0.2);
+}
+
+@media (max-width: 768px) {
+  .case-hero {
+    padding: 32px;
+  }
+  .case-section {
+    padding: 28px;
+  }
+}
+`
+
+export const buildCaseStudyTemplate = (project: ProjectMeta): CaseStudyDocument => {
+  const heroAsset = findHeroAsset(project)
+  const heroMedia = heroAsset
+    ? `<img class="case-hero__media" src="${heroAsset.dataUrl}" alt="${escapeHtml(heroAsset.description ?? heroAsset.name ?? project.title)}" />`
+    : ''
+
+  const summary = project.summary ?? project.problem ?? 'Summarize your project in a sentence or two to set the stage for the reader.'
+  const problem = formatParagraphs(project.problem, 'Outline the core challenge your team needed to solve and who was affected.')
+  const solution = formatParagraphs(project.solution, 'Describe the solution you delivered and why you made key design or technical decisions.')
+  const outcomes = formatParagraphs(project.outcomes, 'Highlight measurable outcomes, user impact, or lessons learned from the engagement.')
+
+  const metricsHtml = buildMetrics(project)
+  const galleryHtml = buildGallery(project)
+
+  const html = `
+    <article class="case-study">
+      <section class="case-hero">
+        <div class="case-hero__content">
+          <span class="case-hero__eyebrow">Case study</span>
+          <h1 class="case-hero__title">${escapeHtml(project.title)}</h1>
+          <p class="case-hero__description">${escapeHtml(summary)}</p>
+          <div class="case-hero__meta">${buildMetaItems(project)}</div>
+          <div class="case-hero__tags">${buildTagBadges(project)}</div>
+        </div>
+        ${heroMedia}
+      </section>
+
+      <section class="case-section">
+        <h2 class="case-section__title">The challenge</h2>
+        <div class="case-section__body">${problem}</div>
+      </section>
+
+      <section class="case-section">
+        <h2 class="case-section__title">Approach</h2>
+        <div class="case-section__body">${solution}</div>
+      </section>
+
+      ${galleryHtml}
+      ${metricsHtml}
+
+      <section class="case-section">
+        <h2 class="case-section__title">Outcomes</h2>
+        <div class="case-section__body">${outcomes}</div>
+      </section>
+
+      <section class="case-cta">
+        <div>
+          <h2 class="case-section__title">Ready to continue the conversation?</h2>
+          <p class="case-section__body">Let’s explore how these results can translate to your team or next initiative.</p>
+        </div>
+        <div class="case-cta__actions">
+          <button class="case-button case-button--primary">Get in touch</button>
+          <button class="case-button case-button--secondary">View live prototype</button>
+        </div>
+      </section>
+    </article>
+  `
+
+  return { html, css: baseCss }
+}
+
+const createSvg = (path: string) =>
+  `<?xml version="1.0" encoding="UTF-8"?>\n<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="${path}" fill="currentColor"/></svg>`
+
+export const createCaseStudyBlocks = (project: ProjectMeta): GrapesBlockDefinition[] => {
+  const defaultSummary = project.summary ?? project.problem ?? 'Add a high-level summary that introduces the case study.'
+  const tags = buildTagBadges(project)
+  const mediaIcon = createSvg('M4 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H6a2 2 0 0 0-2 2v12a1 1 0 0 1-2 0V5a4 4 0 0 1 4-4h12a4 4 0 0 1 4 4v14a3 3 0 0 1-4.665 2.495L15 19l-3.335 2.495A3 3 0 0 1 6 19V5H4Z')
+
+  return [
+    {
+      id: 'case-hero',
+      label: 'Hero narrative',
+      category: 'Narrative',
+      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Z'),
+      content: `
+        <section class="case-hero">
+          <div class="case-hero__content">
+            <span class="case-hero__eyebrow">Case study</span>
+            <h1 class="case-hero__title">${escapeHtml(project.title)}</h1>
+            <p class="case-hero__description">${escapeHtml(defaultSummary)}</p>
+            <div class="case-hero__meta">${buildMetaItems(project)}</div>
+            <div class="case-hero__tags">${tags}</div>
+          </div>
+        </section>
+      `,
+    },
+    {
+      id: 'case-problem',
+      label: 'Problem section',
+      category: 'Narrative',
+      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Zm4 8h4v2h-4v-2Zm0-4h4v2h-4V9Z'),
+      content: `
+        <section class="case-section">
+          <h2 class="case-section__title">The challenge</h2>
+          <div class="case-section__body">
+            <p>Summarize the core challenge, the audience, and why it mattered.</p>
+            <p>Call out constraints, insights, or context that framed the work.</p>
+          </div>
+        </section>
+      `,
+    },
+    {
+      id: 'case-approach',
+      label: 'Approach section',
+      category: 'Narrative',
+      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Zm2 10h4v2h-4v-2Zm0-4h4v2h-4v-2Z'),
+      content: `
+        <section class="case-section">
+          <h2 class="case-section__title">Approach</h2>
+          <div class="case-section__body">
+            <p>Describe the strategy, frameworks, or experiments that shaped the solution.</p>
+            <p>Highlight collaboration, tooling, and how you validated decisions.</p>
+          </div>
+        </section>
+      `,
+    },
+    {
+      id: 'case-outcomes',
+      label: 'Outcomes section',
+      category: 'Narrative',
+      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Zm2 8h4v2h-4v-2Zm0-4h4v2h-4V9Z'),
+      content: `
+        <section class="case-section">
+          <h2 class="case-section__title">Outcomes</h2>
+          <div class="case-section__body">
+            <p>Share measurable results, adoption metrics, or qualitative feedback.</p>
+            <p>Capture what changed for users or the business after launch.</p>
+          </div>
+        </section>
+      `,
+    },
+    {
+      id: 'case-gallery',
+      label: 'Image gallery',
+      category: 'Media',
+      media: mediaIcon,
+      content: `
+        <section class="case-section case-section--media">
+          <h2 class="case-section__title">Visual highlights</h2>
+          <div class="case-gallery">
+            <figure class="case-gallery__item case-gallery__item--placeholder"></figure>
+            <figure class="case-gallery__item case-gallery__item--placeholder"></figure>
+            <figure class="case-gallery__item case-gallery__item--placeholder"></figure>
+          </div>
+        </section>
+      `,
+    },
+    {
+      id: 'case-metrics',
+      label: 'Metrics',
+      category: 'Outcomes',
+      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Zm2 2h4v2h-4V7Zm0 4h4v2h-4v-2Zm0 4h2v2h-2v-2Z'),
+      content: `
+        <section class="case-section case-section--metrics">
+          <h2 class="case-section__title">Impact metrics</h2>
+          <div class="case-metrics__grid">
+            <div class="case-metrics__item">
+              <span class="case-metrics__label">Metric</span>
+              <span class="case-metrics__value">+45% engagement</span>
+            </div>
+            <div class="case-metrics__item">
+              <span class="case-metrics__label">Metric</span>
+              <span class="case-metrics__value">-30% support tickets</span>
+            </div>
+          </div>
+        </section>
+      `,
+    },
+    {
+      id: 'case-quote',
+      label: 'Pull quote',
+      category: 'Storytelling',
+      media: createSvg('M5 4h4a3 3 0 0 1 3 3v4a3 3 0 0 1-3 3H7l-1 4H3l1-4A3 3 0 0 1 1 11V7a3 3 0 0 1 3-3Zm10 0h4a3 3 0 0 1 3 3v4a3 3 0 0 1-3 3h-2l-1 4h-3l1-4a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3Z'),
+      content: `
+        <section class="case-section">
+          <blockquote class="case-quote">
+            "Include a quote from a stakeholder or customer that captures the impact of the work."
+          </blockquote>
+        </section>
+      `,
+    },
+    {
+      id: 'case-cta',
+      label: 'Call to action',
+      category: 'Engagement',
+      media: createSvg('M4 4h16a2 2 0 0 1 2 2v6.382a2 2 0 0 1-.586 1.414l-7.618 7.618a2 2 0 0 1-2.828 0l-7.618-7.618A2 2 0 0 1 2 12.382V6a2 2 0 0 1 2-2Zm2 4v2h12V8H6Z'),
+      content: `
+        <section class="case-cta">
+          <div>
+            <h2 class="case-section__title">Next steps</h2>
+            <p class="case-section__body">Invite the reader to connect, explore prototypes, or review the launch.</p>
+          </div>
+          <div class="case-cta__actions">
+            <button class="case-button case-button--primary">Schedule a chat</button>
+            <button class="case-button case-button--secondary">View prototype</button>
+          </div>
+        </section>
+      `,
+    },
+  ]
+}

--- a/src/utils/fileStore.ts
+++ b/src/utils/fileStore.ts
@@ -83,8 +83,8 @@ const readStore = (): Store => {
       outcomes: typeof meta.outcomes === 'string' ? meta.outcomes : '',
       tags,
       technologies: technologiesArray.length > 0 ? technologiesArray : undefined,
-      status: (typeof meta.status === 'string' && ['draft', 'cast', 'published'].includes(meta.status)) 
-        ? meta.status as ProjectStatus 
+      status: (typeof meta.status === 'string' && ['draft', 'cast', 'published'].includes(meta.status))
+        ? meta.status as ProjectStatus
         : 'draft',
       role: (typeof meta.role === 'string' && ['designer', 'developer', 'director', 'project-manager', 'researcher', 'strategist', 'other'].includes(meta.role))
         ? meta.role as ProjectRole
@@ -100,6 +100,8 @@ const readStore = (): Store => {
       layout: normaliseLayout(meta.layout),
       autoGenerateNarrative: typeof meta.autoGenerateNarrative === 'boolean' ? meta.autoGenerateNarrative : false,
       aiGeneratedSummary: typeof meta.aiGeneratedSummary === 'string' ? meta.aiGeneratedSummary : undefined,
+      caseStudyHtml: typeof meta.caseStudyHtml === 'string' ? meta.caseStudyHtml : undefined,
+      caseStudyCss: typeof meta.caseStudyCss === 'string' ? meta.caseStudyCss : undefined,
     }
   })
 

--- a/src/utils/grapesLoader.ts
+++ b/src/utils/grapesLoader.ts
@@ -1,0 +1,65 @@
+import type { GrapesNamespace } from '../types/grapes'
+
+const GRAPES_SCRIPT_URL = 'https://unpkg.com/grapesjs@0.22.5/dist/grapes.min.js'
+const GRAPES_STYLE_URL = 'https://unpkg.com/grapesjs@0.22.5/dist/css/grapes.min.css'
+
+let loadPromise: Promise<GrapesNamespace> | null = null
+
+const loadScript = (url: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>('script[data-grapesjs]')
+    if (existing) {
+      if (existing.dataset.grapesjsLoaded === 'true') {
+        resolve()
+        return
+      }
+      existing.addEventListener('load', () => resolve(), { once: true })
+      existing.addEventListener('error', () => reject(new Error('Failed to load GrapesJS script')), { once: true })
+      return
+    }
+
+    const script = document.createElement('script')
+    script.src = url
+    script.async = true
+    script.dataset.grapesjs = 'true'
+    script.onload = () => {
+      script.dataset.grapesjsLoaded = 'true'
+      resolve()
+    }
+    script.onerror = () => reject(new Error('Failed to load GrapesJS script'))
+    document.head.appendChild(script)
+  })
+
+const ensureStylesheet = (url: string) => {
+  if (document.querySelector('link[data-grapesjs]')) {
+    return
+  }
+  const link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = url
+  link.dataset.grapesjs = 'true'
+  document.head.appendChild(link)
+}
+
+export const ensureGrapesJS = async (): Promise<GrapesNamespace> => {
+  if (typeof window === 'undefined') {
+    throw new Error('GrapesJS requires a browser environment')
+  }
+
+  if (window.grapesjs) {
+    return window.grapesjs
+  }
+
+  if (!loadPromise) {
+    ensureStylesheet(GRAPES_STYLE_URL)
+    loadPromise = (async () => {
+      await loadScript(GRAPES_SCRIPT_URL)
+      if (!window.grapesjs) {
+        throw new Error('GrapesJS failed to initialize')
+      }
+      return window.grapesjs
+    })()
+  }
+
+  return loadPromise
+}

--- a/src/utils/portfolioStorage.ts
+++ b/src/utils/portfolioStorage.ts
@@ -1,0 +1,50 @@
+import type { PortfolioDocument } from './portfolioTemplates'
+
+const STORAGE_KEY = 'portfolio-forge-document'
+
+type StoredPortfolioDocument = PortfolioDocument & { updatedAt: string }
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+
+export const loadPortfolioDocument = (): StoredPortfolioDocument | null => {
+  if (!isBrowser()) {
+    return null
+  }
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredPortfolioDocument>
+    if (!parsed || typeof parsed.html !== 'string' || typeof parsed.css !== 'string') {
+      return null
+    }
+    return {
+      html: parsed.html,
+      css: parsed.css,
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
+    }
+  } catch (error) {
+    console.warn('Failed to parse stored portfolio document', error)
+    return null
+  }
+}
+
+export const savePortfolioDocument = (document: PortfolioDocument): void => {
+  if (!isBrowser()) {
+    return
+  }
+  const payload: StoredPortfolioDocument = {
+    html: document.html,
+    css: document.css,
+    updatedAt: new Date().toISOString(),
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+}
+
+export const clearPortfolioDocument = (): void => {
+  if (!isBrowser()) {
+    return
+  }
+  window.localStorage.removeItem(STORAGE_KEY)
+}

--- a/src/utils/portfolioTemplates.ts
+++ b/src/utils/portfolioTemplates.ts
@@ -1,0 +1,405 @@
+import type { ProjectMeta } from '../intake/schema'
+import type { GrapesBlockDefinition } from '../types/grapes'
+
+export type PortfolioDocument = {
+  html: string
+  css: string
+}
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+const truncate = (value: string, length: number): string => {
+  if (value.length <= length) {
+    return value
+  }
+  return `${value.slice(0, length - 1)}…`
+}
+
+const summarizeProject = (project: ProjectMeta): string => {
+  const summary = project.summary || project.solution || project.problem
+  if (!summary) {
+    return 'Add a short summary that introduces this case study to prospective clients.'
+  }
+  return summary
+}
+
+const buildTagGroup = (tags: string[]): string =>
+  tags
+    .slice(0, 4)
+    .map(tag => `<span class="portfolio-tag">${escapeHtml(tag)}</span>`)
+    .join('')
+
+const baseCss = `
+:root {
+  color-scheme: light;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --portfolio-bg: radial-gradient(circle at top left, rgba(76, 29, 149, 0.16), rgba(17, 24, 39, 1));
+  --portfolio-surface: rgba(15, 23, 42, 0.85);
+  --portfolio-border: rgba(148, 163, 184, 0.24);
+  --portfolio-primary: #6366f1;
+  --portfolio-primary-soft: rgba(99, 102, 241, 0.16);
+  --portfolio-text: #e2e8f0;
+  --portfolio-muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--portfolio-bg);
+  color: var(--portfolio-text);
+  font-family: inherit;
+}
+
+.portfolio {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 72px 24px 120px;
+  display: grid;
+  gap: 64px;
+}
+
+.portfolio-hero {
+  position: relative;
+  overflow: hidden;
+  padding: 64px;
+  border-radius: 40px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.22), rgba(14, 116, 144, 0.18));
+  border: 1px solid rgba(99, 102, 241, 0.28);
+  box-shadow: 0 30px 80px -40px rgba(15, 23, 42, 0.8);
+}
+
+.portfolio-hero__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.portfolio-hero__title {
+  margin: 12px 0 16px;
+  font-size: clamp(2.4rem, 5vw, 3.6rem);
+  font-weight: 700;
+  line-height: 1.08;
+}
+
+.portfolio-hero__description {
+  max-width: 640px;
+  font-size: 1.125rem;
+  color: rgba(241, 245, 249, 0.86);
+}
+
+.portfolio-hero__actions {
+  margin-top: 32px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.portfolio-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  border: none;
+}
+
+.portfolio-button--primary {
+  background: rgba(255, 255, 255, 0.18);
+  color: white;
+  box-shadow: 0 20px 60px -40px rgba(59, 130, 246, 0.8);
+}
+
+.portfolio-button--secondary {
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--portfolio-primary);
+  border: 1px solid rgba(99, 102, 241, 0.32);
+}
+
+.portfolio-grid {
+  display: grid;
+  gap: 32px;
+}
+
+.portfolio-grid__cards {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.portfolio-card {
+  position: relative;
+  padding: 28px;
+  border-radius: 28px;
+  background: var(--portfolio-surface);
+  border: 1px solid var(--portfolio-border);
+  box-shadow: 0 16px 60px -40px rgba(15, 23, 42, 0.65);
+  display: grid;
+  gap: 18px;
+}
+
+.portfolio-card__title {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.portfolio-card__summary {
+  color: var(--portfolio-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.portfolio-tag-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.portfolio-tag {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.14);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.portfolio-showcase {
+  display: grid;
+  gap: 32px;
+}
+
+.portfolio-case-study {
+  padding: 40px;
+  border-radius: 32px;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  backdrop-filter: blur(8px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 24px 80px -50px rgba(15, 23, 42, 0.9);
+}
+
+.portfolio-case-study__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.portfolio-case-study__title {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.portfolio-case-study__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.portfolio-case-study__body {
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.portfolio-case-study__body > * {
+  margin: 0;
+}
+
+@media (max-width: 960px) {
+  .portfolio-hero {
+    padding: 48px 32px;
+  }
+  .portfolio-case-study {
+    padding: 32px;
+  }
+}
+`
+
+const createSvg = (path: string) =>
+  `<?xml version="1.0" encoding="UTF-8"?>\n<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="${path}" fill="currentColor"/></svg>`
+
+export const buildPortfolioTemplate = (projects: ProjectMeta[]): PortfolioDocument => {
+  const cards = projects.map(project => {
+    const summary = truncate(summarizeProject(project), 160)
+    const tags = buildTagGroup(project.tags ?? [])
+    return `
+      <article class="portfolio-card" data-project="${escapeHtml(project.slug)}">
+        <h3 class="portfolio-card__title">${escapeHtml(project.title)}</h3>
+        <p class="portfolio-card__summary">${escapeHtml(summary)}</p>
+        <div class="portfolio-tag-group">${tags}</div>
+      </article>
+    `
+  })
+
+  const caseStudies = projects.map(project => {
+    const tags = buildTagGroup(project.tags ?? [])
+    const caseContent = project.caseStudyHtml ?? '<p>Add your case study narrative using the project editor.</p>'
+    return `
+      <article class="portfolio-case-study" data-project="${escapeHtml(project.slug)}">
+        <div class="portfolio-case-study__header">
+          <div>
+            <h3 class="portfolio-case-study__title">${escapeHtml(project.title)}</h3>
+            <div class="portfolio-tag-group">${tags}</div>
+          </div>
+        </div>
+        <div class="portfolio-case-study__body">
+          ${caseContent}
+        </div>
+      </article>
+    `
+  })
+
+  const html = `
+    <main class="portfolio">
+      <section class="portfolio-hero">
+        <span class="portfolio-hero__eyebrow">Portfolio</span>
+        <h1 class="portfolio-hero__title">Selected work & case studies</h1>
+        <p class="portfolio-hero__description">
+          A collection of collaborative product design and development projects, each grounded in outcomes and measurable impact.
+        </p>
+        <div class="portfolio-hero__actions">
+          <button class="portfolio-button portfolio-button--primary">Book a working session</button>
+          <button class="portfolio-button portfolio-button--secondary">Download resume</button>
+        </div>
+      </section>
+
+      <section class="portfolio-grid">
+        <div>
+          <h2>Highlights</h2>
+          <p class="portfolio-card__summary">Explore a curated mix of engagements spanning research, product design, and engineering.</p>
+        </div>
+        <div class="portfolio-grid__cards">
+          ${cards.join('')}
+        </div>
+      </section>
+
+      <section class="portfolio-showcase">
+        <div>
+          <h2>Case studies</h2>
+          <p class="portfolio-card__summary">Deep dives into the process, strategy, and impact behind the selected projects.</p>
+        </div>
+        <div class="portfolio-showcase__list">
+          ${caseStudies.join('')}
+        </div>
+      </section>
+    </main>
+  `
+
+  const cssFragments = [baseCss, ...projects.map(project => project.caseStudyCss ?? '').filter(Boolean)]
+
+  return {
+    html,
+    css: cssFragments.join('\n\n'),
+  }
+}
+
+export const createPortfolioBlocks = (projects: ProjectMeta[]): GrapesBlockDefinition[] => {
+  const blocks: GrapesBlockDefinition[] = [
+    {
+      id: 'portfolio-hero',
+      label: 'Portfolio hero',
+      category: 'Structure',
+      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Z'),
+      content: `
+        <section class="portfolio-hero">
+          <span class="portfolio-hero__eyebrow">Portfolio</span>
+          <h1 class="portfolio-hero__title">Headline for your body of work</h1>
+          <p class="portfolio-hero__description">Describe your focus areas, strengths, and the value you bring to product teams.</p>
+          <div class="portfolio-hero__actions">
+            <button class="portfolio-button portfolio-button--primary">Book a conversation</button>
+            <button class="portfolio-button portfolio-button--secondary">Download resume</button>
+          </div>
+        </section>
+      `,
+    },
+    {
+      id: 'portfolio-highlights',
+      label: 'Highlights grid',
+      category: 'Structure',
+      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Zm8 0h2v2h-2V5Zm0 4h2v2h-2V9Zm0 4h2v2h-2v-2Z'),
+      content: `
+        <section class="portfolio-grid">
+          <div>
+            <h2>Highlights</h2>
+            <p class="portfolio-card__summary">Pair a short narrative with the types of projects you love shipping.</p>
+          </div>
+          <div class="portfolio-grid__cards">
+            <article class="portfolio-card">
+              <h3 class="portfolio-card__title">Project title</h3>
+              <p class="portfolio-card__summary">Add a sentence about the outcome and your role.</p>
+              <div class="portfolio-tag-group">
+                <span class="portfolio-tag">UX Strategy</span>
+                <span class="portfolio-tag">Design Systems</span>
+              </div>
+            </article>
+            <article class="portfolio-card">
+              <h3 class="portfolio-card__title">Project title</h3>
+              <p class="portfolio-card__summary">Highlight measurable impact or shipped features.</p>
+              <div class="portfolio-tag-group">
+                <span class="portfolio-tag">Product Design</span>
+                <span class="portfolio-tag">Leadership</span>
+              </div>
+            </article>
+          </div>
+        </section>
+      `,
+    },
+    {
+      id: 'portfolio-cta',
+      label: 'Contact banner',
+      category: 'Structure',
+      media: createSvg('M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Zm2 6h4v2H6v-2Zm0 4h8v2H6v-2Zm10-8h2v2h-2V6Z'),
+      content: `
+        <section class="portfolio-hero">
+          <span class="portfolio-hero__eyebrow">Let’s collaborate</span>
+          <h2 class="portfolio-hero__title">Tell readers how to reach you</h2>
+          <p class="portfolio-hero__description">Share availability, preferred contact channels, or upcoming talks and workshops.</p>
+          <div class="portfolio-hero__actions">
+            <button class="portfolio-button portfolio-button--primary">Start a project</button>
+            <button class="portfolio-button portfolio-button--secondary">Download case studies</button>
+          </div>
+        </section>
+      `,
+    },
+  ]
+
+  projects.forEach(project => {
+    const tags = buildTagGroup(project.tags ?? [])
+    const caseContent = project.caseStudyHtml ?? '<p>Add the case study narrative from the project editor.</p>'
+    blocks.push({
+      id: `portfolio-case-${project.slug}`,
+      label: `Case study: ${project.title}`,
+      category: 'Case studies',
+      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Zm2 4h4v2h-4V9Zm0 4h4v2h-4v-2Z'),
+      content: `
+        <article class="portfolio-case-study" data-project="${escapeHtml(project.slug)}">
+          <div class="portfolio-case-study__header">
+            <div>
+              <h3 class="portfolio-case-study__title">${escapeHtml(project.title)}</h3>
+              <div class="portfolio-tag-group">${tags}</div>
+            </div>
+          </div>
+          <div class="portfolio-case-study__body">
+            ${caseContent}
+          </div>
+        </article>
+      `,
+    })
+  })
+
+  return blocks
+}


### PR DESCRIPTION
## Summary
- load GrapesJS dynamically and expose a reusable editor wrapper with custom case study blocks and styles
- replace the project editor with a GrapesJS-powered case study builder, generate defaults during intake, and surface a live preview
- add portfolio editor and public view pages that assemble saved case studies, including navigation links and local storage for the portfolio document

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb65148a8832f856355e6f6abb194