### PR TITLE
Restore dashboard exports and previews

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -19,7 +19,6 @@ import {
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useApp } from '../contexts/AppContext';
-import { useApi, useApiRequest } from '../hooks/useApi';
 import { Button, Input, LoadingSpinner } from '../components/ui';
 import Card from '../components/ui/Card';
 import ThemeToggle from '../components/ThemeToggle';
@@ -62,6 +61,289 @@ export type ApiProject = {
   deliverablePreviews: ApiDeliverablePreview[];
 };
 
+const joinClasses = (
+  ...classes: Array<string | false | null | undefined>
+) => classes.filter(Boolean).join(' ');
+
+const parseDate = (value?: string | null): number | undefined => {
+  if (!value) return undefined;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+};
+
+const formatDateDisplay = (
+  value?: string | null,
+  fallback = 'Unknown',
+) => {
+  const timestamp = parseDate(value);
+  if (timestamp === undefined) return fallback;
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const formatDateTimeDisplay = (
+  value?: string | null,
+  fallback = 'Unknown',
+) => {
+  const timestamp = parseDate(value);
+  if (timestamp === undefined) return fallback;
+  return new Date(timestamp).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+const fileNameFromPath = (relativePath: string) =>
+  relativePath.split('/').filter(Boolean).pop() ?? relativePath;
+
+export type FreshnessState =
+  | 'in-sync'
+  | 'filesystem-updated'
+  | 'metadata-updated'
+  | 'brief-updated'
+  | 'sync-needed'
+  | 'never-synced';
+
+type FreshnessUpdate =
+  | 'filesystem-updated'
+  | 'metadata-updated'
+  | 'brief-updated';
+
+type FreshnessCopy = {
+  label: string;
+  description: string;
+  tone: 'neutral' | 'warning' | 'danger' | 'success';
+  icon: React.ReactNode;
+};
+
+const FRESHNESS_COPY: Record<FreshnessState, FreshnessCopy> = {
+  'in-sync': {
+    label: 'Up to date',
+    description: 'Project is fully synchronised with the filesystem',
+    tone: 'success',
+    icon: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />,
+  },
+  'filesystem-updated': {
+    label: 'Filesystem newer',
+    description: 'Files changed on disk since the last sync',
+    tone: 'warning',
+    icon: <Activity className="h-3.5 w-3.5" aria-hidden="true" />,
+  },
+  'metadata-updated': {
+    label: 'Metadata newer',
+    description: 'Project metadata has changes waiting to sync',
+    tone: 'warning',
+    icon: <FileText className="h-3.5 w-3.5" aria-hidden="true" />,
+  },
+  'brief-updated': {
+    label: 'Brief newer',
+    description: 'Project brief has been edited since the last sync',
+    tone: 'warning',
+    icon: <FileEdit className="h-3.5 w-3.5" aria-hidden="true" />,
+  },
+  'sync-needed': {
+    label: 'Needs sync',
+    description: 'Project reports pending changes',
+    tone: 'danger',
+    icon: <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />,
+  },
+  'never-synced': {
+    label: 'Never synced',
+    description: 'Project has not been synchronised yet',
+    tone: 'neutral',
+    icon: <Calendar className="h-3.5 w-3.5" aria-hidden="true" />,
+  },
+};
+
+const FRESHNESS_TONE_CLASSES: Record<
+  FreshnessCopy['tone'],
+  string
+> = {
+  success:
+    'bg-emerald-100/80 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-200 dark:ring-emerald-800/60',
+  warning:
+    'bg-amber-100/80 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:ring-amber-800/60',
+  danger:
+    'bg-rose-100/80 text-rose-700 ring-1 ring-inset ring-rose-200 dark:bg-rose-900/40 dark:text-rose-200 dark:ring-rose-800/60',
+  neutral:
+    'bg-gray-100/80 text-gray-700 ring-1 ring-inset ring-gray-200 dark:bg-gray-800/60 dark:text-gray-200 dark:ring-gray-700/60',
+};
+
+const getLatestUpdate = (
+  project: ApiProject,
+): { type: FreshnessUpdate; timestamp: number } | undefined => {
+  const updates: Array<{
+    type: FreshnessUpdate;
+    timestamp?: number;
+  }> = [
+    { type: 'filesystem-updated', timestamp: parseDate(project.fsLastModified) },
+    { type: 'metadata-updated', timestamp: parseDate(project.metadataUpdatedAt) },
+    { type: 'brief-updated', timestamp: parseDate(project.briefUpdatedAt) },
+  ];
+
+  return updates
+    .filter((update): update is { type: FreshnessUpdate; timestamp: number } =>
+      update.timestamp !== undefined,
+    )
+    .sort((a, b) => b.timestamp - a.timestamp)[0];
+};
+
+export const computeFreshness = (project: ApiProject): FreshnessState => {
+  const lastSynced = parseDate(project.lastSyncedAt);
+  const latestUpdate = getLatestUpdate(project);
+
+  if (project.syncStatus && project.syncStatus !== 'synced' && project.syncStatus !== 'clean') {
+    return 'sync-needed';
+  }
+
+  if (!latestUpdate) {
+    return lastSynced === undefined ? 'never-synced' : 'in-sync';
+  }
+
+  if (lastSynced === undefined) {
+    return latestUpdate.type;
+  }
+
+  if (latestUpdate.timestamp > lastSynced) {
+    return latestUpdate.type;
+  }
+
+  return 'in-sync';
+};
+
+type FreshnessBadgeProps = {
+  project: ApiProject;
+  className?: string;
+};
+
+export const FreshnessBadge: React.FC<FreshnessBadgeProps> = ({
+  project,
+  className,
+}) => {
+  const state = computeFreshness(project);
+  const { label, description, tone, icon } = FRESHNESS_COPY[state];
+
+  return (
+    <span
+      className={joinClasses(
+        'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
+        FRESHNESS_TONE_CLASSES[tone],
+        className,
+      )}
+      title={description}
+    >
+      {icon}
+      <span>{label}</span>
+    </span>
+  );
+};
+
+type AssetPreviewListProps = {
+  assets: ApiAssetPreview[];
+  title?: string;
+  emptyMessage?: string;
+};
+
+export const AssetPreviewList: React.FC<AssetPreviewListProps> = ({
+  assets,
+  title,
+  emptyMessage = 'No assets available yet.',
+}) => (
+  <section className="space-y-2">
+    {title ? (
+      <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {title}
+      </h5>
+    ) : null}
+    {assets.length === 0 ? (
+      <p className="text-sm text-gray-500 dark:text-gray-400">{emptyMessage}</p>
+    ) : (
+      <ul className="space-y-2">
+        {assets.map((asset) => {
+          const displayLabel = asset.label ?? fileNameFromPath(asset.relativePath);
+          return (
+            <li
+              key={asset.id}
+              className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-white/60 px-3 py-2 text-sm shadow-sm backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/40"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium text-gray-900 dark:text-gray-100">
+                  {displayLabel}
+                </p>
+                <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                  {asset.relativePath}
+                </p>
+              </div>
+              <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                {formatDateTimeDisplay(asset.updatedAt)}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    )}
+  </section>
+);
+
+type DeliverablePreviewListProps = {
+  deliverables: ApiDeliverablePreview[];
+  title?: string;
+  emptyMessage?: string;
+};
+
+export const DeliverablePreviewList: React.FC<DeliverablePreviewListProps> = ({
+  deliverables,
+  title,
+  emptyMessage = 'No deliverables available yet.',
+}) => (
+  <section className="space-y-2">
+    {title ? (
+      <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {title}
+      </h5>
+    ) : null}
+    {deliverables.length === 0 ? (
+      <p className="text-sm text-gray-500 dark:text-gray-400">{emptyMessage}</p>
+    ) : (
+      <ul className="space-y-2">
+        {deliverables.map((deliverable) => {
+          const displayLabel =
+            deliverable.label ?? fileNameFromPath(deliverable.relativePath);
+          const formatLabel = deliverable.format
+            ? deliverable.format.toUpperCase()
+            : undefined;
+
+          return (
+            <li
+              key={deliverable.id}
+              className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-white/60 px-3 py-2 text-sm shadow-sm backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/40"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium text-gray-900 dark:text-gray-100">
+                  {displayLabel}
+                </p>
+                <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                  {formatLabel ? `${formatLabel} • ` : ''}
+                  {deliverable.relativePath}
+                </p>
+              </div>
+              <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                {formatDateTimeDisplay(deliverable.updatedAt)}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    )}
+  </section>
+);
+
 const DashboardPage = () => {
   const { addNotification } = useApp();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -72,17 +354,24 @@ const DashboardPage = () => {
   const [importing, setImporting] = useState(false);
 
   // Mock data for demonstration - replace with actual API calls
-  const stats = useMemo(() => ({
-    totalProjects: projects.length,
-    totalAssets: projects.reduce((sum, p) => sum + p.assetCount, 0),
-    totalDeliverables: projects.reduce((sum, p) => sum + p.deliverableCount, 0),
-    recentlyUpdated: projects.filter(p => {
-      const lastModified = new Date(p.fsLastModified || 0);
-      const weekAgo = new Date();
-      weekAgo.setDate(weekAgo.getDate() - 7);
-      return lastModified > weekAgo;
-    }).length,
-  }), [projects]);
+  const stats = useMemo(() => {
+    const weekAgo = new Date();
+    weekAgo.setDate(weekAgo.getDate() - 7);
+    const weekAgoTimestamp = weekAgo.getTime();
+
+    return {
+      totalProjects: projects.length,
+      totalAssets: projects.reduce((sum, project) => sum + project.assetCount, 0),
+      totalDeliverables: projects.reduce(
+        (sum, project) => sum + project.deliverableCount,
+        0,
+      ),
+      recentlyUpdated: projects.filter(project => {
+        const lastModified = parseDate(project.fsLastModified);
+        return lastModified !== undefined && lastModified >= weekAgoTimestamp;
+      }).length,
+    };
+  }, [projects]);
 
   const filteredProjects = useMemo(() => {
     if (!searchQuery) return projects;
@@ -145,10 +434,8 @@ const DashboardPage = () => {
     loadProjects();
   }, [addNotification]);
 
-  const formatDate = (dateString?: string | null) => {
-    if (!dateString) return 'Never';
-    return new Date(dateString).toLocaleDateString();
-  };
+  const formatDate = (dateString?: string | null) =>
+    formatDateDisplay(dateString, 'Never');
 
   if (loading) {
     return (
@@ -378,50 +665,117 @@ const DashboardPage = () => {
               </div>
             ) : (
               <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {filteredProjects.map((project) => (
-                  <Card key={project.id} className="border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow">
-                    <Card.Body className="p-4">
-                      <div className="flex items-start justify-between mb-3">
-                        <h4 className="font-semibold text-gray-900 dark:text-white truncate">
-                          {project.title}
-                        </h4>
-                        <span className={`text-xs px-2 py-1 rounded-full ${
-                          project.syncStatus === 'synced'
-                            ? 'bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300'
-                            : 'bg-yellow-100 dark:bg-yellow-900 text-yellow-700 dark:text-yellow-300'
-                        }`}>
-                          {project.syncStatus}
-                        </span>
-                      </div>
-                      {project.organization && (
-                        <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">{project.organization}</p>
-                      )}
-                      <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-                        <span>{project.assetCount} assets</span>
-                        <span>{formatDate(project.fsLastModified)}</span>
-                      </div>
-                      <div className="mt-3 flex gap-2">
-                        <Button
-                          as={Link}
-                          to={`/editor/${project.id}`}
-                          variant="outline"
-                          size="sm"
-                          leftIcon={<FileEdit className="h-3 w-3" />}
-                          className="flex-1"
-                        >
-                          Edit
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          leftIcon={<Download className="h-3 w-3" />}
-                        >
-                          Export
-                        </Button>
-                      </div>
-                    </Card.Body>
-                  </Card>
-                ))}
+                {filteredProjects.map((project) => {
+                  const assetPreviews = project.assetPreviews.slice(0, 3);
+                  const deliverablePreviews = project.deliverablePreviews.slice(0, 3);
+                  const tagsToShow = project.tags.slice(0, 3);
+
+                  return (
+                    <Card
+                      key={project.id}
+                      className="border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow"
+                    >
+                      <Card.Body className="space-y-4 p-4">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="min-w-0 space-y-2">
+                            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                              <h4 className="truncate text-base font-semibold text-gray-900 dark:text-white">
+                                {project.title}
+                              </h4>
+                              {project.year ? (
+                                <span className="text-xs text-gray-500 dark:text-gray-400">
+                                  {project.year}
+                                </span>
+                              ) : null}
+                            </div>
+                            {project.organization ? (
+                              <p className="text-sm text-gray-600 dark:text-gray-400">
+                                {project.organization}
+                              </p>
+                            ) : null}
+                            {project.summary ? (
+                              <p className="text-sm text-gray-500 dark:text-gray-400">
+                                {project.summary}
+                              </p>
+                            ) : null}
+                            {tagsToShow.length > 0 ? (
+                              <div className="flex flex-wrap gap-2 pt-1">
+                                {tagsToShow.map(tag => (
+                                  <span
+                                    key={tag}
+                                    className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                                  >
+                                    #{tag}
+                                  </span>
+                                ))}
+                                {project.tags.length > tagsToShow.length ? (
+                                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                                    +{project.tags.length - tagsToShow.length} more
+                                  </span>
+                                ) : null}
+                              </div>
+                            ) : null}
+                          </div>
+                          <div className="flex flex-col items-end gap-2">
+                            <FreshnessBadge project={project} />
+                            <span
+                              className={`text-[11px] font-semibold uppercase tracking-wide ${
+                                project.syncStatus === 'synced' || project.syncStatus === 'clean'
+                                  ? 'text-emerald-600 dark:text-emerald-300'
+                                  : 'text-amber-600 dark:text-amber-300'
+                              }`}
+                            >
+                              {project.syncStatus}
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-gray-500 dark:text-gray-400">
+                          <span>{project.assetCount} assets</span>
+                          <span>{project.deliverableCount} deliverables</span>
+                          <span>Filesystem updated {formatDate(project.fsLastModified)}</span>
+                          {project.lastSyncedAt ? (
+                            <span>Last sync {formatDate(project.lastSyncedAt)}</span>
+                          ) : (
+                            <span>Never synced</span>
+                          )}
+                        </div>
+
+                        <div className="grid gap-4 md:grid-cols-2">
+                          <AssetPreviewList
+                            assets={assetPreviews}
+                            title={`Assets (${project.assetCount})`}
+                          />
+                          <DeliverablePreviewList
+                            deliverables={deliverablePreviews}
+                            title={`Deliverables (${project.deliverableCount})`}
+                          />
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            as={Link}
+                            to={`/editor/${project.id}`}
+                            variant="outline"
+                            size="sm"
+                            leftIcon={<FileEdit className="h-3 w-3" />}
+                            className="flex-1 sm:flex-none"
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            leftIcon={<Download className="h-3 w-3" />}
+                            className="flex-1 sm:flex-none"
+                          >
+                            Export
+                          </Button>
+                        </div>
+                      </Card.Body>
+                    </Card>
+                  );
+                })}
               </div>
             )}
           </Card.Body>


### PR DESCRIPTION
## Summary
- add reusable helpers and exports for dashboard building blocks like computeFreshness, FreshnessBadge, AssetPreviewList, and DeliverablePreviewList
- improve project stats formatting and show preview lists and freshness badges inside dashboard project cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce16a661cc832faea80c11751ed365