### PR TITLE
Fix Card compound component exports

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -24,11 +24,7 @@ interface CardFooterProps {
   className?: string;
 }
 
-const Card: React.FC<CardProps> & {
-  Header: React.FC<CardHeaderProps>;
-  Body: React.FC<CardBodyProps>;
-  Footer: React.FC<CardFooterProps>;
-} = ({
+const CardComponent: React.FC<CardProps> = ({
   children,
   className = '',
   padding = 'md',
@@ -110,8 +106,14 @@ const CardFooter: React.FC<CardFooterProps> = ({ children, className = '' }) => 
   );
 };
 
+const Card = React.memo(CardComponent) as React.MemoExoticComponent<React.FC<CardProps>> & {
+  Header: React.FC<CardHeaderProps>;
+  Body: React.FC<CardBodyProps>;
+  Footer: React.FC<CardFooterProps>;
+};
+
 Card.Header = React.memo(CardHeader);
 Card.Body = React.memo(CardBody);
 Card.Footer = React.memo(CardFooter);
 
-export default React.memo(Card);
+export default Card;


### PR DESCRIPTION
## Summary
- ensure the Card compound component retains its Header, Body, and Footer subcomponents after memoization
- export the memoized Card instance directly so consumers can access Card.Header/Card.Body/Card.Footer

## Testing
- npm run build *(fails: existing TypeScript errors in Input.tsx and several pages)*

------
https://chatgpt.com/codex/tasks/task_e_68ce25464d08832f9a24aae4ede47376