### PR TITLE
feat: add projects center showcase

### DIFF
--- a/src/TestPage.tsx
+++ b/src/TestPage.tsx
@@ -1,17 +1,536 @@
 import React from 'react';
+import {
+  AlertTriangle,
+  Calendar,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  Filter,
+  Plus,
+  Search,
+  Sparkles,
+  Star,
+  Target,
+  TrendingUp,
+  Users,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import './styles/projects-center.css';
 
-const TestPage = () => {
+type StatCard = {
+  id: string;
+  title: string;
+  value: string;
+  suffix?: string;
+  change: string;
+  changeTone: 'up' | 'steady' | 'down';
+  description: string;
+  background: string;
+};
+
+type FilterChip = {
+  id: string;
+  label: string;
+  icon?: LucideIcon;
+  active?: boolean;
+};
+
+type ProjectStatusTone = 'review' | 'execution' | 'planning' | 'research';
+type ProjectHealth = 'good' | 'watch' | 'risk';
+type MilestoneState = 'completed' | 'active' | 'upcoming';
+type UpdateStatus = 'complete' | 'pending' | 'risk';
+
+interface ProjectMeta {
+  label: string;
+  value: string;
+  icon: LucideIcon;
+}
+
+interface ProjectMilestone {
+  title: string;
+  caption: string;
+  state: MilestoneState;
+}
+
+interface TeamMember {
+  name: string;
+  role: string;
+  initials: string;
+  color: string;
+}
+
+interface Project {
+  id: string;
+  name: string;
+  category: string;
+  status: string;
+  statusTone: ProjectStatusTone;
+  priority: string;
+  description: string;
+  tags: string[];
+  meta: ProjectMeta[];
+  progress: number;
+  tasksCompleted: number;
+  tasksTotal: number;
+  healthState: ProjectHealth;
+  healthLabel: string;
+  team: TeamMember[];
+  milestones: ProjectMilestone[];
+}
+
+interface TeamUpdate {
+  id: string;
+  status: UpdateStatus;
+  title: string;
+  detail: string;
+  time: string;
+}
+
+interface UpcomingReview {
+  id: string;
+  title: string;
+  owner: string;
+  time: string;
+}
+
+const stats: StatCard[] = [
+  {
+    id: 'active-projects',
+    title: 'Active Projects',
+    value: '32',
+    suffix: '/ 40',
+    change: '+12%',
+    changeTone: 'up',
+    description: 'In production this month',
+    background: 'linear-gradient(135deg, #4338ca, #6366f1)',
+  },
+  {
+    id: 'upcoming-launches',
+    title: 'Upcoming Launches',
+    value: '12',
+    suffix: ' scheduled',
+    change: '4 this week',
+    changeTone: 'steady',
+    description: 'Coordinated across 5 teams',
+    background: 'linear-gradient(135deg, #7c3aed, #a855f7)',
+  },
+  {
+    id: 'team-capacity',
+    title: 'Team Capacity',
+    value: '82%',
+    suffix: ' utilised',
+    change: '6 open slots',
+    changeTone: 'up',
+    description: 'Creative pods ready to assist',
+    background: 'linear-gradient(135deg, #0f766e, #22c55e)',
+  },
+];
+
+const filters: FilterChip[] = [
+  { id: 'focus', label: 'High focus', icon: Sparkles, active: true },
+  { id: 'launch', label: 'Launch ready', icon: TrendingUp },
+  { id: 'review', label: 'Needs review', icon: AlertTriangle },
+  { id: 'design', label: 'Design systems' },
+  { id: 'week', label: 'This week' },
+];
+
+const projects: Project[] = [
+  {
+    id: 'synthwave-stories',
+    name: 'Synthwave Stories',
+    category: 'Case Study',
+    status: 'In review',
+    statusTone: 'review',
+    priority: 'High focus',
+    description:
+      'Narrative-driven product storytelling paired with interactive prototypes for the new marketing site.',
+    tags: ['Brand strategy', 'Interactive web', 'Motion'],
+    meta: [
+      { label: 'Launch window', value: 'Aug 22 · 3 weeks', icon: Calendar },
+      { label: 'Next milestone', value: 'Final QA review', icon: Target },
+      { label: 'Collaboration', value: 'Design × Marketing', icon: Users },
+    ],
+    progress: 76,
+    tasksCompleted: 28,
+    tasksTotal: 36,
+    healthState: 'good',
+    healthLabel: 'On track',
+    team: [
+      { name: 'Lara Owens', role: 'Art direction', initials: 'LO', color: '#f97316' },
+      { name: 'Mina Patel', role: 'UX research', initials: 'MP', color: '#6366f1' },
+      { name: 'Jasper Lin', role: 'Content strategy', initials: 'JL', color: '#10b981' },
+    ],
+    milestones: [
+      { title: 'Research synthesis', caption: 'Complete', state: 'completed' },
+      { title: 'QA review', caption: 'Due Aug 18', state: 'active' },
+      { title: 'Client presentation', caption: 'Aug 24', state: 'upcoming' },
+    ],
+  },
+  {
+    id: 'lumen-experience',
+    name: 'Lumen Experience',
+    category: 'Product launch',
+    status: 'In execution',
+    statusTone: 'execution',
+    priority: 'Launch sprint',
+    description:
+      'Immersive product demo built with real-time data visualisation and guided onboarding flows.',
+    tags: ['Product marketing', '3D visuals', 'Growth'],
+    meta: [
+      { label: 'Launch window', value: 'Sep 4 · 5 weeks', icon: Calendar },
+      { label: 'Next milestone', value: 'Beta invite drop', icon: Target },
+      { label: 'Collaboration', value: 'Product × Growth', icon: Users },
+    ],
+    progress: 64,
+    tasksCompleted: 41,
+    tasksTotal: 64,
+    healthState: 'watch',
+    healthLabel: 'Scope review',
+    team: [
+      { name: 'Alyssa Moore', role: 'Product design', initials: 'AM', color: '#ec4899' },
+      { name: 'Noah Kim', role: 'Engineering', initials: 'NK', color: '#22c55e' },
+      { name: 'Sasha Reed', role: 'Marketing', initials: 'SR', color: '#f97316' },
+    ],
+    milestones: [
+      { title: 'Prototype handoff', caption: 'Done', state: 'completed' },
+      { title: 'Scope alignment', caption: 'This week', state: 'active' },
+      { title: 'Launch rehearsal', caption: 'Sep 1', state: 'upcoming' },
+    ],
+  },
+  {
+    id: 'aurora-brand-refresh',
+    name: 'Aurora Brand Refresh',
+    category: 'Brand system',
+    status: 'In planning',
+    statusTone: 'planning',
+    priority: 'Discovery',
+    description:
+      'Elevated design system with adaptive color language, component library, and storytelling toolkit.',
+    tags: ['Identity', 'Design ops', 'Guidelines'],
+    meta: [
+      { label: 'Launch window', value: 'Oct 12 · 8 weeks', icon: Calendar },
+      { label: 'Next milestone', value: 'Stakeholder workshops', icon: Target },
+      { label: 'Collaboration', value: 'Brand × Ops', icon: Users },
+    ],
+    progress: 38,
+    tasksCompleted: 12,
+    tasksTotal: 32,
+    healthState: 'good',
+    healthLabel: 'Healthy pace',
+    team: [
+      { name: 'Diego Summers', role: 'Brand lead', initials: 'DS', color: '#3b82f6' },
+      { name: 'Kim Lee', role: 'Design ops', initials: 'KL', color: '#8b5cf6' },
+      { name: 'Priya Shah', role: 'Storytelling', initials: 'PS', color: '#f59e0b' },
+    ],
+    milestones: [
+      { title: 'Audience research', caption: 'Complete', state: 'completed' },
+      { title: 'Moodboard sprint', caption: 'Aug 27', state: 'active' },
+      { title: 'System rollout', caption: 'Oct 4', state: 'upcoming' },
+    ],
+  },
+];
+
+const teamUpdates: TeamUpdate[] = [
+  {
+    id: 'design-review',
+    status: 'complete',
+    title: 'Design research ready for review',
+    detail: 'Persona mapping & journeys uploaded to workspace.',
+    time: 'Today · 10:30 AM',
+  },
+  {
+    id: 'dev-sync',
+    status: 'pending',
+    title: 'Engineering sync scheduled',
+    detail: 'Frontend + platform walkthrough with QA team.',
+    time: 'Tomorrow · 2:00 PM',
+  },
+  {
+    id: 'risk-flag',
+    status: 'risk',
+    title: 'Content dependencies flagged',
+    detail: 'Awaiting final copy for hero narrative.',
+    time: 'Needs update · 3 owners',
+  },
+];
+
+const upcomingReviews: UpcomingReview[] = [
+  {
+    id: 'review-1',
+    title: 'Portfolio walkthrough dry run',
+    owner: 'Synthwave Stories',
+    time: 'Aug 18 · 4:00 PM',
+  },
+  {
+    id: 'review-2',
+    title: 'Brand system component audit',
+    owner: 'Aurora Refresh',
+    time: 'Aug 20 · 11:00 AM',
+  },
+  {
+    id: 'review-3',
+    title: 'Beta success metrics alignment',
+    owner: 'Lumen Experience',
+    time: 'Aug 22 · 9:30 AM',
+  },
+];
+
+const templateActions = ['Campaign blueprint', 'Case study outline', 'Launch checklist'];
+
+const TestPage: React.FC = () => {
   return (
-    <div className="min-h-screen bg-white text-black p-8">
-      <h1 className="text-4xl font-bold mb-4">Test Page Working!</h1>
-      <p className="text-lg">If you can see this, React is working properly.</p>
-      <div className="mt-8 p-4 bg-blue-100 border border-blue-300 rounded">
-        <h2 className="text-2xl font-semibold text-blue-800 mb-2">Debug Info:</h2>
-        <ul className="text-blue-700">
-          <li>• React is rendering</li>
-          <li>• CSS is loading</li>
-          <li>• Routing is working</li>
-        </ul>
+    <div className="projects-center-page">
+      <div className="projects-center-container">
+        <div className="projects-center-backdrop" aria-hidden="true" />
+        <div className="projects-center-shell">
+          <section className="pc-glass-card">
+            <header className="pc-header">
+              <div className="pc-header-top">
+                <div className="pc-header-intro">
+                  <span className="pc-pill">Creator hub · Weekly briefing</span>
+                  <h1>Projects Center</h1>
+                  <p>
+                    Plan, track, and launch portfolio-ready stories with a clear pulse on momentum,
+                    ownership, and upcoming deadlines.
+                  </p>
+                </div>
+                <div className="pc-header-actions-wrapper">
+                  <div className="pc-header-actions">
+                    <button type="button" className="pc-secondary-btn">
+                      <span className="icon">
+                        <Sparkles size={16} />
+                      </span>
+                      AI suggestions
+                    </button>
+                    <button type="button" className="pc-primary-btn">
+                      <span className="icon">
+                        <Plus size={16} />
+                      </span>
+                      New project
+                    </button>
+                  </div>
+                  <div className="pc-header-user">
+                    <span className="pc-avatar" aria-hidden="true">
+                      AO
+                    </span>
+                    <div>
+                      <strong>Alejandro Ortiz</strong>
+                      <span>Portfolio strategist</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="pc-search-row">
+                <div className="pc-search-input">
+                  <Search size={18} />
+                  <input type="search" placeholder="Search projects, tasks, and collaborators…" />
+                  <button type="button" className="pc-inline-action">
+                    <Filter size={16} />
+                    Filters
+                  </button>
+                </div>
+                <div className="pc-quick-filters" role="group" aria-label="Quick filters">
+                  {filters.map((filter) => {
+                    const Icon = filter.icon;
+                    return (
+                      <button
+                        key={filter.id}
+                        type="button"
+                        className={`pc-filter-chip${filter.active ? ' active' : ''}`}
+                      >
+                        {Icon ? <Icon size={14} /> : null}
+                        {filter.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              <div className="pc-stats-grid">
+                {stats.map((stat) => (
+                  <article key={stat.id} className="pc-stat-card" style={{ background: stat.background }}>
+                    <span className="pc-stat-label">{stat.title}</span>
+                    <div className="pc-stat-value">
+                      {stat.value}
+                      {stat.suffix ? <span className="suffix">{stat.suffix}</span> : null}
+                    </div>
+                    <div className="pc-stat-footer">
+                      <span>{stat.description}</span>
+                      <span className={`pc-stat-change ${stat.changeTone}`}>
+                        {stat.changeTone === 'up' ? (
+                          <TrendingUp size={15} />
+                        ) : stat.changeTone === 'down' ? (
+                          <AlertTriangle size={15} />
+                        ) : (
+                          <Clock size={15} />
+                        )}
+                        {stat.change}
+                      </span>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </header>
+          </section>
+
+          <div className="pc-main-grid">
+            <section className="pc-section-card">
+              <div className="pc-section-header">
+                <div>
+                  <h2>Active projects</h2>
+                  <span>5 updates since yesterday · aligned with quarterly roadmap</span>
+                </div>
+                <button type="button" className="pc-link">
+                  View pipeline
+                  <ChevronRight size={16} />
+                </button>
+              </div>
+
+              <div className="pc-project-list">
+                {projects.map((project) => (
+                  <article key={project.id} className="pc-project-card">
+                    <div>
+                      <div className="pc-project-header">
+                        <span className="pc-type-badge">{project.category}</span>
+                        <span className={`pc-status ${project.statusTone}`}>{project.status}</span>
+                      </div>
+                      <div className="pc-project-title">
+                        <h3>{project.name}</h3>
+                        <span className="pc-priority">
+                          <Star size={14} />
+                          {project.priority}
+                        </span>
+                      </div>
+                      <p className="pc-project-description">{project.description}</p>
+                      <div className="pc-project-tags">
+                        {project.tags.map((tag) => (
+                          <span key={tag} className="pc-tag">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <div className="pc-project-meta">
+                        {project.meta.map((item) => {
+                          const Icon = item.icon;
+                          return (
+                            <div key={item.label} className="pc-meta-item">
+                              <Icon />
+                              <div>
+                                <span className="pc-meta-label">{item.label}</span>
+                                <span className="pc-meta-value">{item.value}</span>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                    <div className="pc-project-progress">
+                      <div className="pc-progress-header">
+                        <span>Progress</span>
+                        <span className="pc-progress-value">{project.progress}%</span>
+                      </div>
+                      <div className="pc-progress-bar">
+                        <div className="pc-progress-fill" style={{ width: `${project.progress}%` }} />
+                      </div>
+                      <div className="pc-progress-footer">
+                        <span>
+                          {project.tasksCompleted}/{project.tasksTotal} tasks
+                        </span>
+                        <span
+                          className={`pc-health${project.healthState === 'good' ? '' : ` ${project.healthState}`}`}
+                        >
+                          {project.healthLabel}
+                        </span>
+                      </div>
+                      <div className="pc-avatar-group">
+                        {project.team.map((member) => (
+                          <span
+                            key={member.initials}
+                            className="pc-avatar"
+                            style={{ background: member.color }}
+                            title={`${member.name} · ${member.role}`}
+                          >
+                            {member.initials}
+                          </span>
+                        ))}
+                        <button type="button" className="pc-add-collaborator">
+                          <Plus size={16} />
+                        </button>
+                      </div>
+                      <div className="pc-progress-milestones">
+                        {project.milestones.map((milestone) => (
+                          <div key={milestone.title} className={`pc-milestone ${milestone.state}`}>
+                            <div>
+                              <strong>{milestone.title}</strong>
+                              <small>{milestone.caption}</small>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <aside className="pc-sidebar">
+              <div className="pc-side-card">
+                <div className="pc-side-header">
+                  <h3>Team updates</h3>
+                  <span>Shared across 3 pods</span>
+                </div>
+                {teamUpdates.map((update) => (
+                  <div key={update.id} className={`pc-update ${update.status}`}>
+                    <div className="pc-update-title">
+                      {update.status === 'complete' ? (
+                        <CheckCircle2 />
+                      ) : update.status === 'pending' ? (
+                        <Clock />
+                      ) : (
+                        <AlertTriangle />
+                      )}
+                      <strong>{update.title}</strong>
+                    </div>
+                    <span>{update.detail}</span>
+                    <span>{update.time}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="pc-resource-card">
+                <h3>Portfolio resources</h3>
+                <p>
+                  Save time with curated playbooks and templates that plug directly into your launch
+                  workflow.
+                </p>
+                <div className="pc-resource-actions">
+                  {templateActions.map((action) => (
+                    <button key={action} type="button">
+                      {action}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="pc-side-card">
+                <div className="pc-side-header">
+                  <h3>Upcoming reviews</h3>
+                  <span>This week&apos;s checkpoints</span>
+                </div>
+                <div className="pc-upcoming-list">
+                  {upcomingReviews.map((item) => (
+                    <div key={item.id} className="pc-upcoming-item">
+                      <strong>{item.title}</strong>
+                      <div className="pc-upcoming-meta">
+                        <span>{item.owner}</span>
+                        <span>{item.time}</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </aside>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,6 +1,8 @@
 import React, { forwardRef, InputHTMLAttributes, useMemo } from 'react';
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+type NativeInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
+
+interface InputProps extends NativeInputProps {
   label?: string;
   error?: string;
   helperText?: string;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,7 +3,3 @@ export { default as Input } from './Input';
 export { default as Card } from './Card';
 export { default as Modal } from './Modal';
 export { default as LoadingSpinner } from './LoadingSpinner';
-
-// Re-export Card with subcomponents for direct access
-import CardComponent from './Card';
-export const CardWithComponents = CardComponent;

--- a/src/pages/NewIntakePage.tsx
+++ b/src/pages/NewIntakePage.tsx
@@ -6,16 +6,26 @@ import {
   Eye, Download, Settings, ChevronDown, X, AlertCircle,
   HelpCircle, BookOpen, Layout
 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { newProject } from '../intake/schema';
 import { buildCaseStudyTemplate } from '../utils/caseStudyTemplates';
 import { saveProject } from '../utils/storageManager';
 
+interface ProjectCategory {
+  id: string;
+  name: string;
+  icon: LucideIcon;
+  description: string;
+  color: string;
+  templates: string[];
+}
+
 const NewIntakePage = () => {
   const navigate = useNavigate();
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [activeStep, setActiveStep] = useState(1);
-  const [showTemplateDetails, setShowTemplateDetails] = useState(null);
+  const [showTemplateDetails, setShowTemplateDetails] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     projectName: '',
     description: '',
@@ -23,11 +33,11 @@ const NewIntakePage = () => {
     template: '',
     color: '#5a3cf4',
     visibility: 'public',
-    tags: [],
-    files: []
+    tags: [] as string[],
+    files: [] as File[]
   });
 
-  const projectCategories = [
+  const projectCategories: ProjectCategory[] = [
     {
       id: 'web-development',
       name: 'Web Development',
@@ -83,12 +93,12 @@ const NewIntakePage = () => {
     '#06b6d4', '#84cc16', '#f97316', '#ec4899', '#6366f1'
   ];
 
-  const handleCategorySelect = (category) => {
+  const handleCategorySelect = (category: ProjectCategory) => {
     setFormData(prev => ({ ...prev, category: category.id }));
     setActiveStep(2);
   };
 
-  const handleTemplateSelect = (template) => {
+  const handleTemplateSelect = (template: string) => {
     setFormData(prev => ({ ...prev, template }));
     setActiveStep(3);
   };

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -102,7 +102,7 @@ const SettingsPage = () => {
     }
   };
 
-  const handleSaveSettings = (section) => {
+  const handleSaveSettings = (section: string) => {
     setSaveStatus('saving');
     // Simulate save operation
     setTimeout(() => {

--- a/src/styles/projects-center.css
+++ b/src/styles/projects-center.css
@@ -1,0 +1,913 @@
+:root {
+  --pc-surface: rgba(255, 255, 255, 0.72);
+  --pc-surface-strong: rgba(255, 255, 255, 0.9);
+  --pc-border: rgba(148, 163, 184, 0.35);
+  --pc-border-strong: rgba(148, 163, 184, 0.45);
+  --pc-text: #0f172a;
+  --pc-muted: #475569;
+  --pc-muted-2: #64748b;
+  --pc-muted-3: #94a3b8;
+  --pc-background: #eef2ff;
+  --pc-background-accent: #d6d7ff;
+  --pc-pill-bg: rgba(99, 102, 241, 0.12);
+  --pc-pill-text: #4338ca;
+  --pc-shadow: 0 24px 45px rgba(79, 70, 229, 0.12);
+  --pc-shadow-soft: 0 18px 35px rgba(30, 64, 175, 0.12);
+  --pc-shadow-sm: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.projects-center-page {
+  min-height: 100vh;
+  padding: 48px 0 64px;
+  background: linear-gradient(180deg, #eef2ff 0%, #e0e7ff 18%, #f8fafc 100%);
+  font-family: 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--pc-text);
+}
+
+.projects-center-container {
+  width: min(1080px, calc(100% - 48px));
+  margin: 0 auto;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.projects-center-backdrop {
+  position: absolute;
+  inset: -120px -120px auto;
+  height: 340px;
+  background: radial-gradient(120% 120% at 0% 0%, rgba(79, 70, 229, 0.25) 0%, rgba(99, 102, 241, 0.08) 46%, rgba(255, 255, 255, 0) 100%),
+    radial-gradient(100% 140% at 90% 10%, rgba(59, 130, 246, 0.22) 0%, rgba(14, 165, 233, 0.1) 48%, rgba(255, 255, 255, 0) 100%);
+  z-index: 0;
+  filter: blur(4px);
+}
+
+.projects-center-shell {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.pc-glass-card {
+  background: var(--pc-surface);
+  border: 1px solid var(--pc-border);
+  box-shadow: var(--pc-shadow);
+  border-radius: 28px;
+  padding: 32px;
+  backdrop-filter: blur(18px);
+}
+
+.pc-header {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.pc-header-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.pc-header-actions-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.pc-header-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pc-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--pc-pill-text);
+  background: var(--pc-pill-bg);
+}
+
+.pc-pill::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #6366f1, #60a5fa);
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.16);
+}
+
+.pc-header-intro h1 {
+  font-size: clamp(32px, 3vw, 44px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.pc-header-intro p {
+  margin: 0;
+  max-width: 540px;
+  color: var(--pc-muted);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.pc-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.pc-header-actions button {
+  border: none;
+  border-radius: 16px;
+  padding: 12px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pc-header-actions button span.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.pc-primary-btn {
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  color: white;
+  box-shadow: 0 16px 28px rgba(79, 70, 229, 0.25);
+}
+
+.pc-primary-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 36px rgba(79, 70, 229, 0.28);
+}
+
+.pc-secondary-btn {
+  background: rgba(15, 23, 42, 0.05);
+  color: #334155;
+}
+
+.pc-secondary-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
+}
+
+.pc-header-user {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.85), rgba(79, 70, 229, 0.9));
+  border-radius: 18px;
+  box-shadow: 0 18px 30px rgba(30, 64, 175, 0.35);
+}
+
+.pc-header-user .pc-avatar {
+  background: linear-gradient(135deg, #c084fc, #6366f1);
+  color: white;
+  font-weight: 600;
+}
+
+.pc-header-user div {
+  display: flex;
+  flex-direction: column;
+}
+
+.pc-header-user span {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.pc-header-user strong {
+  color: white;
+  font-size: 15px;
+}
+
+.pc-search-row {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.pc-search-input {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--pc-border);
+  box-shadow: var(--pc-shadow-sm);
+}
+
+.pc-search-input input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 15px;
+  background: transparent;
+  color: var(--pc-text);
+}
+
+.pc-inline-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  background: rgba(255, 255, 255, 0.9);
+  font-size: 13px;
+  font-weight: 600;
+  color: #4338ca;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 18px rgba(79, 70, 229, 0.16);
+}
+
+.pc-inline-action svg {
+  width: 16px;
+  height: 16px;
+}
+
+.pc-inline-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 24px rgba(79, 70, 229, 0.2);
+}
+
+.pc-quick-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pc-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--pc-muted);
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  transition: all 0.2s ease;
+}
+
+.pc-filter-chip.active {
+  color: #4338ca;
+  background: rgba(99, 102, 241, 0.14);
+  border-color: rgba(99, 102, 241, 0.35);
+  box-shadow: 0 14px 26px rgba(79, 70, 229, 0.18);
+}
+
+.pc-filter-chip svg {
+  width: 16px;
+  height: 16px;
+}
+
+.pc-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.pc-stat-card {
+  border-radius: 24px;
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 156px;
+  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.18);
+}
+
+.pc-stat-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 120% at 80% 0%, rgba(255, 255, 255, 0.24) 0%, rgba(255, 255, 255, 0) 60%);
+}
+
+.pc-stat-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.pc-stat-label {
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.85;
+}
+
+.pc-stat-value {
+  font-size: 40px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.pc-stat-value span.suffix {
+  font-size: 18px;
+  opacity: 0.82;
+}
+
+.pc-stat-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+  opacity: 0.9;
+}
+
+.pc-stat-change {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.pc-stat-change.up {
+  color: #bbf7d0;
+}
+
+.pc-stat-change.steady {
+  color: #fde68a;
+}
+
+.pc-stat-change.down {
+  color: #fecaca;
+}
+
+.pc-main-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2.4fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
+.pc-section-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--pc-border-strong);
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: var(--pc-shadow-soft);
+  backdrop-filter: blur(14px);
+}
+
+.pc-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  gap: 12px;
+}
+
+.pc-section-header h2 {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+}
+
+.pc-section-header span {
+  color: var(--pc-muted-2);
+  font-size: 14px;
+}
+
+.pc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #4338ca;
+  text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.pc-link svg {
+  width: 16px;
+  height: 16px;
+}
+
+.pc-project-list {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.pc-project-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(0, 1.1fr);
+  gap: 22px;
+  padding: 24px;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.82) 0%, rgba(226, 232, 255, 0.65) 45%, rgba(255, 255, 255, 0.9) 100%);
+  box-shadow: var(--pc-shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pc-project-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 28px rgba(99, 102, 241, 0.16);
+}
+
+.pc-project-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.pc-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(79, 70, 229, 0.12);
+  color: #4338ca;
+}
+
+.pc-status {
+  padding: 6px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.pc-status.review {
+  background: rgba(168, 85, 247, 0.12);
+  color: #7c3aed;
+}
+
+.pc-status.research {
+  background: rgba(14, 165, 233, 0.12);
+  color: #0284c7;
+}
+
+.pc-status.execution {
+  background: rgba(34, 197, 94, 0.12);
+  color: #16a34a;
+}
+
+.pc-status.planning {
+  background: rgba(251, 191, 36, 0.15);
+  color: #b45309;
+}
+
+.pc-project-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.pc-project-title h3 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+
+.pc-priority {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 12px;
+  color: var(--pc-muted);
+}
+
+.pc-project-description {
+  margin: 0 0 12px;
+  color: var(--pc-muted);
+  line-height: 1.6;
+  font-size: 14px;
+}
+
+.pc-project-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.pc-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--pc-muted-2);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.pc-project-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.pc-meta-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.pc-meta-item svg {
+  width: 18px;
+  height: 18px;
+  color: #6366f1;
+  margin-top: 2px;
+}
+
+.pc-meta-label {
+  display: block;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pc-muted-3);
+  margin-bottom: 4px;
+}
+
+.pc-meta-value {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--pc-text);
+}
+
+.pc-project-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 20px;
+  padding: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.pc-progress-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pc-muted-3);
+}
+
+.pc-progress-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #4338ca;
+  letter-spacing: -0.02em;
+}
+
+.pc-progress-bar {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.pc-progress-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+}
+
+.pc-health {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.12);
+  color: #16a34a;
+}
+
+.pc-health.watch {
+  background: rgba(251, 191, 36, 0.15);
+  color: #b45309;
+}
+
+.pc-health.risk {
+  background: rgba(248, 113, 113, 0.14);
+  color: #b91c1c;
+}
+
+.pc-progress-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+  color: var(--pc-muted-2);
+}
+
+.pc-avatar-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pc-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: 600;
+  font-size: 14px;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.18);
+}
+
+.pc-add-collaborator {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px dashed rgba(99, 102, 241, 0.45);
+  background: rgba(255, 255, 255, 0.85);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #6366f1;
+  cursor: pointer;
+}
+
+.pc-progress-milestones {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.pc-milestone {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.pc-milestone::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.65);
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.12);
+}
+
+.pc-milestone.completed::before {
+  background: #22c55e;
+}
+
+.pc-milestone.active {
+  border-color: rgba(99, 102, 241, 0.45);
+  box-shadow: 0 16px 28px rgba(79, 70, 229, 0.18);
+}
+
+.pc-milestone small {
+  display: block;
+  color: var(--pc-muted-3);
+  font-size: 11px;
+}
+
+.pc-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.pc-side-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: var(--pc-shadow-sm);
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pc-side-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pc-side-header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.pc-side-header span {
+  font-size: 12px;
+  color: var(--pc-muted-3);
+}
+
+.pc-update {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(248, 250, 252, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.pc-update-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pc-update-title svg {
+  width: 18px;
+  height: 18px;
+  color: #22c55e;
+}
+
+.pc-update.pending .pc-update-title svg {
+  color: #f59e0b;
+}
+
+.pc-update.risk .pc-update-title svg {
+  color: #ef4444;
+}
+
+.pc-update strong {
+  font-size: 15px;
+  color: var(--pc-text);
+}
+
+.pc-update span {
+  font-size: 13px;
+  color: var(--pc-muted-2);
+}
+
+.pc-resource-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 24px;
+  background: linear-gradient(135deg, #312e81, #4338ca, #2563eb);
+  color: white;
+  padding: 26px;
+  box-shadow: 0 24px 38px rgba(30, 64, 175, 0.35);
+}
+
+.pc-resource-card::after {
+  content: '';
+  position: absolute;
+  inset: -20% 30% auto auto;
+  width: 200px;
+  height: 200px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.28) 0%, rgba(255, 255, 255, 0) 70%);
+}
+
+.pc-resource-card h3 {
+  margin: 0 0 8px;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+}
+
+.pc-resource-card p {
+  margin: 0 0 18px;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.pc-resource-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pc-resource-actions button {
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: none;
+  font-size: 13px;
+  font-weight: 600;
+  color: #312e81;
+  background: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+}
+
+.pc-upcoming-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.pc-upcoming-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(248, 250, 252, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.pc-upcoming-item strong {
+  font-size: 15px;
+}
+
+.pc-upcoming-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: var(--pc-muted-3);
+}
+
+@media (max-width: 1024px) {
+  .pc-main-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .projects-center-page {
+    padding-top: 32px;
+  }
+
+  .pc-glass-card,
+  .pc-section-card {
+    padding: 24px;
+  }
+
+  .pc-header-top {
+    flex-direction: column;
+  }
+
+  .pc-header-actions-wrapper {
+    align-items: flex-start;
+  }
+
+  .pc-project-card {
+    grid-template-columns: 1fr;
+  }
+
+  .pc-header-actions,
+  .pc-quick-filters {
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the /test route with a Projects Center dashboard showcasing stats, pipeline progress, and sidebar updates
- add a dedicated glassmorphism-inspired stylesheet to match the provided visual design
- tighten shared UI and intake/settings typing so the project builds cleanly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce2e37d144832fa8482a7d1c21d64d