### PR TITLE
feat: build TailAdmin React dashboard

### DIFF
--- a/portfolio-intake/src/App.css
+++ b/portfolio-intake/src/App.css
@@ -1,42 +1,788 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  background: radial-gradient(circle at top, rgba(30, 64, 175, 0.35), rgba(15, 23, 42, 0.92));
+  color: #e2e8f0;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.sidebar {
+  width: 260px;
+  background: rgba(10, 16, 32, 0.85);
+  backdrop-filter: blur(12px);
+  border-right: 1px solid rgba(148, 163, 184, 0.16);
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  gap: 24px;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.sidebar__brand {
+  display: flex;
+  gap: 12px;
+  align-items: center;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.sidebar__mark {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.32), rgba(45, 212, 191, 0.32));
+  display: grid;
+  place-items: center;
+  color: #f8fafc;
+}
+
+.sidebar__title {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.sidebar__subtitle {
+  display: block;
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.sidebar__nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  color: rgba(226, 232, 240, 0.8);
+  text-decoration: none;
+  border-radius: 12px;
+  transition: background 160ms ease, color 160ms ease;
+}
+
+.sidebar__link:hover,
+.sidebar__link:focus-visible {
+  background: rgba(99, 102, 241, 0.16);
+  color: #f8fafc;
+}
+
+.sidebar__link.is-active {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.22), rgba(45, 212, 191, 0.18));
+  color: #f8fafc;
+  box-shadow: 0 12px 28px -18px rgba(99, 102, 241, 0.85);
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  padding: 18px;
+  border-radius: 18px;
+  background: rgba(30, 41, 59, 0.65);
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  display: grid;
+  gap: 10px;
+}
+
+.sidebar__footer-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.sidebar__footer-body {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.85rem;
+}
+
+.sidebar__footer-action {
+  margin-top: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(99, 102, 241, 0.22);
+  border: none;
+  border-radius: 12px;
+  padding: 8px 12px;
+  color: #f8fafc;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+
+.sidebar__footer-action:hover {
+  background: rgba(129, 140, 248, 0.32);
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(8px);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 22px 32px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(10, 16, 32, 0.65);
+}
+
+.topbar__menu {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.65);
+  color: rgba(226, 232, 240, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.topbar__search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  padding: 10px 14px;
+}
+
+.topbar__search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.topbar__search input:focus-visible {
+  outline: none;
+}
+
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.icon-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(30, 41, 59, 0.65);
+  color: rgba(226, 232, 240, 0.82);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.user-pill {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 999px;
+  padding: 6px 14px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  cursor: pointer;
+}
+
+.user-pill__avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(99, 102, 241, 0.28);
+  color: #f8fafc;
+}
+
+.user-pill__meta {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.user-pill__name {
+  font-weight: 600;
+}
+
+.user-pill__role {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.workspace__content {
+  flex: 1;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.page-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.page-heading__eyebrow {
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.page-heading__title {
+  margin: 6px 0;
+  font-size: clamp(1.8rem, 2.5vw, 2.4rem);
+}
+
+.page-heading__description {
+  margin: 0;
+  max-width: 520px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.timeframe-toggle {
+  display: inline-flex;
+  gap: 10px;
+  background: rgba(15, 23, 42, 0.65);
+  padding: 8px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.timeframe-toggle__button {
+  border: none;
+  padding: 8px 16px;
+  border-radius: 10px;
+  background: transparent;
+  color: rgba(226, 232, 240, 0.75);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.timeframe-toggle__button.is-active {
+  background: rgba(99, 102, 241, 0.32);
+  color: #f8fafc;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.metrics-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.metric-card {
+  padding: 20px;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  display: grid;
+  gap: 12px;
+}
+
+.metric-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.metric-card__title {
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.metric-card__trend {
+  font-size: 0.85rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.metric-card__trend--positive {
+  color: #4ade80;
+}
+
+.metric-card__trend--negative {
+  color: #f97316;
+}
+
+.metric-card__value {
+  font-size: 1.8rem;
+  font-weight: 600;
+}
+
+.metric-card__description {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.85rem;
+}
+
+.primary-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
 }
 
 .card {
-  padding: 2em;
+  padding: 24px;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
-.read-the-docs {
-  color: #888;
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.card__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.card__subtitle {
+  margin: 4px 0 0;
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.9rem;
+}
+
+.card__trend,
+.card__hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(99, 102, 241, 0.18);
+  border-radius: 999px;
+  padding: 6px 12px;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.85rem;
+}
+
+.revenue-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+}
+
+.revenue-summary__label {
+  display: block;
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.revenue-summary__value {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.revenue-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  height: 200px;
+}
+
+.revenue-chart__column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.revenue-chart__bar {
+  width: 100%;
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.revenue-chart__bar-total {
+  width: 70%;
+  border-radius: 999px 999px 14px 14px;
+  background: linear-gradient(180deg, rgba(99, 102, 241, 0.62), rgba(99, 102, 241, 0.18));
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.revenue-chart__bar-profit {
+  width: 100%;
+  border-radius: inherit;
+  background: linear-gradient(180deg, rgba(45, 212, 191, 0.9), rgba(45, 212, 191, 0.24));
+}
+
+.revenue-chart__label {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.team-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.team-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.team-list__avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.team-list__content {
+  display: grid;
+  gap: 10px;
+}
+
+.team-list__heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.team-list__name {
+  font-weight: 600;
+}
+
+.team-list__role {
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.85rem;
+}
+
+.team-list__focus {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.85rem;
+}
+
+.team-list__progress {
+  height: 6px;
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.team-list__progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(129, 140, 248, 0.85), rgba(45, 212, 191, 0.85));
+  border-radius: inherit;
+}
+
+.team-list__metrics {
+  display: grid;
+  text-align: right;
+  gap: 6px;
+}
+
+.team-list__metric-label {
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.team-list__metric-value {
+  font-weight: 600;
+}
+
+.secondary-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 24px;
+}
+
+.secondary-grid__column {
+  display: grid;
+  gap: 24px;
+}
+
+.pipeline-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.pipeline-table th,
+.pipeline-table td {
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.pipeline-table th {
+  text-align: left;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.pipeline-project {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pipeline-project__code {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.6);
+  letter-spacing: 0.1em;
+}
+
+.pipeline-project__name {
+  font-weight: 600;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.status-badge--positive {
+  background: rgba(34, 197, 94, 0.18);
+  color: #4ade80;
+}
+
+.status-badge--warning {
+  background: rgba(234, 179, 8, 0.18);
+  color: #facc15;
+}
+
+.status-badge--danger {
+  background: rgba(248, 113, 113, 0.18);
+  color: #f87171;
+}
+
+.status-badge--neutral {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.progress__bar {
+  height: 8px;
+  flex: 1;
+  background: linear-gradient(90deg, rgba(129, 140, 248, 0.85), rgba(45, 212, 191, 0.85));
+  border-radius: 999px;
+}
+
+.progress__value {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.align-right {
+  text-align: right;
+}
+
+.channel-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.channel-summary__label {
+  display: block;
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.channel-summary__value {
+  display: block;
+  margin-top: 4px;
+  font-weight: 600;
+}
+
+.channel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.channel-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.channel-list__details {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.75);
+  margin-top: 4px;
+}
+
+.channel-list__metrics {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  font-weight: 600;
+}
+
+.channel-list__rate {
+  color: #38bdf8;
+}
+
+.channel-list__trend {
+  color: #34d399;
+  font-size: 0.85rem;
+}
+
+.announcement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.announcement-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.announcement-list__icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(99, 102, 241, 0.22);
+  display: grid;
+  place-items: center;
+  color: #f8fafc;
+}
+
+.announcement-list__heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.announcement-list__title {
+  font-weight: 600;
+}
+
+.announcement-list__date {
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.85rem;
+}
+
+.announcement-list__message {
+  margin: 6px 0 0;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1200px) {
+  .primary-grid,
+  .secondary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  }
+
+  .sidebar__nav {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .sidebar__footer {
+    display: none;
+  }
+
+  .workspace__content {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 700px) {
+  .topbar {
+    flex-wrap: wrap;
+  }
+
+  .timeframe-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .metrics-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .pipeline-table th,
+  .pipeline-table td {
+    padding: 12px 0;
+  }
 }

--- a/portfolio-intake/src/App.tsx
+++ b/portfolio-intake/src/App.tsx
@@ -1,34 +1,481 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { type ComponentType, useMemo, useState } from 'react'
+import {
+  Activity,
+  ArrowUpRight,
+  BarChart3,
+  Bell,
+  CheckCircle2,
+  ChevronDown,
+  LayoutDashboard,
+  Menu,
+  Search,
+  Settings,
+  ShieldCheck,
+  Sparkles,
+  Target,
+  TrendingUp,
+  Users,
+} from 'lucide-react'
 import './App.css'
+import {
+  DASHBOARD_TIMEFRAMES,
+  buildDashboardSnapshot,
+  defaultDashboardTimeframe,
+  formatCurrency,
+  formatNumber,
+  formatPercentage,
+} from './dashboardData'
+import type {
+  Announcement,
+  ChannelPerformance,
+  DashboardSnapshot,
+  DashboardTimeframe,
+  Metric,
+  PipelineItem,
+  TeamMember,
+} from './dashboardData'
 
-function App() {
-  const [count, setCount] = useState(0)
+const NAVIGATION_ITEMS: Array<{ label: string; icon: ComponentType<{ size?: number }> }> = [
+  { label: 'Overview', icon: LayoutDashboard },
+  { label: 'Analytics', icon: BarChart3 },
+  { label: 'Projects', icon: Activity },
+  { label: 'Team', icon: Users },
+  { label: 'Settings', icon: Settings },
+]
+
+const TIMEFRAME_LABELS: Record<DashboardTimeframe, string> = {
+  week: 'Weekly',
+  month: 'Monthly',
+  quarter: 'Quarterly',
+  year: 'Yearly',
+}
+
+const TIMEFRAME_DESCRIPTION: Record<DashboardTimeframe, string> = {
+  week: 'A real-time look at momentum across the current sprint.',
+  month: 'A strategic overview of performance across the current month.',
+  quarter: 'Quarterly health across pipeline, revenue, and delivery.',
+  year: 'An annual perspective on growth, retention, and utilisation.',
+}
+
+type MetricCardProps = {
+  metric: Metric
+}
+
+const MetricCard = ({ metric }: MetricCardProps) => {
+  const isPositive = metric.direction === 'up'
+  const formattedValue =
+    metric.unit === 'currency'
+      ? formatCurrency(metric.value)
+      : metric.unit === 'percentage'
+        ? formatPercentage(metric.value)
+        : formatNumber(metric.value)
 
   return (
-    <>
+    <article className="metric-card" aria-label={`${metric.label} summary`}>
+      <header className="metric-card__header">
+        <span className="metric-card__title">{metric.label}</span>
+        <span
+          className={`metric-card__trend metric-card__trend--${isPositive ? 'positive' : 'negative'}`}
+          aria-label={`Change ${metric.direction === 'up' ? 'upward' : 'downward'} ${formatPercentage(metric.change)}`}
+        >
+          {isPositive ? '▲' : '▼'} {formatPercentage(metric.change)}
+        </span>
+      </header>
+      <p className="metric-card__value">{formattedValue}</p>
+      <p className="metric-card__description">{metric.description}</p>
+    </article>
+  )
+}
+
+type RevenuePanelProps = {
+  snapshot: DashboardSnapshot
+}
+
+const RevenuePanel = ({ snapshot }: RevenuePanelProps) => {
+  const revenueMetric = snapshot.metrics.find(metric => metric.id === 'revenue')
+  const trendLabel = revenueMetric
+    ? `${revenueMetric.direction === 'up' ? '+' : '−'}${formatPercentage(revenueMetric.change)}`
+    : null
+  const chartMax = Math.max(...snapshot.revenue.series.map(point => point.revenue), 1)
+
+  return (
+    <section className="card revenue-card" aria-labelledby="revenue-heading">
+      <header className="card__header">
+        <div>
+          <h2 id="revenue-heading">Revenue overview</h2>
+          <p className="card__subtitle">Revenue and profit trends for the selected timeframe.</p>
+        </div>
+        <div className="card__trend">
+          <TrendingUp size={16} aria-hidden="true" />
+          <span>{trendLabel ?? 'Stable vs previous period'}</span>
+        </div>
+      </header>
+
+      <div className="revenue-summary">
+        <div>
+          <span className="revenue-summary__label">Total revenue</span>
+          <span className="revenue-summary__value">{formatCurrency(snapshot.revenue.totalRevenue)}</span>
+        </div>
+        <div>
+          <span className="revenue-summary__label">Net profit</span>
+          <span className="revenue-summary__value">{formatCurrency(snapshot.revenue.totalProfit)}</span>
+        </div>
+        <div>
+          <span className="revenue-summary__label">Average margin</span>
+          <span className="revenue-summary__value">{formatPercentage(snapshot.revenue.averageMargin)}</span>
+        </div>
+      </div>
+
+      <div className="revenue-chart" role="list" aria-label="Revenue trend chart">
+        {snapshot.revenue.series.map(point => {
+          const revenueHeight = Math.round((point.revenue / chartMax) * 100)
+          const profitHeight = Math.round((point.profit / point.revenue) * 100)
+          return (
+            <div key={point.label} className="revenue-chart__column" role="listitem">
+              <div className="revenue-chart__bar" aria-hidden="true">
+                <span
+                  className="revenue-chart__bar-total"
+                  style={{ height: `${revenueHeight}%` }}
+                >
+                  <span
+                    className="revenue-chart__bar-profit"
+                    style={{ height: `${profitHeight}%` }}
+                  />
+                </span>
+              </div>
+              <span className="revenue-chart__label">{point.label}</span>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+type PipelineTableProps = {
+  items: PipelineItem[]
+}
+
+const statusTone: Record<PipelineItem['status'], 'positive' | 'warning' | 'danger' | 'neutral'> = {
+  Completed: 'positive',
+  'In review': 'warning',
+  'In progress': 'neutral',
+  'At risk': 'danger',
+}
+
+const PipelineTable = ({ items }: PipelineTableProps) => (
+  <section className="card pipeline-card" aria-labelledby="pipeline-heading">
+    <header className="card__header">
       <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+        <h2 id="pipeline-heading">Project pipeline</h2>
+        <p className="card__subtitle">Active client engagements across discovery, delivery, and QA.</p>
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
+      <div className="card__hint">
+        <CheckCircle2 size={16} aria-hidden="true" />
+        <span>{formatNumber(items.filter(item => item.status === 'Completed').length)} completed</span>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </header>
+
+    <table className="pipeline-table">
+      <thead>
+        <tr>
+          <th scope="col">Project</th>
+          <th scope="col">Client</th>
+          <th scope="col">Status</th>
+          <th scope="col">Progress</th>
+          <th scope="col" className="align-right">Budget</th>
+          <th scope="col">Due</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map(item => (
+          <tr key={item.id}>
+            <td data-title="Project">
+              <div className="pipeline-project">
+                <span className="pipeline-project__code">{item.id}</span>
+                <span className="pipeline-project__name">{item.project}</span>
+              </div>
+            </td>
+            <td data-title="Client">{item.client}</td>
+            <td data-title="Status">
+              <span className={`status-badge status-badge--${statusTone[item.status]}`}>{item.status}</span>
+            </td>
+            <td data-title="Progress">
+              <div className="progress">
+                <span className="progress__bar" style={{ width: `${item.progress}%` }} />
+                <span className="progress__value">{item.progress}%</span>
+              </div>
+            </td>
+            <td data-title="Budget" className="align-right">{formatCurrency(item.amount)}</td>
+            <td data-title="Due">{formatDate(item.dueDate)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </section>
+)
+
+type TeamListProps = {
+  members: TeamMember[]
+}
+
+const TeamList = ({ members }: TeamListProps) => {
+  const maxContribution = Math.max(...members.map(member => member.contributions), 1)
+
+  return (
+    <section className="card team-card" aria-labelledby="team-heading">
+      <header className="card__header">
+        <div>
+          <h2 id="team-heading">Team focus</h2>
+          <p className="card__subtitle">Allocation, contributions, and current focus areas.</p>
+        </div>
+        <div className="card__hint">
+          <Users size={16} aria-hidden="true" />
+          <span>{formatNumber(members.length)} key contributors</span>
+        </div>
+      </header>
+      <ul className="team-list">
+        {members.map(member => (
+          <li key={member.id} className="team-list__item">
+            <span className="team-list__avatar" style={{ backgroundColor: member.avatarColor }} aria-hidden="true">
+              {initials(member.name)}
+            </span>
+            <div className="team-list__content">
+              <div className="team-list__heading">
+                <span className="team-list__name">{member.name}</span>
+                <span className="team-list__role">{member.role}</span>
+              </div>
+              <p className="team-list__focus">Current focus: {member.focus}</p>
+              <div className="team-list__progress" aria-label={`${member.contributions} contributions`}>
+                <span
+                  className="team-list__progress-bar"
+                  style={{ width: `${Math.round((member.contributions / maxContribution) * 100)}%` }}
+                />
+              </div>
+            </div>
+            <div className="team-list__metrics">
+              <span className="team-list__metric-label">Contributions</span>
+              <span className="team-list__metric-value">{formatNumber(member.contributions)}</span>
+              <span className="team-list__metric-label">Hours</span>
+              <span className="team-list__metric-value">{formatNumber(member.hours)}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+type ChannelListProps = {
+  channels: ChannelPerformance[]
+  summary: DashboardSnapshot['channelSummary']
+}
+
+const ChannelList = ({ channels, summary }: ChannelListProps) => (
+  <section className="card channel-card" aria-labelledby="channel-heading">
+    <header className="card__header">
+      <div>
+        <h2 id="channel-heading">Growth channels</h2>
+        <p className="card__subtitle">Lead generation and conversion performance.</p>
+      </div>
+      <div className="channel-summary">
+        <div>
+          <span className="channel-summary__label">Leads</span>
+          <span className="channel-summary__value">{formatNumber(summary.totalLeads)}</span>
+        </div>
+        <div>
+          <span className="channel-summary__label">Top channel</span>
+          <span className="channel-summary__value">{summary.strongestChannel.channel}</span>
+        </div>
+        <div>
+          <span className="channel-summary__label">Avg. conversion</span>
+          <span className="channel-summary__value">{formatPercentage(summary.averageConversion)}</span>
+        </div>
+      </div>
+    </header>
+    <ul className="channel-list">
+      {channels.map(channel => (
+        <li key={channel.id} className="channel-list__item">
+          <div>
+            <span className="channel-list__name">{channel.channel}</span>
+            <span className="channel-list__details">
+              {formatNumber(channel.leads)} leads • {formatNumber(channel.opportunities)} opportunities
+            </span>
+          </div>
+          <div className="channel-list__metrics">
+            <span className="channel-list__rate">{formatPercentage(channel.conversionRate)}</span>
+            <span className="channel-list__trend">
+              +{formatPercentage(channel.trend)}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  </section>
+)
+
+type AnnouncementListProps = {
+  items: Announcement[]
+}
+
+const AnnouncementList = ({ items }: AnnouncementListProps) => (
+  <section className="card announcement-card" aria-labelledby="announcement-heading">
+    <header className="card__header">
+      <div>
+        <h2 id="announcement-heading">Updates</h2>
+        <p className="card__subtitle">Operational updates and enablement highlights for the team.</p>
+      </div>
+    </header>
+    <ul className="announcement-list">
+      {items.map(item => (
+        <li key={item.id} className="announcement-list__item">
+          <div className="announcement-list__icon" aria-hidden="true">
+            <Sparkles size={16} />
+          </div>
+          <div className="announcement-list__content">
+            <div className="announcement-list__heading">
+              <span className="announcement-list__title">{item.title}</span>
+              <span className="announcement-list__date">{formatDate(item.date)}</span>
+            </div>
+            <p className="announcement-list__message">{item.message}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  </section>
+)
+
+const formatDate = (value: string): string => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+const initials = (name: string): string => {
+  const parts = name.split(' ').filter(Boolean)
+  if (parts.length === 0) {
+    return 'T'
+  }
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2).toUpperCase()
+  }
+  return `${parts[0]!.charAt(0)}${parts[parts.length - 1]!.charAt(0)}`.toUpperCase()
+}
+
+function App() {
+  const [timeframe, setTimeframe] = useState<DashboardTimeframe>(defaultDashboardTimeframe)
+  const snapshot = useMemo<DashboardSnapshot>(() => buildDashboardSnapshot(timeframe), [timeframe])
+
+  return (
+    <div className="app-shell">
+      <aside className="sidebar" aria-label="Primary navigation">
+        <div className="sidebar__brand">
+          <div className="sidebar__mark" aria-hidden="true">
+            <ShieldCheck size={24} />
+          </div>
+          <div>
+            <span className="sidebar__title">TailAdmin</span>
+            <span className="sidebar__subtitle">React edition</span>
+          </div>
+        </div>
+        <nav>
+          <ul className="sidebar__nav">
+            {NAVIGATION_ITEMS.map(item => (
+              <li key={item.label}>
+                <a className={`sidebar__link${item.label === 'Overview' ? ' is-active' : ''}`} href="#">
+                  <item.icon size={16} aria-hidden="true" />
+                  <span>{item.label}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <div className="sidebar__footer">
+          <div className="sidebar__footer-heading">
+            <Target size={16} aria-hidden="true" />
+            <span>Quarterly target</span>
+          </div>
+          <p className="sidebar__footer-body">
+            Tracking ahead of plan. Maintain inbound cadence and delivery velocity.
+          </p>
+          <button type="button" className="sidebar__footer-action">
+            <ArrowUpRight size={16} aria-hidden="true" />
+            View playbook
+          </button>
+        </div>
+      </aside>
+
+      <div className="workspace">
+        <header className="topbar">
+          <button type="button" className="topbar__menu" aria-label="Open navigation">
+            <Menu size={18} />
+          </button>
+          <div className="topbar__search">
+            <Search size={16} aria-hidden="true" />
+            <input type="search" placeholder="Search projects, clients, and docs" aria-label="Search dashboard" />
+          </div>
+          <div className="topbar__actions">
+            <button type="button" className="icon-button" aria-label="Notifications">
+              <Bell size={18} />
+            </button>
+            <div className="user-pill" role="button" tabIndex={0} aria-label="Account menu">
+              <div className="user-pill__avatar" aria-hidden="true">
+                <Users size={16} />
+              </div>
+              <div className="user-pill__meta">
+                <span className="user-pill__name">Nova Martinez</span>
+                <span className="user-pill__role">Operations lead</span>
+              </div>
+              <ChevronDown size={16} aria-hidden="true" />
+            </div>
+          </div>
+        </header>
+
+        <main className="workspace__content">
+          <section className="page-heading">
+            <div>
+              <span className="page-heading__eyebrow">TailAdmin React</span>
+              <h1 className="page-heading__title">Control centre</h1>
+              <p className="page-heading__description">{TIMEFRAME_DESCRIPTION[timeframe]}</p>
+            </div>
+            <div className="timeframe-toggle" role="group" aria-label="Select timeframe">
+              {DASHBOARD_TIMEFRAMES.map(option => (
+                <button
+                  key={option}
+                  type="button"
+                  className={`timeframe-toggle__button${option === timeframe ? ' is-active' : ''}`}
+                  onClick={() => setTimeframe(option)}
+                  aria-pressed={option === timeframe}
+                >
+                  {TIMEFRAME_LABELS[option]}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="metrics-grid">
+            {snapshot.metrics.map(metric => (
+              <MetricCard key={metric.id} metric={metric} />
+            ))}
+          </section>
+
+          <div className="primary-grid">
+            <RevenuePanel snapshot={snapshot} />
+            <TeamList members={snapshot.team} />
+          </div>
+
+          <div className="secondary-grid">
+            <PipelineTable items={snapshot.pipeline} />
+            <div className="secondary-grid__column">
+              <ChannelList channels={snapshot.channels} summary={snapshot.channelSummary} />
+              <AnnouncementList items={snapshot.highlights} />
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
   )
 }
 

--- a/portfolio-intake/src/dashboardData.ts
+++ b/portfolio-intake/src/dashboardData.ts
@@ -1,0 +1,595 @@
+export type DashboardTimeframe = 'week' | 'month' | 'quarter' | 'year'
+
+type MetricUnit = 'currency' | 'count' | 'percentage'
+
+type Metric = {
+  id: string
+  label: string
+  value: number
+  unit: MetricUnit
+  change: number
+  direction: 'up' | 'down'
+  description: string
+}
+
+type RevenuePoint = {
+  label: string
+  revenue: number
+  profit: number
+}
+
+type OrderStatus = 'Completed' | 'In review' | 'In progress' | 'At risk'
+
+type PipelineItem = {
+  id: string
+  client: string
+  project: string
+  amount: number
+  status: OrderStatus
+  dueDate: string
+  progress: number
+}
+
+type TeamMember = {
+  id: string
+  name: string
+  role: string
+  avatarColor: string
+  contributions: number
+  focus: string
+  hours: number
+}
+
+type ChannelPerformance = {
+  id: string
+  channel: string
+  leads: number
+  opportunities: number
+  conversionRate: number
+  trend: number
+}
+
+type Announcement = {
+  id: string
+  title: string
+  message: string
+  date: string
+}
+
+export type DashboardSnapshot = {
+  timeframe: DashboardTimeframe
+  metrics: Metric[]
+  revenue: RevenueSummary
+  pipeline: PipelineItem[]
+  team: TeamMember[]
+  channels: ChannelPerformance[]
+  highlights: Announcement[]
+  channelSummary: ChannelSummary
+}
+
+type RevenueSummary = {
+  series: RevenuePoint[]
+  totalRevenue: number
+  totalProfit: number
+  averageMargin: number
+}
+
+type ChannelSummary = {
+  totalLeads: number
+  strongestChannel: ChannelPerformance
+  averageConversion: number
+}
+
+export const DASHBOARD_TIMEFRAMES: DashboardTimeframe[] = [
+  'week',
+  'month',
+  'quarter',
+  'year',
+]
+
+const DEFAULT_TIMEFRAME: DashboardTimeframe = 'month'
+
+const METRIC_DATA: Record<DashboardTimeframe, Metric[]> = {
+  week: [
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      value: 48250,
+      unit: 'currency',
+      change: 12.6,
+      direction: 'up',
+      description: 'vs last week',
+    },
+    {
+      id: 'active-clients',
+      label: 'Active clients',
+      value: 28,
+      unit: 'count',
+      change: 3.2,
+      direction: 'up',
+      description: '9 projects delivered on time',
+    },
+    {
+      id: 'conversion',
+      label: 'Proposal win rate',
+      value: 37.4,
+      unit: 'percentage',
+      change: 1.4,
+      direction: 'up',
+      description: 'Improved follow-up cadence',
+    },
+    {
+      id: 'utilisation',
+      label: 'Team utilisation',
+      value: 76,
+      unit: 'percentage',
+      change: 4.3,
+      direction: 'down',
+      description: 'Capacity available for rush work',
+    },
+  ],
+  month: [
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      value: 192400,
+      unit: 'currency',
+      change: 18.2,
+      direction: 'up',
+      description: 'vs last month',
+    },
+    {
+      id: 'active-clients',
+      label: 'Active clients',
+      value: 42,
+      unit: 'count',
+      change: 6.5,
+      direction: 'up',
+      description: '12 new retainers won',
+    },
+    {
+      id: 'conversion',
+      label: 'Proposal win rate',
+      value: 41.2,
+      unit: 'percentage',
+      change: 5.1,
+      direction: 'up',
+      description: 'Automation in outreach workflow',
+    },
+    {
+      id: 'utilisation',
+      label: 'Team utilisation',
+      value: 83,
+      unit: 'percentage',
+      change: 2.8,
+      direction: 'down',
+      description: 'Hiring pipeline opened',
+    },
+  ],
+  quarter: [
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      value: 562900,
+      unit: 'currency',
+      change: 11.4,
+      direction: 'up',
+      description: 'vs previous quarter',
+    },
+    {
+      id: 'active-clients',
+      label: 'Active clients',
+      value: 65,
+      unit: 'count',
+      change: 8.1,
+      direction: 'up',
+      description: 'Enterprise pipeline growth',
+    },
+    {
+      id: 'conversion',
+      label: 'Proposal win rate',
+      value: 44.3,
+      unit: 'percentage',
+      change: 3.9,
+      direction: 'up',
+      description: 'Improved discovery process',
+    },
+    {
+      id: 'utilisation',
+      label: 'Team utilisation',
+      value: 88,
+      unit: 'percentage',
+      change: 1.5,
+      direction: 'down',
+      description: 'Increased tooling efficiency',
+    },
+  ],
+  year: [
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      value: 2104300,
+      unit: 'currency',
+      change: 24.7,
+      direction: 'up',
+      description: 'Year over year',
+    },
+    {
+      id: 'active-clients',
+      label: 'Active clients',
+      value: 112,
+      unit: 'count',
+      change: 15.4,
+      direction: 'up',
+      description: 'Portfolio diversification',
+    },
+    {
+      id: 'conversion',
+      label: 'Proposal win rate',
+      value: 46.1,
+      unit: 'percentage',
+      change: 6.2,
+      direction: 'up',
+      description: 'Advisory services introduced',
+    },
+    {
+      id: 'utilisation',
+      label: 'Team utilisation',
+      value: 86,
+      unit: 'percentage',
+      change: 3.7,
+      direction: 'down',
+      description: 'Scaled creative operations',
+    },
+  ],
+}
+
+const REVENUE_DATA: Record<DashboardTimeframe, RevenuePoint[]> = {
+  week: [
+    { label: 'Mon', revenue: 5800, profit: 2100 },
+    { label: 'Tue', revenue: 6400, profit: 2600 },
+    { label: 'Wed', revenue: 7200, profit: 2900 },
+    { label: 'Thu', revenue: 6900, profit: 2700 },
+    { label: 'Fri', revenue: 5400, profit: 2100 },
+    { label: 'Sat', revenue: 4300, profit: 1700 },
+    { label: 'Sun', revenue: 3650, profit: 1400 },
+  ],
+  month: [
+    { label: 'Week 1', revenue: 42000, profit: 16300 },
+    { label: 'Week 2', revenue: 45800, profit: 17200 },
+    { label: 'Week 3', revenue: 51800, profit: 19100 },
+    { label: 'Week 4', revenue: 52700, profit: 19800 },
+  ],
+  quarter: [
+    { label: 'Jan', revenue: 172000, profit: 61500 },
+    { label: 'Feb', revenue: 186500, profit: 67100 },
+    { label: 'Mar', revenue: 204400, profit: 74200 },
+  ],
+  year: [
+    { label: 'Q1', revenue: 552000, profit: 196200 },
+    { label: 'Q2', revenue: 512600, profit: 184300 },
+    { label: 'Q3', revenue: 516800, profit: 182900 },
+    { label: 'Q4', revenue: 524900, profit: 187600 },
+  ],
+}
+
+const PIPELINE_DATA: Record<DashboardTimeframe, PipelineItem[]> = {
+  week: [
+    {
+      id: 'PX-1024',
+      client: 'Atlas Fintech',
+      project: 'Mobile banking onboarding',
+      amount: 18200,
+      status: 'In progress',
+      dueDate: '2025-01-18',
+      progress: 64,
+    },
+    {
+      id: 'PX-1011',
+      client: 'Greenline Energy',
+      project: 'Analytics portal redesign',
+      amount: 26800,
+      status: 'In review',
+      dueDate: '2025-01-15',
+      progress: 82,
+    },
+    {
+      id: 'PX-1008',
+      client: 'Northwind Labs',
+      project: 'Product launch microsite',
+      amount: 9400,
+      status: 'In progress',
+      dueDate: '2025-01-22',
+      progress: 47,
+    },
+  ],
+  month: [
+    {
+      id: 'PX-1036',
+      client: 'Stellar Networks',
+      project: 'Enterprise dashboard system',
+      amount: 74200,
+      status: 'In progress',
+      dueDate: '2025-02-04',
+      progress: 58,
+    },
+    {
+      id: 'PX-1021',
+      client: 'Helix Bio',
+      project: 'Clinical research workspace',
+      amount: 52300,
+      status: 'In review',
+      dueDate: '2025-01-28',
+      progress: 76,
+    },
+    {
+      id: 'PX-1014',
+      client: 'Marble & Co.',
+      project: 'Immersive showroom experience',
+      amount: 38600,
+      status: 'Completed',
+      dueDate: '2024-12-19',
+      progress: 100,
+    },
+    {
+      id: 'PX-1009',
+      client: 'Nimbus Aviation',
+      project: 'Brand system expansion',
+      amount: 24800,
+      status: 'At risk',
+      dueDate: '2025-02-11',
+      progress: 35,
+    },
+  ],
+  quarter: [
+    {
+      id: 'PX-1055',
+      client: 'Silverline Logistics',
+      project: 'Operations control tower',
+      amount: 98200,
+      status: 'In progress',
+      dueDate: '2025-03-30',
+      progress: 44,
+    },
+    {
+      id: 'PX-1042',
+      client: 'Cardinal Health',
+      project: 'Supply planning suite',
+      amount: 117400,
+      status: 'In review',
+      dueDate: '2025-04-12',
+      progress: 61,
+    },
+    {
+      id: 'PX-1031',
+      client: 'Aurora Travel',
+      project: 'Omnichannel booking platform',
+      amount: 84600,
+      status: 'Completed',
+      dueDate: '2024-11-18',
+      progress: 100,
+    },
+    {
+      id: 'PX-1026',
+      client: 'Brightwave Retail',
+      project: 'Store analytics dashboard',
+      amount: 58600,
+      status: 'At risk',
+      dueDate: '2025-03-14',
+      progress: 28,
+    },
+  ],
+  year: [
+    {
+      id: 'PX-1108',
+      client: 'Blue Horizon',
+      project: 'Customer intelligence platform',
+      amount: 186400,
+      status: 'In progress',
+      dueDate: '2025-06-22',
+      progress: 31,
+    },
+    {
+      id: 'PX-1099',
+      client: 'Vector Manufacturing',
+      project: 'Predictive maintenance system',
+      amount: 164800,
+      status: 'In review',
+      dueDate: '2025-07-09',
+      progress: 48,
+    },
+    {
+      id: 'PX-1084',
+      client: 'Evergreen Foods',
+      project: 'Supply chain visualisation',
+      amount: 121900,
+      status: 'Completed',
+      dueDate: '2024-10-28',
+      progress: 100,
+    },
+    {
+      id: 'PX-1072',
+      client: 'Harbor Insurance',
+      project: 'Claims automation suite',
+      amount: 143200,
+      status: 'At risk',
+      dueDate: '2025-05-17',
+      progress: 39,
+    },
+  ],
+}
+
+const TEAM_MEMBERS: TeamMember[] = [
+  {
+    id: 'team-1',
+    name: 'Nova Martinez',
+    role: 'Design Lead',
+    avatarColor: '#6366f1',
+    contributions: 24,
+    focus: 'Research synthesis',
+    hours: 32,
+  },
+  {
+    id: 'team-2',
+    name: 'Mikael Chen',
+    role: 'Product Strategist',
+    avatarColor: '#ec4899',
+    contributions: 18,
+    focus: 'Roadmap planning',
+    hours: 29,
+  },
+  {
+    id: 'team-3',
+    name: 'Priya Patel',
+    role: 'Engineering Manager',
+    avatarColor: '#22d3ee',
+    contributions: 31,
+    focus: 'Platform acceleration',
+    hours: 36,
+  },
+  {
+    id: 'team-4',
+    name: 'Caleb Wright',
+    role: 'Delivery Partner',
+    avatarColor: '#f97316',
+    contributions: 15,
+    focus: 'Client onboarding',
+    hours: 21,
+  },
+]
+
+const CHANNEL_DATA: Record<DashboardTimeframe, ChannelPerformance[]> = {
+  week: [
+    { id: 'channel-1', channel: 'Referrals', leads: 28, opportunities: 14, conversionRate: 0.48, trend: 6.2 },
+    { id: 'channel-2', channel: 'Newsletter', leads: 32, opportunities: 12, conversionRate: 0.37, trend: 3.8 },
+    { id: 'channel-3', channel: 'LinkedIn', leads: 21, opportunities: 9, conversionRate: 0.42, trend: 4.9 },
+  ],
+  month: [
+    { id: 'channel-1', channel: 'Referrals', leads: 132, opportunities: 68, conversionRate: 0.52, trend: 7.4 },
+    { id: 'channel-2', channel: 'Webinars', leads: 96, opportunities: 42, conversionRate: 0.44, trend: 5.3 },
+    { id: 'channel-3', channel: 'LinkedIn', leads: 84, opportunities: 33, conversionRate: 0.39, trend: 4.8 },
+    { id: 'channel-4', channel: 'Newsletter', leads: 102, opportunities: 36, conversionRate: 0.35, trend: 3.6 },
+  ],
+  quarter: [
+    { id: 'channel-1', channel: 'Referrals', leads: 384, opportunities: 182, conversionRate: 0.47, trend: 6.9 },
+    { id: 'channel-2', channel: 'Enterprise events', leads: 266, opportunities: 121, conversionRate: 0.46, trend: 7.1 },
+    { id: 'channel-3', channel: 'LinkedIn', leads: 218, opportunities: 84, conversionRate: 0.39, trend: 4.3 },
+    { id: 'channel-4', channel: 'Advisory content', leads: 204, opportunities: 77, conversionRate: 0.38, trend: 4.9 },
+  ],
+  year: [
+    { id: 'channel-1', channel: 'Referrals', leads: 1340, opportunities: 612, conversionRate: 0.46, trend: 6.2 },
+    { id: 'channel-2', channel: 'Partnerships', leads: 986, opportunities: 418, conversionRate: 0.42, trend: 5.5 },
+    { id: 'channel-3', channel: 'Thought leadership', leads: 842, opportunities: 307, conversionRate: 0.36, trend: 4.3 },
+    { id: 'channel-4', channel: 'Paid media', leads: 764, opportunities: 268, conversionRate: 0.31, trend: 3.1 },
+  ],
+}
+
+const ANNOUNCEMENTS: Announcement[] = [
+  {
+    id: 'announce-1',
+    title: 'January reporting window',
+    message: 'Submit partner performance scorecards by 21 January. Templates are pre-filled with CRM metrics.',
+    date: '2025-01-12',
+  },
+  {
+    id: 'announce-2',
+    title: 'Growth playbook 2.1',
+    message: 'New discovery scripts and objection handling flows are now available in the enablement hub.',
+    date: '2025-01-10',
+  },
+  {
+    id: 'announce-3',
+    title: 'Design asset refresh',
+    message: 'Updated TailAdmin illustration set launched to marketing. Use v2 components for all paid channels.',
+    date: '2025-01-08',
+  },
+]
+
+const getValidTimeframe = (timeframe?: DashboardTimeframe | string | null): DashboardTimeframe => {
+  if (timeframe && DASHBOARD_TIMEFRAMES.includes(timeframe as DashboardTimeframe)) {
+    return timeframe as DashboardTimeframe
+  }
+  return DEFAULT_TIMEFRAME
+}
+
+const sumNumbers = (values: number[]): number =>
+  values.reduce((total, value) => total + value, 0)
+
+const computeRevenueSummary = (series: RevenuePoint[]): RevenueSummary => {
+  const totalRevenue = sumNumbers(series.map(point => point.revenue))
+  const totalProfit = sumNumbers(series.map(point => point.profit))
+  const averageMargin = series.length === 0 ? 0 : Math.round((totalProfit / totalRevenue) * 100)
+  return {
+    series,
+    totalRevenue,
+    totalProfit,
+    averageMargin: Number.isFinite(averageMargin) ? averageMargin : 0,
+  }
+}
+
+const computeChannelSummary = (channels: ChannelPerformance[]): ChannelSummary => {
+  if (channels.length === 0) {
+    return {
+      totalLeads: 0,
+      strongestChannel: {
+        id: 'channel-empty',
+        channel: 'No data',
+        leads: 0,
+        opportunities: 0,
+        conversionRate: 0,
+        trend: 0,
+      },
+      averageConversion: 0,
+    }
+  }
+
+  const totalLeads = sumNumbers(channels.map(channel => channel.leads))
+  const strongestChannel = [...channels].sort(
+    (a, b) => b.conversionRate * b.opportunities - a.conversionRate * a.opportunities,
+  )[0]
+  const averageConversion =
+    channels.reduce((total, channel) => total + channel.conversionRate, 0) / channels.length
+
+  return {
+    totalLeads,
+    strongestChannel,
+    averageConversion: Math.round(averageConversion * 1000) / 10,
+  }
+}
+
+export const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: value >= 1000 ? 0 : 2,
+  }).format(value)
+
+export const formatNumber = (value: number): string =>
+  new Intl.NumberFormat('en-US').format(value)
+
+export const formatPercentage = (value: number): string => {
+  const normalised = value > 1 ? value : value * 100
+  return `${Math.round(normalised * 10) / 10}%`
+}
+
+export const buildDashboardSnapshot = (timeframe?: DashboardTimeframe | string | null): DashboardSnapshot => {
+  const safeTimeframe = getValidTimeframe(timeframe)
+  const metrics = METRIC_DATA[safeTimeframe]
+  const revenueSeries = REVENUE_DATA[safeTimeframe]
+  const pipeline = PIPELINE_DATA[safeTimeframe]
+  const channels = CHANNEL_DATA[safeTimeframe]
+
+  return {
+    timeframe: safeTimeframe,
+    metrics,
+    revenue: computeRevenueSummary(revenueSeries),
+    pipeline,
+    team: TEAM_MEMBERS,
+    channels,
+    highlights: ANNOUNCEMENTS,
+    channelSummary: computeChannelSummary(channels),
+  }
+}
+
+export type { Metric, RevenuePoint, PipelineItem, TeamMember, ChannelPerformance, Announcement, RevenueSummary, ChannelSummary }
+export { DEFAULT_TIMEFRAME as defaultDashboardTimeframe, ANNOUNCEMENTS as dashboardAnnouncements }

--- a/portfolio-intake/src/index.css
+++ b/portfolio-intake/src/index.css
@@ -1,68 +1,36 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color-scheme: dark;
+  color: #e2e8f0;
+  background-color: #0b1120;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
 }
+
 a:hover {
-  color: #535bf2;
+  color: #f8fafc;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  background: radial-gradient(circle at 20% -10%, rgba(129, 140, 248, 0.3), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.25), transparent 55%),
+    #0b1120;
+  display: block;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+#root {
+  min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- add a data module that assembles metrics, revenue, pipeline, team, channel, and announcement datasets for TailAdmin views
- implement a TailAdmin React control centre with timeframe switcher, analytics cards, pipeline table, team focus, growth channels, and updates
- refresh the TailAdmin styling layer with a dark gradient workspace, responsive layout, and chart/list treatments

## Testing
- npm run --silent lint
- npm test --silent
- (cd portfolio-intake) npm run --silent lint
- (cd portfolio-intake) npm run --silent build

------
https://chatgpt.com/codex/tasks/task_e_68ce0892f210832f8bf08533041f01db