### PR TITLE
Implement simplified portfolio intake and editors with AI narrative

### DIFF
--- a/src/intake/schema.ts
+++ b/src/intake/schema.ts
@@ -10,6 +10,15 @@ export type ProjectAsset = {
   thumbnailUrl?: string | null
 }
 
+export type CaseStudyContent = {
+  overview: string
+  challenge: string
+  approach: string[]
+  results: string[]
+  learnings: string
+  callToAction?: string
+}
+
 export type ProjectBlockWidth = 'full' | 'two-thirds' | 'half' | 'third'
 export type ProjectBlockAlignment = 'left' | 'center' | 'right'
 export type ProjectBlockPadding = 'none' | 'small' | 'medium' | 'large'
@@ -144,6 +153,7 @@ export type ProjectMeta = {
   layout?: ProjectLayoutBlock[]
   caseStudyHtml?: string
   caseStudyCss?: string
+  caseStudyContent?: CaseStudyContent
 
   // AI Integration
   autoGenerateNarrative?: boolean
@@ -191,5 +201,13 @@ export const newProject = (title: string): ProjectMeta => ({
   updatedAt: new Date().toISOString(),
   assets: [],
   layout: [],
-  autoGenerateNarrative: false
+  autoGenerateNarrative: false,
+  caseStudyContent: {
+    overview: '',
+    challenge: '',
+    approach: [],
+    results: [],
+    learnings: '',
+    callToAction: undefined,
+  },
 })

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,106 +1,75 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
-  RefreshCcw,
-  Upload,
+  ArrowRightCircle,
   Download,
-  FileEdit,
   FileText,
-  Search,
   Folder,
-  AlertCircle,
-  CheckCircle2,
-  Loader2,
-  FileArchive,
+  Layers,
   Plus,
-  Settings,
-  Calendar,
-  TrendingUp,
-  Activity,
-} from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { useApp } from '../contexts/AppContext';
-import { Button, Input, LoadingSpinner } from '../components/ui';
-import Card from '../components/ui/Card';
-import ThemeToggle from '../components/ThemeToggle';
+  RefreshCw,
+  Trash2,
+  Upload,
+} from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { Button, Input, LoadingSpinner } from '../components/ui'
+import { useApp } from '../contexts/AppContext'
+import {
+  deleteProject,
+  getStorageUsage,
+  listProjects,
+  saveProject,
+} from '../utils/storageManager'
+import type { ProjectMeta } from '../intake/schema'
+import ThemeToggle from '../components/ThemeToggle'
 
-// Use the same types from the original file
 export type ApiAssetPreview = {
-  id: string;
-  label: string | null;
-  relativePath: string;
-  type: string | null;
-  updatedAt: string;
-};
+  id: string
+  label: string | null
+  relativePath: string
+  type: string | null
+  updatedAt: string
+}
 
 export type ApiDeliverablePreview = {
-  id: string;
-  label: string | null;
-  relativePath: string;
-  format: string | null;
-  updatedAt: string;
-};
+  id: string
+  label: string | null
+  relativePath: string
+  format: string | null
+  updatedAt: string
+}
 
 export type ApiProject = {
-  id: string;
-  slug: string;
-  title: string;
-  summary?: string | null;
-  organization?: string | null;
-  workType?: string | null;
-  year?: number | null;
-  tags: string[];
-  highlights: string[];
-  syncStatus: string;
-  lastSyncedAt?: string | null;
-  fsLastModified?: string | null;
-  metadataUpdatedAt?: string | null;
-  briefUpdatedAt?: string | null;
-  assetCount: number;
-  deliverableCount: number;
-  assetPreviews: ApiAssetPreview[];
-  deliverablePreviews: ApiDeliverablePreview[];
-};
-
-const joinClasses = (
-  ...classes: Array<string | false | null | undefined>
-) => classes.filter(Boolean).join(' ');
+  id: string
+  slug: string
+  title: string
+  summary?: string | null
+  organization?: string | null
+  workType?: string | null
+  year?: number | null
+  tags: string[]
+  highlights: string[]
+  syncStatus: string
+  lastSyncedAt?: string | null
+  fsLastModified?: string | null
+  metadataUpdatedAt?: string | null
+  briefUpdatedAt?: string | null
+  assetCount: number
+  deliverableCount: number
+  assetPreviews: ApiAssetPreview[]
+  deliverablePreviews: ApiDeliverablePreview[]
+}
 
 const parseDate = (value?: string | null): number | undefined => {
-  if (!value) return undefined;
-  const timestamp = Date.parse(value);
-  return Number.isNaN(timestamp) ? undefined : timestamp;
-};
+  if (!value) return undefined
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? undefined : timestamp
+}
 
-const formatDateDisplay = (
-  value?: string | null,
-  fallback = 'Unknown',
-) => {
-  const timestamp = parseDate(value);
-  if (timestamp === undefined) return fallback;
-  return new Date(timestamp).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-};
-
-const formatDateTimeDisplay = (
-  value?: string | null,
-  fallback = 'Unknown',
-) => {
-  const timestamp = parseDate(value);
-  if (timestamp === undefined) return fallback;
-  return new Date(timestamp).toLocaleString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-};
-
-const fileNameFromPath = (relativePath: string) =>
-  relativePath.split('/').filter(Boolean).pop() ?? relativePath;
+const formatDateTimeDisplay = (value?: string | null, fallback = 'Unknown') => {
+  const timestamp = parseDate(value)
+  if (timestamp === undefined) return fallback
+  return new Date(timestamp).toLocaleString()
+}
 
 export type FreshnessState =
   | 'in-sync'
@@ -108,681 +77,512 @@ export type FreshnessState =
   | 'metadata-updated'
   | 'brief-updated'
   | 'sync-needed'
-  | 'never-synced';
+  | 'never-synced'
 
-type FreshnessUpdate =
-  | 'filesystem-updated'
-  | 'metadata-updated'
-  | 'brief-updated';
+type FreshnessUpdate = 'filesystem-updated' | 'metadata-updated' | 'brief-updated'
 
-type FreshnessCopy = {
-  label: string;
-  description: string;
-  tone: 'neutral' | 'warning' | 'danger' | 'success';
-  icon: React.ReactNode;
-};
-
-const FRESHNESS_COPY: Record<FreshnessState, FreshnessCopy> = {
+const FRESHNESS_COPY: Record<FreshnessState, { label: string; description: string; tone: 'neutral' | 'warning' | 'danger' | 'success' }> = {
   'in-sync': {
     label: 'Up to date',
-    description: 'Project is fully synchronised with the filesystem',
+    description: 'Project is synchronised with stored metadata.',
     tone: 'success',
-    icon: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />,
   },
   'filesystem-updated': {
     label: 'Filesystem newer',
     description: 'Files changed on disk since the last sync',
     tone: 'warning',
-    icon: <Activity className="h-3.5 w-3.5" aria-hidden="true" />,
   },
   'metadata-updated': {
     label: 'Metadata newer',
-    description: 'Project metadata has changes waiting to sync',
+    description: 'Metadata has been edited locally',
     tone: 'warning',
-    icon: <FileText className="h-3.5 w-3.5" aria-hidden="true" />,
   },
   'brief-updated': {
     label: 'Brief newer',
-    description: 'Project brief has been edited since the last sync',
+    description: 'Project brief changed since last sync',
     tone: 'warning',
-    icon: <FileEdit className="h-3.5 w-3.5" aria-hidden="true" />,
   },
   'sync-needed': {
     label: 'Needs sync',
     description: 'Project reports pending changes',
     tone: 'danger',
-    icon: <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />,
   },
   'never-synced': {
     label: 'Never synced',
     description: 'Project has not been synchronised yet',
     tone: 'neutral',
-    icon: <Calendar className="h-3.5 w-3.5" aria-hidden="true" />,
   },
-};
+}
 
-const FRESHNESS_TONE_CLASSES: Record<
-  FreshnessCopy['tone'],
-  string
-> = {
-  success:
-    'bg-emerald-100/80 text-emerald-700 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-200 dark:ring-emerald-800/60',
-  warning:
-    'bg-amber-100/80 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:ring-amber-800/60',
-  danger:
-    'bg-rose-100/80 text-rose-700 ring-1 ring-inset ring-rose-200 dark:bg-rose-900/40 dark:text-rose-200 dark:ring-rose-800/60',
-  neutral:
-    'bg-gray-100/80 text-gray-700 ring-1 ring-inset ring-gray-200 dark:bg-gray-800/60 dark:text-gray-200 dark:ring-gray-700/60',
-};
+const FRESHNESS_TONE_CLASSES: Record<FreshnessState, string> = {
+  'in-sync': 'bg-emerald-100/80 text-emerald-700',
+  'filesystem-updated': 'bg-amber-100/80 text-amber-700',
+  'metadata-updated': 'bg-amber-100/80 text-amber-700',
+  'brief-updated': 'bg-amber-100/80 text-amber-700',
+  'sync-needed': 'bg-rose-100/80 text-rose-700',
+  'never-synced': 'bg-gray-100/80 text-gray-700',
+}
 
-const getLatestUpdate = (
-  project: ApiProject,
-): { type: FreshnessUpdate; timestamp: number } | undefined => {
-  const updates: Array<{
-    type: FreshnessUpdate;
-    timestamp?: number;
-  }> = [
+const getLatestUpdate = (project: ApiProject): { type: FreshnessUpdate; timestamp: number } | undefined => {
+  const updates: Array<{ type: FreshnessUpdate; timestamp?: number }> = [
     { type: 'filesystem-updated', timestamp: parseDate(project.fsLastModified) },
     { type: 'metadata-updated', timestamp: parseDate(project.metadataUpdatedAt) },
     { type: 'brief-updated', timestamp: parseDate(project.briefUpdatedAt) },
-  ];
+  ]
 
   return updates
-    .filter((update): update is { type: FreshnessUpdate; timestamp: number } =>
-      update.timestamp !== undefined,
-    )
-    .sort((a, b) => b.timestamp - a.timestamp)[0];
-};
+    .filter((update): update is { type: FreshnessUpdate; timestamp: number } => update.timestamp !== undefined)
+    .sort((a, b) => b.timestamp - a.timestamp)[0]
+}
 
 export const computeFreshness = (project: ApiProject): FreshnessState => {
-  const lastSynced = parseDate(project.lastSyncedAt);
-  const latestUpdate = getLatestUpdate(project);
+  const lastSynced = parseDate(project.lastSyncedAt)
+  const latestUpdate = getLatestUpdate(project)
 
   if (project.syncStatus && project.syncStatus !== 'synced' && project.syncStatus !== 'clean') {
-    return 'sync-needed';
+    return 'sync-needed'
   }
 
   if (!latestUpdate) {
-    return lastSynced === undefined ? 'never-synced' : 'in-sync';
+    return lastSynced === undefined ? 'never-synced' : 'in-sync'
   }
 
   if (lastSynced === undefined) {
-    return latestUpdate.type;
+    return latestUpdate.type
   }
 
   if (latestUpdate.timestamp > lastSynced) {
-    return latestUpdate.type;
+    return latestUpdate.type
   }
 
-  return 'in-sync';
-};
+  return 'in-sync'
+}
 
-type FreshnessBadgeProps = {
-  project: ApiProject;
-  className?: string;
-};
-
-export const FreshnessBadge: React.FC<FreshnessBadgeProps> = ({
-  project,
-  className,
-}) => {
-  const state = computeFreshness(project);
-  const { label, description, tone, icon } = FRESHNESS_COPY[state];
-
+export const FreshnessBadge: React.FC<{ project: ApiProject }> = ({ project }) => {
+  const state = computeFreshness(project)
+  const copy = FRESHNESS_COPY[state]
   return (
     <span
-      className={joinClasses(
-        'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
-        FRESHNESS_TONE_CLASSES[tone],
-        className,
-      )}
-      title={description}
+      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium ${FRESHNESS_TONE_CLASSES[state]}`}
+      title={copy.description}
     >
-      {icon}
-      <span>{label}</span>
+      {copy.label}
     </span>
-  );
-};
+  )
+}
 
-type AssetPreviewListProps = {
-  assets: ApiAssetPreview[];
-  title?: string;
-  emptyMessage?: string;
-};
-
-export const AssetPreviewList: React.FC<AssetPreviewListProps> = ({
-  assets,
-  title,
-  emptyMessage = 'No assets available yet.',
-}) => (
+export const AssetPreviewList: React.FC<{ assets: ApiAssetPreview[]; title?: string; emptyMessage?: string }> = ({ assets, title, emptyMessage = 'No assets available yet.' }) => (
   <section className="space-y-2">
-    {title ? (
-      <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-        {title}
-      </h5>
-    ) : null}
+    {title ? <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{title}</h5> : null}
     {assets.length === 0 ? (
       <p className="text-sm text-gray-500 dark:text-gray-400">{emptyMessage}</p>
     ) : (
       <ul className="space-y-2">
-        {assets.map((asset) => {
-          const displayLabel = asset.label ?? fileNameFromPath(asset.relativePath);
-          return (
-            <li
-              key={asset.id}
-              className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-white/60 px-3 py-2 text-sm shadow-sm backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/40"
-            >
-              <div className="min-w-0">
-                <p className="truncate font-medium text-gray-900 dark:text-gray-100">
-                  {displayLabel}
-                </p>
-                <p className="truncate text-xs text-gray-500 dark:text-gray-400">
-                  {asset.relativePath}
-                </p>
-              </div>
-              <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">
-                {formatDateTimeDisplay(asset.updatedAt)}
-              </span>
-            </li>
-          );
-        })}
+        {assets.map(asset => (
+          <li key={asset.id} className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white/60 px-3 py-2 text-sm shadow-sm backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/40">
+            <div className="min-w-0">
+              <p className="truncate font-medium text-gray-900 dark:text-gray-100">{asset.label ?? asset.relativePath}</p>
+              <p className="truncate text-xs text-gray-500 dark:text-gray-400">{asset.relativePath}</p>
+            </div>
+            <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">{formatDateTimeDisplay(asset.updatedAt)}</span>
+          </li>
+        ))}
       </ul>
     )}
   </section>
-);
+)
 
-type DeliverablePreviewListProps = {
-  deliverables: ApiDeliverablePreview[];
-  title?: string;
-  emptyMessage?: string;
-};
-
-export const DeliverablePreviewList: React.FC<DeliverablePreviewListProps> = ({
-  deliverables,
-  title,
-  emptyMessage = 'No deliverables available yet.',
-}) => (
+export const DeliverablePreviewList: React.FC<{ deliverables: ApiDeliverablePreview[]; title?: string; emptyMessage?: string }> = ({ deliverables, title, emptyMessage = 'No deliverables available yet.' }) => (
   <section className="space-y-2">
-    {title ? (
-      <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-        {title}
-      </h5>
-    ) : null}
+    {title ? <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{title}</h5> : null}
     {deliverables.length === 0 ? (
       <p className="text-sm text-gray-500 dark:text-gray-400">{emptyMessage}</p>
     ) : (
       <ul className="space-y-2">
-        {deliverables.map((deliverable) => {
-          const displayLabel =
-            deliverable.label ?? fileNameFromPath(deliverable.relativePath);
-          const formatLabel = deliverable.format
-            ? deliverable.format.toUpperCase()
-            : undefined;
-
-          return (
-            <li
-              key={deliverable.id}
-              className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-white/60 px-3 py-2 text-sm shadow-sm backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/40"
-            >
-              <div className="min-w-0">
-                <p className="truncate font-medium text-gray-900 dark:text-gray-100">
-                  {displayLabel}
-                </p>
-                <p className="truncate text-xs text-gray-500 dark:text-gray-400">
-                  {formatLabel ? `${formatLabel} • ` : ''}
-                  {deliverable.relativePath}
-                </p>
-              </div>
-              <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">
-                {formatDateTimeDisplay(deliverable.updatedAt)}
-              </span>
-            </li>
-          );
-        })}
+        {deliverables.map(deliverable => (
+          <li key={deliverable.id} className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 bg-white/60 px-3 py-2 text-sm shadow-sm backdrop-blur-sm dark:border-gray-700 dark:bg-gray-900/40">
+            <div className="min-w-0">
+              <p className="truncate font-medium text-gray-900 dark:text-gray-100">{deliverable.label ?? deliverable.relativePath}</p>
+              <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                {deliverable.format ? `${deliverable.format.toUpperCase()} • ` : ''}
+                {deliverable.relativePath}
+              </p>
+            </div>
+            <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">{formatDateTimeDisplay(deliverable.updatedAt)}</span>
+          </li>
+        ))}
       </ul>
     )}
   </section>
-);
+)
 
-const DashboardPage = () => {
-  const { addNotification } = useApp();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [projects, setProjects] = useState<ApiProject[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [syncing, setSyncing] = useState(false);
-  const [importing, setImporting] = useState(false);
+const formatDate = (value?: string) => {
+  if (!value) {
+    return 'Just created'
+  }
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) {
+    return value
+  }
+  return new Date(parsed).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
 
-  // Mock data for demonstration - replace with actual API calls
-  const stats = useMemo(() => {
-    const weekAgo = new Date();
-    weekAgo.setDate(weekAgo.getDate() - 7);
-    const weekAgoTimestamp = weekAgo.getTime();
+const downloadJson = (filename: string, payload: unknown) => {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
 
-    return {
-      totalProjects: projects.length,
-      totalAssets: projects.reduce((sum, project) => sum + project.assetCount, 0),
-      totalDeliverables: projects.reduce(
-        (sum, project) => sum + project.deliverableCount,
-        0,
-      ),
-      recentlyUpdated: projects.filter(project => {
-        const lastModified = parseDate(project.fsLastModified);
-        return lastModified !== undefined && lastModified >= weekAgoTimestamp;
-      }).length,
-    };
-  }, [projects]);
+const countCaseStudiesReady = (projects: ProjectMeta[]) =>
+  projects.filter(project => Boolean(project.caseStudyContent?.overview || project.caseStudyHtml)).length
 
-  const filteredProjects = useMemo(() => {
-    if (!searchQuery) return projects;
-    const query = searchQuery.toLowerCase();
-    return projects.filter(project =>
-      project.title.toLowerCase().includes(query) ||
-      project.organization?.toLowerCase().includes(query) ||
-      project.workType?.toLowerCase().includes(query) ||
-      project.tags.some(tag => tag.toLowerCase().includes(query))
-    );
-  }, [projects, searchQuery]);
+const DashboardPage: React.FC = () => {
+  const { addNotification } = useApp()
 
-  const handleSync = async () => {
-    setSyncing(true);
+  const [projects, setProjects] = useState<ProjectMeta[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [storageUsage, setStorageUsage] = useState<{ used: number; available: number; percentage: number } | null>(null)
+  const [isImporting, setIsImporting] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const refreshProjects = useCallback(async () => {
+    setIsLoading(true)
     try {
-      // Replace with actual sync API call
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      addNotification('success', 'Filesystem sync completed successfully');
+      const [loadedProjects, usage] = await Promise.all([
+        listProjects(),
+        getStorageUsage(),
+      ])
+      setProjects(loadedProjects)
+      setStorageUsage(usage)
     } catch (error) {
-      addNotification('error', 'Sync failed. Please try again.');
+      console.error('Failed to load projects', error)
+      addNotification('error', 'Unable to load portfolio projects from local storage.')
     } finally {
-      setSyncing(false);
+      setIsLoading(false)
     }
-  };
-
-  const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    setImporting(true);
-    try {
-      // Replace with actual import API call
-      await new Promise(resolve => setTimeout(resolve, 3000));
-      addNotification('success', `Successfully imported ${file.name}`);
-    } catch (error) {
-      addNotification('error', 'Import failed. Please try again.');
-    } finally {
-      setImporting(false);
-      if (fileInputRef.current) {
-        fileInputRef.current.value = '';
-      }
-    }
-  };
+  }, [addNotification])
 
   useEffect(() => {
-    // Load projects - replace with actual API call
-    const loadProjects = async () => {
-      setLoading(true);
-      try {
-        // Mock API call
-        await new Promise(resolve => setTimeout(resolve, 1000));
-        setProjects([]); // Empty for now
-      } catch (error) {
-        addNotification('error', 'Failed to load projects');
-      } finally {
-        setLoading(false);
+    void refreshProjects()
+  }, [refreshProjects])
+
+  const filteredProjects = useMemo(() => {
+    if (!searchQuery) {
+      return projects
+    }
+    const query = searchQuery.toLowerCase()
+    return projects.filter(project =>
+      project.title.toLowerCase().includes(query) ||
+      project.summary?.toLowerCase().includes(query) ||
+      project.tags.some(tag => tag.toLowerCase().includes(query)),
+    )
+  }, [projects, searchQuery])
+
+  const stats = useMemo(() => {
+    const totalAssets = projects.reduce((count, project) => count + project.assets.length, 0)
+    return {
+      totalProjects: projects.length,
+      caseStudiesReady: countCaseStudiesReady(projects),
+      totalAssets,
+    }
+  }, [projects])
+
+  const handleDelete = async (slug: string) => {
+    const project = projects.find(candidate => candidate.slug === slug)
+    if (!project) {
+      return
+    }
+    const confirmed = window.confirm(`Delete “${project.title}”? This only removes the local copy.`)
+    if (!confirmed) {
+      return
+    }
+    try {
+      await deleteProject(slug)
+      addNotification('success', 'Project deleted from local storage.')
+      void refreshProjects()
+    } catch (error) {
+      console.error('Delete failed', error)
+      addNotification('error', 'Unable to delete this project.')
+    }
+  }
+
+  const handleExport = (project: ProjectMeta) => {
+    downloadJson(`${project.slug || 'project'}.json`, project)
+    addNotification('success', 'Project exported as JSON.')
+  }
+
+  const handleImport: React.ChangeEventHandler<HTMLInputElement> = async event => {
+    const file = event.target.files?.[0]
+    if (!file) {
+      return
+    }
+    setIsImporting(true)
+    try {
+      const text = await file.text()
+      const parsed = JSON.parse(text) as ProjectMeta | ProjectMeta[]
+      const payload = Array.isArray(parsed) ? parsed : [parsed]
+      let imported = 0
+      for (const project of payload) {
+        if (project && typeof project === 'object' && typeof project.slug === 'string') {
+          await saveProject(project)
+          imported += 1
+        }
       }
-    };
+      addNotification('success', `Imported ${imported} project${imported === 1 ? '' : 's'} successfully.`)
+      void refreshProjects()
+    } catch (error) {
+      console.error('Import failed', error)
+      addNotification('error', 'Import failed. Provide a JSON export created from this tool.')
+    } finally {
+      setIsImporting(false)
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
+    }
+  }
 
-    loadProjects();
-  }, [addNotification]);
-
-  const formatDate = (dateString?: string | null) =>
-    formatDateDisplay(dateString, 'Never');
-
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
-        <LoadingSpinner size="lg" text="Loading dashboard..." centered />
+        <LoadingSpinner size="lg" text="Loading your projects..." centered />
       </div>
-    );
+    )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200">
-      {/* Header */}
-      <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm">
-        <div className="mx-auto max-w-7xl px-6 py-6">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div className="flex items-center gap-4">
-              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-blue-100 dark:bg-blue-900">
-                <Folder className="h-6 w-6 text-blue-600 dark:text-blue-400" />
-              </div>
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Portfolio Dashboard</h1>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  Manage your projects and keep files in sync
-                </p>
-              </div>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <header className="border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-900/80 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-start gap-4">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/40">
+              <Folder className="h-6 w-6 text-indigo-600 dark:text-indigo-300" />
             </div>
-            <div className="flex items-center gap-3">
-              <ThemeToggle />
-              <Button
-                as={Link}
-                to="/create"
-                variant="primary"
-                leftIcon={<Plus className="h-4 w-4" />}
-                className="shadow-md"
-              >
-                New Project
-              </Button>
-              <Button
-                as={Link}
-                to="/settings"
-                variant="outline"
-                leftIcon={<Settings className="h-4 w-4" />}
-              >
-                Settings
-              </Button>
+            <div>
+              <h1 className="text-2xl font-bold">Portfolio control centre</h1>
+              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                Capture project details, manage files locally, and generate polished narratives.
+              </p>
             </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <ThemeToggle />
+            <Button as={Link} to="/portfolio" variant="outline" leftIcon={<Layers className="h-4 w-4" />}>
+              View portfolio
+            </Button>
+            <Button as={Link} to="/create" variant="primary" leftIcon={<Plus className="h-4 w-4" />}>
+              New project
+            </Button>
           </div>
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl px-6 py-8 space-y-8">
-        {/* Stats Cards */}
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-          <Card className="bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900 dark:to-blue-800 border-blue-200 dark:border-blue-700">
-            <Card.Body className="p-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium text-blue-600 dark:text-blue-400">Projects</p>
-                  <p className="text-2xl font-bold text-blue-900 dark:text-blue-100">{stats.totalProjects}</p>
-                </div>
-                <div className="h-12 w-12 rounded-lg bg-blue-500 dark:bg-blue-600 flex items-center justify-center">
-                  <Folder className="h-6 w-6 text-white" />
-                </div>
+      <main className="mx-auto max-w-7xl px-6 py-10 space-y-8">
+        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <article className="rounded-2xl border border-indigo-100 bg-indigo-50 p-6 shadow-sm dark:border-indigo-800/60 dark:bg-indigo-950/40">
+            <div className="flex items-start justify-between">
+              <div>
+                <p className="text-sm font-medium text-indigo-600 dark:text-indigo-300">Projects</p>
+                <p className="mt-2 text-3xl font-semibold">{stats.totalProjects}</p>
               </div>
-            </Card.Body>
-          </Card>
-
-          <Card className="bg-gradient-to-br from-green-50 to-green-100 dark:from-green-900 dark:to-green-800 border-green-200 dark:border-green-700">
-            <Card.Body className="p-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium text-green-600 dark:text-green-400">Assets</p>
-                  <p className="text-2xl font-bold text-green-900 dark:text-green-100">{stats.totalAssets}</p>
-                </div>
-                <div className="h-12 w-12 rounded-lg bg-green-500 dark:bg-green-600 flex items-center justify-center">
-                  <FileArchive className="h-6 w-6 text-white" />
-                </div>
+              <div className="rounded-full bg-white/70 p-2 dark:bg-indigo-900/60">
+                <Folder className="h-5 w-5 text-indigo-600 dark:text-indigo-300" />
               </div>
-            </Card.Body>
-          </Card>
+            </div>
+            <p className="mt-3 text-xs text-indigo-700/80 dark:text-indigo-200/80">
+              All projects are saved locally in your browser.
+            </p>
+          </article>
 
-          <Card className="bg-gradient-to-br from-purple-50 to-purple-100 dark:from-purple-900 dark:to-purple-800 border-purple-200 dark:border-purple-700">
-            <Card.Body className="p-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium text-purple-600 dark:text-purple-400">Deliverables</p>
-                  <p className="text-2xl font-bold text-purple-900 dark:text-purple-100">{stats.totalDeliverables}</p>
-                </div>
-                <div className="h-12 w-12 rounded-lg bg-purple-500 dark:bg-purple-600 flex items-center justify-center">
-                  <Download className="h-6 w-6 text-white" />
-                </div>
+          <article className="rounded-2xl border border-purple-100 bg-purple-50 p-6 shadow-sm dark:border-purple-900/50 dark:bg-purple-950/40">
+            <div className="flex items-start justify-between">
+              <div>
+                <p className="text-sm font-medium text-purple-600 dark:text-purple-300">Case studies ready</p>
+                <p className="mt-2 text-3xl font-semibold">{stats.caseStudiesReady}</p>
               </div>
-            </Card.Body>
-          </Card>
-
-          <Card className="bg-gradient-to-br from-orange-50 to-orange-100 dark:from-orange-900 dark:to-orange-800 border-orange-200 dark:border-orange-700">
-            <Card.Body className="p-6">
-              <div className="flex items-center justify-between">
-                <div>
-                  <p className="text-sm font-medium text-orange-600 dark:text-orange-400">Recent Updates</p>
-                  <p className="text-2xl font-bold text-orange-900 dark:text-orange-100">{stats.recentlyUpdated}</p>
-                </div>
-                <div className="h-12 w-12 rounded-lg bg-orange-500 dark:bg-orange-600 flex items-center justify-center">
-                  <TrendingUp className="h-6 w-6 text-white" />
-                </div>
+              <div className="rounded-full bg-white/70 p-2 dark:bg-purple-900/60">
+                <FileText className="h-5 w-5 text-purple-600 dark:text-purple-300" />
               </div>
-            </Card.Body>
-          </Card>
-        </div>
+            </div>
+            <p className="mt-3 text-xs text-purple-700/80 dark:text-purple-200/80">
+              AI-assisted narratives make these projects portfolio-ready.
+            </p>
+          </article>
 
-        {/* Action Cards */}
-        <div className="grid gap-6 md:grid-cols-2">
-          <Card className="shadow-md">
-            <Card.Header>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Quick Actions</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Manage your portfolio files and data</p>
-            </Card.Header>
-            <Card.Body className="space-y-4">
-              <Button
-                onClick={handleSync}
-                variant="outline"
-                leftIcon={syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCcw className="h-4 w-4" />}
-                disabled={syncing}
-                fullWidth
-                className="justify-start"
-              >
-                {syncing ? 'Syncing...' : 'Sync Filesystem'}
-              </Button>
-              <Button
-                variant="primary"
-                leftIcon={importing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
-                disabled={importing}
-                onClick={() => fileInputRef.current?.click()}
-                fullWidth
-                className="justify-start"
-              >
-                {importing ? 'Importing...' : 'Import Project (.zip)'}
+          <article className="rounded-2xl border border-sky-100 bg-sky-50 p-6 shadow-sm dark:border-sky-900/60 dark:bg-sky-950/40">
+            <div className="flex items-start justify-between">
+              <div>
+                <p className="text-sm font-medium text-sky-600 dark:text-sky-300">Assets</p>
+                <p className="mt-2 text-3xl font-semibold">{stats.totalAssets}</p>
+              </div>
+              <div className="rounded-full bg-white/70 p-2 dark:bg-sky-900/60">
+                <Upload className="h-5 w-5 text-sky-600 dark:text-sky-300" />
+              </div>
+            </div>
+            <p className="mt-3 text-xs text-sky-700/80 dark:text-sky-200/80">
+              Upload images and files directly into each project.
+            </p>
+          </article>
+
+          <article className="rounded-2xl border border-emerald-100 bg-emerald-50 p-6 shadow-sm dark:border-emerald-900/50 dark:bg-emerald-950/40">
+            <div className="flex items-start justify-between">
+              <div>
+                <p className="text-sm font-medium text-emerald-600 dark:text-emerald-300">Storage used</p>
+                <p className="mt-2 text-3xl font-semibold">
+                  {storageUsage ? `${storageUsage.used}MB` : '—'}
+                </p>
+              </div>
+              <div className="rounded-full bg-white/70 p-2 dark:bg-emerald-900/60">
+                <RefreshCw className="h-5 w-5 text-emerald-600 dark:text-emerald-300" />
+              </div>
+            </div>
+            <p className="mt-3 text-xs text-emerald-700/80 dark:text-emerald-200/80">
+              {storageUsage
+                ? `Approx. ${storageUsage.percentage}% of ${storageUsage.available}MB local capacity`
+                : 'Storage usage unavailable'}
+            </p>
+          </article>
+        </section>
+
+        <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+          <div className="flex flex-col gap-4 border-b border-gray-200 pb-6 dark:border-gray-800 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Local projects</h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Search, export, or jump straight into the case study editor.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Input
+                placeholder="Search projects"
+                value={searchQuery}
+                onChange={event => setSearchQuery(event.target.value)}
+                leftIcon={<ArrowRightCircle className="h-4 w-4 rotate-45" />}
+              />
+              <div className="flex items-center gap-2">
                 <input
                   ref={fileInputRef}
                   type="file"
-                  accept="application/zip"
+                  accept="application/json"
+                  hidden
                   onChange={handleImport}
-                  className="hidden"
-                  disabled={importing}
                 />
-              </Button>
-            </Card.Body>
-          </Card>
-
-          <Card className="shadow-md">
-            <Card.Header>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Portfolio Tools</h3>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Create and manage your portfolio</p>
-            </Card.Header>
-            <Card.Body className="space-y-4">
-              <Button
-                as={Link}
-                to="/portfolio"
-                variant="outline"
-                leftIcon={<FileText className="h-4 w-4" />}
-                fullWidth
-                className="justify-start"
-              >
-                View Portfolio
-              </Button>
-              <Button
-                as={Link}
-                to="/portfolio/editor"
-                variant="outline"
-                leftIcon={<FileEdit className="h-4 w-4" />}
-                fullWidth
-                className="justify-start"
-              >
-                Portfolio Editor
-              </Button>
-            </Card.Body>
-          </Card>
-        </div>
-
-        {/* Projects Section */}
-        <Card className="shadow-md">
-          <Card.Header>
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Projects</h3>
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  {filteredProjects.length} of {stats.totalProjects} projects
-                </p>
-              </div>
-              <div className="flex items-center gap-3">
-                <Input
-                  placeholder="Search projects..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  leftIcon={<Search className="h-4 w-4" />}
-                  className="w-full sm:w-64"
-                />
+                <Button
+                  variant="outline"
+                  onClick={() => fileInputRef.current?.click()}
+                  leftIcon={<Upload className="h-4 w-4" />}
+                  loading={isImporting}
+                >
+                  Import
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => downloadJson('portfolio-projects.json', projects)}
+                  leftIcon={<Download className="h-4 w-4" />}
+                  disabled={projects.length === 0}
+                >
+                  Export all
+                </Button>
               </div>
             </div>
-          </Card.Header>
-          <Card.Body>
-            {filteredProjects.length === 0 ? (
-              <div className="text-center py-12">
-                <Folder className="h-12 w-12 text-gray-400 dark:text-gray-600 mx-auto mb-4" />
-                <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-2">No projects found</h4>
-                <p className="text-gray-600 dark:text-gray-400 mb-6">
-                  {searchQuery ? 'Try adjusting your search or' : 'Get started by creating your first project or'} sync your filesystem to discover existing projects.
-                </p>
-                <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                  <Button
-                    as={Link}
-                    to="/create"
-                    variant="primary"
-                    leftIcon={<Plus className="h-4 w-4" />}
-                  >
-                    Create Project
-                  </Button>
-                  <Button
-                    onClick={handleSync}
-                    variant="outline"
-                    leftIcon={<RefreshCcw className="h-4 w-4" />}
-                    disabled={syncing}
-                  >
-                    Sync Filesystem
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {filteredProjects.map((project) => {
-                  const assetPreviews = project.assetPreviews.slice(0, 3);
-                  const deliverablePreviews = project.deliverablePreviews.slice(0, 3);
-                  const tagsToShow = project.tags.slice(0, 3);
+          </div>
 
-                  return (
-                    <Card
-                      key={project.id}
-                      className="border border-gray-200 dark:border-gray-700 hover:shadow-md transition-shadow"
+          {filteredProjects.length === 0 ? (
+            <div className="flex h-48 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+              {projects.length === 0
+                ? 'No projects yet. Start by creating your first project intake.'
+                : 'No projects match your search.'}
+            </div>
+          ) : (
+            <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+              {filteredProjects.map(project => (
+                <li key={project.slug} className="flex flex-col gap-4 py-6 md:flex-row md:items-center md:justify-between">
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-3">
+                      <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                        {project.title}
+                      </h3>
+                      <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                        {project.status === 'draft' ? 'Draft' : project.status === 'cast' ? 'In review' : 'Published'}
+                      </span>
+                    </div>
+                    {project.summary && (
+                      <p className="max-w-2xl text-sm text-gray-600 dark:text-gray-400">{project.summary}</p>
+                    )}
+                    <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500 dark:text-gray-500">
+                      <span>{project.assets.length} assets</span>
+                      <span>Updated {formatDate(project.updatedAt)}</span>
+                      <span>
+                        {project.caseStudyContent?.overview
+                          ? 'Narrative ready'
+                          : 'Needs narrative'}
+                      </span>
+                    </div>
+                    {project.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {project.tags.slice(0, 5).map(tag => (
+                          <span
+                            key={tag}
+                            className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs text-indigo-600 dark:bg-indigo-900/50 dark:text-indigo-200"
+                          >
+                            #{tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      as={Link}
+                      to={`/editor/${project.slug}`}
+                      variant="primary"
+                      size="sm"
+                      leftIcon={<FileText className="h-4 w-4" />}
                     >
-                      <Card.Body className="space-y-4 p-4">
-                        <div className="flex items-start justify-between gap-4">
-                          <div className="min-w-0 space-y-2">
-                            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                              <h4 className="truncate text-base font-semibold text-gray-900 dark:text-white">
-                                {project.title}
-                              </h4>
-                              {project.year ? (
-                                <span className="text-xs text-gray-500 dark:text-gray-400">
-                                  {project.year}
-                                </span>
-                              ) : null}
-                            </div>
-                            {project.organization ? (
-                              <p className="text-sm text-gray-600 dark:text-gray-400">
-                                {project.organization}
-                              </p>
-                            ) : null}
-                            {project.summary ? (
-                              <p className="text-sm text-gray-500 dark:text-gray-400">
-                                {project.summary}
-                              </p>
-                            ) : null}
-                            {tagsToShow.length > 0 ? (
-                              <div className="flex flex-wrap gap-2 pt-1">
-                                {tagsToShow.map(tag => (
-                                  <span
-                                    key={tag}
-                                    className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-300"
-                                  >
-                                    #{tag}
-                                  </span>
-                                ))}
-                                {project.tags.length > tagsToShow.length ? (
-                                  <span className="text-xs text-gray-500 dark:text-gray-400">
-                                    +{project.tags.length - tagsToShow.length} more
-                                  </span>
-                                ) : null}
-                              </div>
-                            ) : null}
-                          </div>
-                          <div className="flex flex-col items-end gap-2">
-                            <FreshnessBadge project={project} />
-                            <span
-                              className={`text-[11px] font-semibold uppercase tracking-wide ${
-                                project.syncStatus === 'synced' || project.syncStatus === 'clean'
-                                  ? 'text-emerald-600 dark:text-emerald-300'
-                                  : 'text-amber-600 dark:text-amber-300'
-                              }`}
-                            >
-                              {project.syncStatus}
-                            </span>
-                          </div>
-                        </div>
+                      Case study
+                    </Button>
+                    <Button
+                      onClick={() => handleExport(project)}
+                      variant="outline"
+                      size="sm"
+                      leftIcon={<Download className="h-4 w-4" />}
+                    >
+                      Export
+                    </Button>
+                    <Button
+                      onClick={() => handleDelete(project.slug)}
+                      variant="danger"
+                      size="sm"
+                      leftIcon={<Trash2 className="h-4 w-4" />}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
 
-                        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-gray-500 dark:text-gray-400">
-                          <span>{project.assetCount} assets</span>
-                          <span>{project.deliverableCount} deliverables</span>
-                          <span>Filesystem updated {formatDate(project.fsLastModified)}</span>
-                          {project.lastSyncedAt ? (
-                            <span>Last sync {formatDate(project.lastSyncedAt)}</span>
-                          ) : (
-                            <span>Never synced</span>
-                          )}
-                        </div>
-
-                        <div className="grid gap-4 md:grid-cols-2">
-                          <AssetPreviewList
-                            assets={assetPreviews}
-                            title={`Assets (${project.assetCount})`}
-                          />
-                          <DeliverablePreviewList
-                            deliverables={deliverablePreviews}
-                            title={`Deliverables (${project.deliverableCount})`}
-                          />
-                        </div>
-
-                        <div className="flex flex-wrap gap-2">
-                          <Button
-                            as={Link}
-                            to={`/editor/${project.id}`}
-                            variant="outline"
-                            size="sm"
-                            leftIcon={<FileEdit className="h-3 w-3" />}
-                            className="flex-1 sm:flex-none"
-                          >
-                            Edit
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            leftIcon={<Download className="h-3 w-3" />}
-                            className="flex-1 sm:flex-none"
-                          >
-                            Export
-                          </Button>
-                        </div>
-                      </Card.Body>
-                    </Card>
-                  );
-                })}
-              </div>
-            )}
-          </Card.Body>
-        </Card>
+        <section className="rounded-3xl border border-indigo-200 bg-indigo-50/60 p-6 text-sm text-indigo-900 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/40 dark:text-indigo-100">
+          <h3 className="text-base font-semibold">Workflow tips</h3>
+          <ol className="mt-3 list-decimal space-y-2 pl-5">
+            <li>Capture a project through the intake to gather narrative hooks and assets.</li>
+            <li>Use the case study editor to refine copy, upload visuals, and generate AI narratives.</li>
+            <li>Arrange your highlights in the portfolio editor before sharing or exporting.</li>
+          </ol>
+        </section>
       </main>
     </div>
-  );
-};
+  )
+}
 
-export default DashboardPage;
+export default DashboardPage

--- a/src/pages/NewEditorPage.tsx
+++ b/src/pages/NewEditorPage.tsx
@@ -1,283 +1,546 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, Loader2, RefreshCw, Save } from 'lucide-react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
-import GrapesJSEditor from '../components/GrapesJSEditor'
-import type { GrapesEditor } from '../types/grapes'
-import type { CaseStudyDocument } from '../utils/caseStudyTemplates'
-import { buildCaseStudyTemplate, createCaseStudyBlocks } from '../utils/caseStudyTemplates'
+import React, { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Image,
+  Loader2,
+  RefreshCw,
+  Save,
+  Sparkles,
+  Trash2,
+} from 'lucide-react'
+import { Button, Input } from '../components/ui'
+import type { CaseStudyContent, ProjectAsset, ProjectMeta } from '../intake/schema'
+import { newProject } from '../intake/schema'
 import { loadProject, saveProject } from '../utils/storageManager'
-import type { ProjectMeta } from '../intake/schema'
-import { newProject, projectRoleLabels } from '../intake/schema'
+import { buildCaseStudyDocument, buildDefaultCaseStudyContent } from '../utils/simpleCaseStudy'
+import { generateCaseStudyNarrative } from '../utils/aiNarrative'
+import { useApp } from '../contexts/AppContext'
 
-const formatTitleFromSlug = (slug: string): string =>
-  slug
-    .split(/[-_]+/)
-    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join(' ')
+const createAssetFromFile = (file: File): Promise<ProjectAsset> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = event => {
+      const result = event.target?.result
+      if (typeof result !== 'string') {
+        reject(new Error('Failed to read file'))
+        return
+      }
+      resolve({
+        id: `${Date.now()}-${file.name}`,
+        name: file.name,
+        mimeType: file.type,
+        size: file.size,
+        dataUrl: result,
+        addedAt: new Date().toISOString(),
+      })
+    }
+    reader.onerror = () => reject(new Error('Unable to read file'))
+    reader.readAsDataURL(file)
+  })
 
-const joinList = (values?: string[]): string =>
-  values && values.length > 0 ? values.join(', ') : 'Add details in project settings'
+const listToMultiline = (items: string[]): string => items.join('\n')
 
-type StatusMessage = { type: 'success' | 'error'; message: string }
+const multilineToList = (value: string): string[] =>
+  value
+    .split(/\r?\n+/)
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0)
 
-const buildInitialDocument = (project: ProjectMeta): { initial: CaseStudyDocument; template: CaseStudyDocument } => {
-  const template = buildCaseStudyTemplate(project)
-  const initial: CaseStudyDocument = {
-    html: project.caseStudyHtml ?? template.html,
-    css: project.caseStudyCss ?? template.css,
+const listToTags = (items: string[]): string => items.join(', ')
+
+const parseTags = (value: string): string[] =>
+  value
+    .split(/[,\n]+/)
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0)
+
+const formatDate = (value?: string) => {
+  if (!value) {
+    return 'Just saved'
   }
-  return { initial, template }
+  const parsed = Date.parse(value)
+  if (Number.isNaN(parsed)) {
+    return value
+  }
+  return new Date(parsed).toLocaleString()
 }
 
 const NewEditorPage: React.FC = () => {
-  const { projectId } = useParams<{ projectId: string }>()
   const navigate = useNavigate()
-
-  const editorRef = useRef<GrapesEditor | null>(null)
+  const { projectId } = useParams<{ projectId: string }>()
+  const { addNotification } = useApp()
 
   const [project, setProject] = useState<ProjectMeta | null>(null)
-  const [initialDoc, setInitialDoc] = useState<CaseStudyDocument | null>(null)
-  const [caseStudyDoc, setCaseStudyDoc] = useState<CaseStudyDocument | null>(null)
-  const [templateDoc, setTemplateDoc] = useState<CaseStudyDocument | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [caseStudy, setCaseStudy] = useState<CaseStudyContent | null>(null)
+  const [summary, setSummary] = useState('')
+  const [problem, setProblem] = useState('')
+  const [solution, setSolution] = useState('')
+  const [outcomes, setOutcomes] = useState('')
+  const [tagsInput, setTagsInput] = useState('')
+  const [approachText, setApproachText] = useState('')
+  const [resultsText, setResultsText] = useState('')
+  const [learnings, setLearnings] = useState('')
+  const [overview, setOverview] = useState('')
+  const [cta, setCta] = useState('')
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
-  const [status, setStatus] = useState<StatusMessage | null>(null)
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [assets, setAssets] = useState<ProjectAsset[]>([])
 
-  const loadProjectData = useCallback(async () => {
-    if (!projectId) {
-      setIsLoading(false)
-      setProject(null)
-      return
-    }
-
-    setIsLoading(true)
-    try {
-      let existing = await loadProject(projectId)
-      if (!existing) {
-        const title = formatTitleFromSlug(projectId)
-        const created = newProject(title)
-        created.slug = projectId
-        created.title = title
-        const { template } = buildInitialDocument(created)
-        created.caseStudyHtml = template.html
-        created.caseStudyCss = template.css
-        await saveProject(created)
-        existing = created
+  useEffect(() => {
+    const load = async () => {
+      if (!projectId) {
+        return
       }
-
-      const { initial, template } = buildInitialDocument(existing)
-      setProject(existing)
-      setInitialDoc(initial)
-      setCaseStudyDoc(initial)
-      setTemplateDoc(template)
-    } catch (error) {
-      console.error('Failed to load project for editor', error)
-      setStatus({ type: 'error', message: 'Unable to load project data. Return to the dashboard and try again.' })
-    } finally {
-      setIsLoading(false)
+      const existing = await loadProject(projectId)
+      if (existing) {
+        setProject(existing)
+      } else {
+        const created = newProject(projectId)
+        created.slug = projectId
+        created.title = projectId
+        setProject(created)
+      }
     }
+    void load()
   }, [projectId])
 
   useEffect(() => {
-    void loadProjectData()
-  }, [loadProjectData])
-
-  useEffect(() => {
-    if (!status) {
+    if (!project) {
       return
     }
-    const timeout = window.setTimeout(() => setStatus(null), 3600)
-    return () => window.clearTimeout(timeout)
-  }, [status])
+    const content = project.caseStudyContent ?? buildDefaultCaseStudyContent(project)
+    setCaseStudy(content)
+    setSummary(project.summary ?? content.overview ?? '')
+    setOverview(content.overview ?? project.summary ?? '')
+    setProblem(project.problem ?? '')
+    setSolution(project.solution ?? '')
+    setOutcomes(project.outcomes ?? '')
+    setTagsInput(listToTags(project.tags ?? []))
+    setApproachText(listToMultiline(content.approach))
+    setResultsText(listToMultiline(content.results))
+    setLearnings(content.learnings ?? '')
+    setCta(content.callToAction ?? '')
+    setAssets(project.assets ?? [])
+  }, [project])
 
-  const blocks = useMemo(() => (project ? createCaseStudyBlocks(project) : []), [project])
+  const previewMarkup = useMemo(() => {
+    if (!project || !caseStudy) {
+      return ''
+    }
+    const next: ProjectMeta = {
+      ...project,
+      summary,
+      problem,
+      solution,
+      outcomes,
+      tags: parseTags(tagsInput),
+      assets,
+    }
+    const doc = buildCaseStudyDocument(next, {
+      overview,
+      challenge: problem,
+      approach: multilineToList(approachText),
+      results: multilineToList(resultsText),
+      learnings,
+      callToAction: cta || undefined,
+    })
+    return `<style>${doc.css}</style>${doc.html}`
+  }, [project, caseStudy, summary, problem, solution, outcomes, tagsInput, assets, overview, approachText, resultsText, learnings, cta])
 
-  const handleEditorReady = useCallback((editor: GrapesEditor) => {
-    editorRef.current = editor
-  }, [])
-
-  const handleEditorChange = useCallback((doc: CaseStudyDocument) => {
-    setCaseStudyDoc(doc)
-  }, [])
-
-  const handleReset = useCallback(() => {
-    if (!templateDoc) {
+  const handleAssetUpload: React.ChangeEventHandler<HTMLInputElement> = async event => {
+    const files = Array.from(event.target.files ?? [])
+    if (files.length === 0) {
       return
     }
-    if (editorRef.current) {
-      editorRef.current.setComponents(templateDoc.html)
-      editorRef.current.setStyle(templateDoc.css)
+    try {
+      const uploaded = await Promise.all(files.map(createAssetFromFile))
+      setAssets(previous => [...previous, ...uploaded])
+      setStatusMessage(`Added ${uploaded.length} asset${uploaded.length === 1 ? '' : 's'}.`)
+    } catch (error) {
+      console.error('Failed to process asset', error)
+      setStatusMessage('Unable to read one of the files.')
     }
-    setCaseStudyDoc(templateDoc)
-    setStatus({ type: 'success', message: 'Case study reset to the starter template.' })
-  }, [templateDoc])
+  }
 
-  const handleSave = useCallback(async () => {
-    if (!project || !caseStudyDoc) {
+  const handleRemoveAsset = (assetId: string) => {
+    setAssets(previous => previous.filter(asset => asset.id !== assetId))
+  }
+
+  const handleSetHero = (assetId: string) => {
+    setAssets(previous =>
+      previous.map(asset => ({
+        ...asset,
+        isHeroImage: asset.id === assetId,
+      })),
+    )
+  }
+
+  const handleGenerateNarrative = async () => {
+    if (!project || !caseStudy) {
+      return
+    }
+    setIsGenerating(true)
+    try {
+      const snapshot: ProjectMeta = {
+        ...project,
+        summary,
+        problem,
+        solution,
+        outcomes,
+        tags: parseTags(tagsInput),
+        assets,
+        caseStudyContent: {
+          overview,
+          challenge: caseStudy.challenge,
+          approach: multilineToList(approachText),
+          results: multilineToList(resultsText),
+          learnings,
+          callToAction: cta || undefined,
+        },
+      }
+      const generated = await generateCaseStudyNarrative(snapshot, snapshot.caseStudyContent)
+      setCaseStudy(generated)
+      setOverview(generated.overview)
+      setApproachText(listToMultiline(generated.approach))
+      setResultsText(listToMultiline(generated.results))
+      setLearnings(generated.learnings)
+      setProblem(generated.challenge)
+      setCta(generated.callToAction ?? '')
+      setStatusMessage('AI narrative updated. Review and tweak before saving.')
+    } catch (error) {
+      console.error('Narrative generation failed', error)
+      setStatusMessage(error instanceof Error ? error.message : 'Unable to generate narrative right now.')
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  const handleResetTemplate = () => {
+    if (!project) {
+      return
+    }
+    const defaults = buildDefaultCaseStudyContent({ ...project, summary, problem, solution, outcomes, tags: parseTags(tagsInput), assets })
+    setCaseStudy(defaults)
+    setOverview(defaults.overview)
+    setApproachText(listToMultiline(defaults.approach))
+    setResultsText(listToMultiline(defaults.results))
+    setLearnings(defaults.learnings)
+    setProblem(defaults.challenge)
+    setCta(defaults.callToAction ?? '')
+    setStatusMessage('Case study sections reset to starter copy.')
+  }
+
+  const handleSave = async () => {
+    if (!project) {
       return
     }
     setIsSaving(true)
     try {
-      const updated: ProjectMeta = {
-        ...project,
-        caseStudyHtml: caseStudyDoc.html,
-        caseStudyCss: caseStudyDoc.css,
-        updatedAt: new Date().toISOString(),
+      const updatedCaseStudy: CaseStudyContent = {
+        overview,
+        challenge: problem,
+        approach: multilineToList(approachText),
+        results: multilineToList(resultsText),
+        learnings,
+        callToAction: cta || undefined,
       }
-      await saveProject(updated)
-      setProject(updated)
-      setStatus({ type: 'success', message: 'Case study saved locally.' })
+      const nextProject: ProjectMeta = {
+        ...project,
+        summary: summary || undefined,
+        problem,
+        solution,
+        outcomes,
+        tags: parseTags(tagsInput),
+        assets,
+        updatedAt: new Date().toISOString(),
+        caseStudyContent: updatedCaseStudy,
+      }
+      const doc = buildCaseStudyDocument(nextProject, updatedCaseStudy)
+      nextProject.caseStudyHtml = doc.html
+      nextProject.caseStudyCss = doc.css
+      await saveProject(nextProject)
+      setProject(nextProject)
+      setCaseStudy(updatedCaseStudy)
+      setStatusMessage('Case study saved locally.')
+      addNotification('success', 'Case study saved locally.')
     } catch (error) {
       console.error('Failed to save case study', error)
-      setStatus({ type: 'error', message: 'Save failed. Check storage quota or try again.' })
+      setStatusMessage('Save failed. Ensure storage is available and try again.')
     } finally {
       setIsSaving(false)
     }
-  }, [caseStudyDoc, project])
+  }
 
-  const previewMarkup = useMemo(() => {
-    if (!caseStudyDoc) {
-      return ''
-    }
-    return `<style>${caseStudyDoc.css}</style>${caseStudyDoc.html}`
-  }, [caseStudyDoc])
-
-  const handleBack = () => {
-    navigate('/dashboard')
+  if (!project || !caseStudy) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Loading editor…
+      </div>
+    )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
-      <header className="border-b bg-white">
-        <div className="mx-auto max-w-7xl px-6 py-6">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex items-center gap-4">
-              <button
-                type="button"
-                onClick={handleBack}
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                Back to dashboard
-              </button>
-              <div>
-                <h1 className="text-xl font-semibold">Case study editor</h1>
-                <p className="text-sm text-gray-500">
-                  Craft a narrative for <span className="font-medium text-gray-700">{project?.title ?? 'your project'}</span> using the visual builder.
-                </p>
-              </div>
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <Link
-                to="/portfolio"
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
-              >
-                View portfolio
-              </Link>
-              <Link
-                to="/portfolio/editor"
-                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-purple-700"
-              >
-                Portfolio editor
-              </Link>
-              <button
-                type="button"
-                onClick={handleReset}
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
-                disabled={!templateDoc}
-              >
-                <RefreshCw className="h-4 w-4" />
-                Reset template
-              </button>
-              <button
-                type="button"
-                onClick={handleSave}
-                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-700 disabled:opacity-50"
-                disabled={isSaving || !caseStudyDoc}
-              >
-                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                Save case study
-              </button>
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <header className="border-b border-gray-200 bg-white/80 backdrop-blur dark:border-gray-800 dark:bg-gray-900/80">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              onClick={() => navigate('/dashboard')}
+              leftIcon={<ArrowLeft className="h-4 w-4" />}
+            >
+              Dashboard
+            </Button>
+            <div>
+              <h1 className="text-xl font-semibold">Case study editor</h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Shape a concise narrative, manage assets, and preview the final layout.
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-500">Last updated {formatDate(project.updatedAt)}</p>
             </div>
           </div>
-          {status && (
-            <div
-              className={`mt-4 rounded-lg border px-4 py-3 text-sm ${
-                status.type === 'error'
-                  ? 'border-red-200 bg-red-50 text-red-600'
-                  : 'border-emerald-200 bg-emerald-50 text-emerald-700'
-              }`}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="ghost"
+              leftIcon={<RefreshCw className="h-4 w-4" />}
+              onClick={handleResetTemplate}
             >
-              {status.message}
-            </div>
-          )}
+              Reset template
+            </Button>
+            <Button
+              variant="outline"
+              leftIcon={<Sparkles className="h-4 w-4" />}
+              onClick={handleGenerateNarrative}
+              loading={isGenerating}
+            >
+              Generate narrative
+            </Button>
+            <Button
+              variant="primary"
+              leftIcon={<Save className="h-4 w-4" />}
+              onClick={handleSave}
+              loading={isSaving}
+            >
+              Save case study
+            </Button>
+          </div>
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl px-6 py-6 lg:py-10">
-        {isLoading || !project || !initialDoc ? (
-          <div className="flex h-[70vh] items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white">
-            <div className="flex items-center gap-2 text-sm text-gray-500">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Loading editor…
-            </div>
-          </div>
-        ) : (
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
-            <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-              <GrapesJSEditor
-                key={project.slug}
-                initialHtml={initialDoc.html}
-                initialCss={initialDoc.css}
-                blocks={blocks}
-                onChange={handleEditorChange}
-                onEditorReady={handleEditorReady}
-                height="calc(100vh - 240px)"
-              />
-            </section>
-            <aside className="flex flex-col gap-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-              <div className="space-y-3">
-                <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Live preview</h2>
-                <div className="rounded-xl border border-gray-200 bg-gray-50 p-3">
-                  {caseStudyDoc ? (
-                    <div
-                      className="case-study-preview max-h-[60vh] overflow-y-auto rounded-lg bg-white p-4"
-                      dangerouslySetInnerHTML={{ __html: previewMarkup }}
-                    />
-                  ) : (
-                    <p className="text-sm text-gray-500">Begin editing to see the rendered case study.</p>
-                  )}
-                </div>
-              </div>
+      <main className="mx-auto grid max-w-6xl gap-8 px-6 py-8 lg:grid-cols-[1.1fr_0.9fr]">
+        <section className="space-y-6">
+          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Hero & summary</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Set the hook for the case study and tune the key metadata.</p>
 
-              <div className="space-y-3">
-                <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Project details</h3>
-                <dl className="space-y-3 text-sm text-gray-600">
-                  <div className="flex justify-between gap-3">
-                    <dt className="text-gray-500">Project</dt>
-                    <dd className="text-right font-medium text-gray-700">{project.title}</dd>
-                  </div>
-                  <div className="flex justify-between gap-3">
-                    <dt className="text-gray-500">Role</dt>
-                    <dd className="text-right text-gray-700">{projectRoleLabels[project.role] ?? project.role}</dd>
-                  </div>
-                  <div>
-                    <dt className="text-gray-500">Summary</dt>
-                    <dd className="mt-1 text-gray-700">{project.summary || 'Add a summary in the project dashboard.'}</dd>
-                  </div>
-                  <div>
-                    <dt className="text-gray-500">Tags</dt>
-                    <dd className="mt-1 text-gray-700">{joinList(project.tags)}</dd>
-                  </div>
-                  <div>
-                    <dt className="text-gray-500">Technologies</dt>
-                    <dd className="mt-1 text-gray-700">{joinList(project.technologies)}</dd>
-                  </div>
-                </dl>
-              </div>
-            </aside>
-          </div>
-        )}
+            <div className="mt-6 space-y-4">
+              <Input
+                label="Project title"
+                value={project.title}
+                onChange={event => setProject(previous => (previous ? { ...previous, title: event.target.value } : previous))}
+                fullWidth
+              />
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Portfolio summary
+                <textarea
+                  value={summary}
+                  onChange={event => setSummary(event.target.value)}
+                  rows={3}
+                  placeholder="A concise one-liner to describe the project."
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Hero narrative
+                <textarea
+                  value={overview}
+                  onChange={event => setOverview(event.target.value)}
+                  rows={3}
+                  placeholder="Set the tone for the story with a short paragraph."
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Tags
+                <textarea
+                  value={tagsInput}
+                  onChange={event => setTagsInput(event.target.value)}
+                  rows={2}
+                  placeholder="product strategy, data visualisation, design systems"
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+            </div>
+          </article>
+
+          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Narrative detail</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">These sections drive the AI narrative and portfolio export.</p>
+
+            <div className="mt-6 space-y-5">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Challenge
+                <textarea
+                  value={problem}
+                  onChange={event => {
+                    setProblem(event.target.value)
+                    setCaseStudy(previous => (previous ? { ...previous, challenge: event.target.value } : previous))
+                  }}
+                  rows={3}
+                  placeholder="What was the problem or opportunity?"
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Approach (one point per line)
+                <textarea
+                  value={approachText}
+                  onChange={event => {
+                    setApproachText(event.target.value)
+                    setCaseStudy(previous => (previous ? { ...previous, approach: multilineToList(event.target.value) } : previous))
+                  }}
+                  rows={4}
+                  placeholder={'Discovery workshops\nCustomer journey mapping\nIterative prototyping'}
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Impact (one metric or story per line)
+                <textarea
+                  value={resultsText}
+                  onChange={event => {
+                    setResultsText(event.target.value)
+                    setCaseStudy(previous => (previous ? { ...previous, results: multilineToList(event.target.value) } : previous))
+                  }}
+                  rows={4}
+                  placeholder={'30% uplift in activation\nShipped cross-team design system'}
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Solution summary
+                <textarea
+                  value={solution}
+                  onChange={event => setSolution(event.target.value)}
+                  rows={3}
+                  placeholder="How did you design, build, or facilitate the outcome?"
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Outcomes & metrics
+                <textarea
+                  value={outcomes}
+                  onChange={event => setOutcomes(event.target.value)}
+                  rows={3}
+                  placeholder="Key numbers, qualitative wins, or momentum unlocked."
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Learnings
+                <textarea
+                  value={learnings}
+                  onChange={event => {
+                    setLearnings(event.target.value)
+                    setCaseStudy(previous => (previous ? { ...previous, learnings: event.target.value } : previous))
+                  }}
+                  rows={3}
+                  placeholder="Key lessons or reflections to carry into the next project."
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Call to action
+                <textarea
+                  value={cta}
+                  onChange={event => {
+                    setCta(event.target.value)
+                    setCaseStudy(previous => (previous ? { ...previous, callToAction: event.target.value } : previous))
+                  }}
+                  rows={2}
+                  placeholder="Let’s shape the next release together."
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+            </div>
+          </article>
+
+        </section>
+
+        <aside className="space-y-6">
+          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Assets</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Select a hero image and keep supporting visuals close at hand.</p>
+
+            <label className="mt-4 flex cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-600 transition hover:border-indigo-400 hover:text-indigo-500 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-400 dark:hover:border-indigo-500">
+              <input type="file" accept="image/*" multiple className="hidden" onChange={handleAssetUpload} />
+              <Image className="h-6 w-6" />
+              <span>Drop imagery or <span className="underline">browse</span></span>
+            </label>
+
+            {assets.length > 0 ? (
+              <ul className="mt-4 space-y-3 text-sm">
+                {assets.map(asset => (
+                  <li
+                    key={asset.id}
+                    className="flex items-center justify-between rounded-2xl border border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-800/70"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{asset.name}</p>
+                      <p className="truncate text-xs text-gray-500">
+                        {asset.mimeType}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant={asset.isHeroImage ? 'primary' : 'outline'}
+                        size="sm"
+                        onClick={() => handleSetHero(asset.id)}
+                      >
+                        {asset.isHeroImage ? 'Hero image' : 'Set hero'}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        leftIcon={<Trash2 className="h-4 w-4" />}
+                        onClick={() => handleRemoveAsset(asset.id)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-4 text-xs text-gray-500 dark:text-gray-500">No assets yet. Upload hero imagery or screenshots to enhance the case study.</p>
+            )}
+          </section>
+
+          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Live preview</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Updated as you type. Export-ready HTML & CSS are saved locally.</p>
+            <div className="mt-4 overflow-hidden rounded-2xl border border-gray-200 bg-gray-900/80 p-4 shadow-inner dark:border-gray-700">
+              <div
+                className="max-h-[420px] overflow-y-auto rounded-xl bg-black/60 text-sm"
+                dangerouslySetInnerHTML={{ __html: previewMarkup }}
+              />
+            </div>
+          </section>
+
+          {statusMessage && (
+            <section className="rounded-3xl border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-900 shadow-sm dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-100">
+              <p className="flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4" />
+                {statusMessage}
+              </p>
+            </section>
+          )}
+        </aside>
       </main>
     </div>
   )

--- a/src/pages/NewIntakePage.tsx
+++ b/src/pages/NewIntakePage.tsx
@@ -1,607 +1,309 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import {
-  Plus, ArrowRight, Folder, Image, Video, FileText, Upload,
-  Zap, Globe, Smartphone, Monitor, Camera, Palette, Code,
-  Star, Clock, User, Search, Filter, Grid, List, Trash2,
-  Eye, Download, Settings, ChevronDown, X, AlertCircle,
-  HelpCircle, BookOpen, Layout
-} from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
-import { Link, useNavigate } from 'react-router-dom';
-import { newProject } from '../intake/schema';
-import { buildCaseStudyTemplate } from '../utils/caseStudyTemplates';
-import { saveProject } from '../utils/storageManager';
+  ArrowLeft,
+  CheckCircle2,
+  FolderPlus,
+  ImagePlus,
+  Sparkles,
+} from 'lucide-react'
+import { Button, Input } from '../components/ui'
+import type { ProjectAsset, ProjectMeta } from '../intake/schema'
+import { newProject } from '../intake/schema'
+import { saveProject } from '../utils/storageManager'
+import { buildDefaultCaseStudyContent } from '../utils/simpleCaseStudy'
+import { useApp } from '../contexts/AppContext'
 
-interface ProjectCategory {
-  id: string;
-  name: string;
-  icon: LucideIcon;
-  description: string;
-  color: string;
-  templates: string[];
-}
-
-const NewIntakePage = () => {
-  const navigate = useNavigate();
-  const [isDarkMode, setIsDarkMode] = useState(false);
-  const [activeStep, setActiveStep] = useState(1);
-  const [showTemplateDetails, setShowTemplateDetails] = useState<string | null>(null);
-  const [formData, setFormData] = useState({
-    projectName: '',
-    description: '',
-    category: '',
-    template: '',
-    color: '#5a3cf4',
-    visibility: 'public',
-    tags: [] as string[],
-    files: [] as File[]
-  });
-
-  const projectCategories: ProjectCategory[] = [
-    {
-      id: 'web-development',
-      name: 'Web Development',
-      icon: Globe,
-      description: 'Websites, web applications, and frontend projects',
-      color: '#3B82F6',
-      templates: ['Landing Page', 'E-commerce', 'Dashboard', 'Blog', 'Portfolio']
-    },
-    {
-      id: 'mobile-development',
-      name: 'Mobile Development',
-      icon: Smartphone,
-      description: 'iOS and Android applications',
-      color: '#10B981',
-      templates: ['Social App', 'E-commerce App', 'Productivity', 'Game', 'Utility']
-    },
-    {
-      id: 'ui-ux-design',
-      name: 'UI/UX Design',
-      icon: Palette,
-      description: 'User interface and experience design projects',
-      color: '#8B5CF6',
-      templates: ['Design System', 'Mobile UI', 'Web UI', 'Wireframes', 'Prototypes']
-    },
-    {
-      id: 'photography',
-      name: 'Photography',
-      icon: Camera,
-      description: 'Photo galleries and visual storytelling',
-      color: '#F59E0B',
-      templates: ['Portrait Gallery', 'Wedding', 'Nature', 'Product', 'Event']
-    },
-    {
-      id: 'branding',
-      name: 'Branding & Identity',
-      icon: Star,
-      description: 'Brand identity and visual communication',
-      color: '#EF4444',
-      templates: ['Logo Design', 'Brand Guidelines', 'Packaging', 'Print Design', 'Marketing']
-    },
-    {
-      id: 'development',
-      name: 'Software Development',
-      icon: Code,
-      description: 'Backend, APIs, and software engineering',
-      color: '#06B6D4',
-      templates: ['API Documentation', 'Library', 'Tool', 'Framework', 'Algorithm']
+const createAssetFromFile = (file: File): Promise<ProjectAsset> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = event => {
+      const result = event.target?.result
+      if (typeof result !== 'string') {
+        reject(new Error('Failed to read file'))
+        return
+      }
+      resolve({
+        id: `${Date.now()}-${file.name}`,
+        name: file.name,
+        mimeType: file.type,
+        size: file.size,
+        dataUrl: result,
+        addedAt: new Date().toISOString(),
+        description: '',
+      })
     }
-  ];
+    reader.onerror = () => reject(new Error('Unable to read file'))
+    reader.readAsDataURL(file)
+  })
 
-  const colorOptions = [
-    '#5a3cf4', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
-    '#06b6d4', '#84cc16', '#f97316', '#ec4899', '#6366f1'
-  ];
+const normaliseListInput = (value: string): string[] =>
+  value
+    .split(/[,\n]+/)
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0)
 
-  const handleCategorySelect = (category: ProjectCategory) => {
-    setFormData(prev => ({ ...prev, category: category.id }));
-    setActiveStep(2);
-  };
+const NewIntakePage: React.FC = () => {
+  const navigate = useNavigate()
+  const { addNotification } = useApp()
 
-  const handleTemplateSelect = (template: string) => {
-    setFormData(prev => ({ ...prev, template }));
-    setActiveStep(3);
-  };
+  const [title, setTitle] = useState('')
+  const [summary, setSummary] = useState('')
+  const [problem, setProblem] = useState('')
+  const [solution, setSolution] = useState('')
+  const [outcomes, setOutcomes] = useState('')
+  const [tags, setTags] = useState('')
+  const [autoNarrative, setAutoNarrative] = useState(true)
+  const [assets, setAssets] = useState<ProjectAsset[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const handleProjectSubmit = async () => {
-    const title = formData.projectName.trim();
-    if (!title) {
-      return;
+  const canSubmit = useMemo(() => title.trim().length > 0, [title])
+
+  const handleAssetUpload: React.ChangeEventHandler<HTMLInputElement> = async event => {
+    const files = Array.from(event.target.files ?? [])
+    if (files.length === 0) {
+      return
+    }
+    try {
+      const uploaded = await Promise.all(files.map(createAssetFromFile))
+      setAssets(previous => [...previous, ...uploaded])
+      addNotification('success', `Added ${uploaded.length} asset${uploaded.length === 1 ? '' : 's'}.`)
+    } catch (error) {
+      console.error('Asset upload failed', error)
+      addNotification('error', 'Unable to read one of the files.')
+    }
+  }
+
+  const handleRemoveAsset = (assetId: string) => {
+    setAssets(previous => previous.filter(asset => asset.id !== assetId))
+  }
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async event => {
+    event.preventDefault()
+    if (!canSubmit) {
+      return
     }
 
-    const project = newProject(title);
-    project.summary = formData.description.trim() || undefined;
-    project.problem = formData.description.trim();
-    project.solution = 'Use the editor to describe the approach, process, and collaboration.';
-    project.outcomes = 'Add measurable impact or learnings from the project in the editor.';
-    project.tags = Array.isArray(formData.tags) ? formData.tags : [];
+    setIsSubmitting(true)
+    try {
+      const project: ProjectMeta = {
+        ...newProject(title.trim()),
+        summary: summary.trim() || undefined,
+        problem: problem.trim(),
+        solution: solution.trim(),
+        outcomes: outcomes.trim(),
+        tags: normaliseListInput(tags),
+        autoGenerateNarrative: autoNarrative,
+        assets,
+      }
+      project.caseStudyContent = buildDefaultCaseStudyContent(project)
+      project.caseStudyContent.overview = project.summary ?? ''
 
-    const template = buildCaseStudyTemplate(project);
-    project.caseStudyHtml = template.html;
-    project.caseStudyCss = template.css;
-
-    await saveProject(project);
-    navigate(`/editor/${project.slug}`);
-  };
-
-  const selectedCategory = projectCategories.find(cat => cat.id === formData.category);
+      await saveProject(project)
+      addNotification('success', 'Project saved locally. Time to craft the case study!')
+      navigate(`/editor/${project.slug}`)
+    } catch (error) {
+      console.error('Failed to create project', error)
+      addNotification('error', 'Unable to save the project to local storage.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
 
   return (
-    <div className={`min-h-screen transition-colors duration-200 ${
-      isDarkMode ? 'dark bg-gray-900 text-white' : 'bg-gray-50 text-gray-900'
-    }`}>
-      {/* Header */}
-      <header className={`border-b ${
-        isDarkMode ? 'bg-gray-900 border-gray-800' : 'bg-white border-gray-200'
-      }`}>
-        <div className="px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <Link
-                to="/dashboard"
-                className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${
-                  isDarkMode
-                    ? 'hover:bg-gray-800 text-gray-400 hover:text-white'
-                    : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                <ArrowRight className="rotate-180" size={16} />
-                <span>Back to Dashboard</span>
-              </Link>
-
-              <div className="border-l border-gray-300 dark:border-gray-700 h-6"></div>
-
-              <div>
-                <h1 className="text-xl font-semibold">Create New Project</h1>
-                <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                  Set up your portfolio project in just a few steps
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <button
-                onClick={() => setIsDarkMode(!isDarkMode)}
-                className={`p-2 rounded-lg transition-colors ${
-                  isDarkMode
-                    ? 'hover:bg-gray-800 text-gray-400 hover:text-white'
-                    : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                {isDarkMode ? '☀️' : '🌙'}
-              </button>
-
-              <Link
-                to="/settings"
-                className={`p-2 rounded-lg transition-colors ${
-                  isDarkMode
-                    ? 'hover:bg-gray-800 text-gray-400 hover:text-white'
-                    : 'hover:bg-gray-100 text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                <Settings size={20} />
-              </Link>
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <header className="border-b border-gray-200 bg-white/80 backdrop-blur dark:border-gray-800 dark:bg-gray-900/80">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-6">
+          <div className="flex items-center gap-3">
+            <Link
+              to="/dashboard"
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-600 transition hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Dashboard
+            </Link>
+            <div>
+              <h1 className="text-xl font-semibold">Project intake</h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Capture the essentials so your case study practically writes itself.
+              </p>
             </div>
           </div>
+          <Button as={Link} to="/portfolio" variant="outline" leftIcon={<Sparkles className="h-4 w-4" />}>
+            Portfolio
+          </Button>
         </div>
       </header>
 
-      {/* Progress Steps */}
-      <div className={`border-b ${isDarkMode ? 'border-gray-800 bg-gray-850' : 'border-gray-200 bg-gray-25'}`}>
-        <div className="px-6 py-4">
-          <div className="flex items-center justify-center">
-            <div className="flex items-center gap-8">
-              {[
-                { step: 1, title: 'Category', icon: Layout },
-                { step: 2, title: 'Template', icon: BookOpen },
-                { step: 3, title: 'Details', icon: User },
-                { step: 4, title: 'Files', icon: Upload }
-              ].map(({ step, title, icon: Icon }) => (
-                <div key={step} className="flex items-center gap-3">
-                  <div className={`flex items-center justify-center w-10 h-10 rounded-full transition-colors ${
-                    activeStep >= step
-                      ? 'bg-purple-600 text-white'
-                      : isDarkMode
-                        ? 'bg-gray-700 text-gray-400'
-                        : 'bg-gray-200 text-gray-500'
-                  }`}>
-                    {activeStep > step ? (
-                      <div className="w-2 h-2 bg-white rounded-full"></div>
-                    ) : (
-                      <Icon size={16} />
-                    )}
-                  </div>
-                  <span className={`text-sm font-medium ${
-                    activeStep >= step
-                      ? 'text-purple-600 dark:text-purple-400'
-                      : isDarkMode
-                        ? 'text-gray-400'
-                        : 'text-gray-500'
-                  }`}>
-                    {title}
-                  </span>
-                  {step < 4 && (
-                    <div className={`w-12 h-px ${
-                      activeStep > step
-                        ? 'bg-purple-600'
-                        : isDarkMode
-                          ? 'bg-gray-700'
-                          : 'bg-gray-200'
-                    }`}></div>
-                  )}
-                </div>
-              ))}
+      <main className="mx-auto max-w-4xl px-6 py-10">
+        <form className="space-y-8" onSubmit={handleSubmit}>
+          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Project overview</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              Give the project a name and a short framing statement.
+            </p>
+
+            <div className="mt-6 space-y-4">
+              <Input
+                label="Project title"
+                value={title}
+                onChange={event => setTitle(event.target.value)}
+                placeholder="e.g. Nova analytics platform redesign"
+                required
+                fullWidth
+              />
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Summary
+                <textarea
+                  value={summary}
+                  onChange={event => setSummary(event.target.value)}
+                  placeholder="One or two sentences that set the scene for the work."
+                  rows={3}
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
             </div>
-          </div>
-        </div>
-      </div>
+          </section>
 
-      {/* Main Content */}
-      <main className="px-6 py-8">
-        <div className="max-w-6xl mx-auto">
-          {/* Step 1: Category Selection */}
-          {activeStep === 1 && (
-            <div className="space-y-8">
-              <div className="text-center">
-                <h2 className="text-2xl font-bold mb-2">Choose Your Project Category</h2>
-                <p className={`text-lg ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                  Select the type of project you want to showcase
-                </p>
-              </div>
+          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Narrative hooks</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              These answers become the backbone of your AI generated case study.
+            </p>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {projectCategories.map((category) => {
-                  const IconComponent = category.icon;
-                  return (
-                    <button
-                      key={category.id}
-                      onClick={() => handleCategorySelect(category)}
-                      className={`p-6 rounded-xl border-2 text-left transition-all hover:shadow-lg group ${
-                        formData.category === category.id
-                          ? 'border-purple-500 bg-purple-50 dark:bg-purple-950'
-                          : isDarkMode
-                            ? 'border-gray-700 bg-gray-800 hover:border-gray-600'
-                            : 'border-gray-200 bg-white hover:border-gray-300'
-                      }`}
-                    >
-                      <div className="flex items-start gap-4">
-                        <div
-                          className="w-12 h-12 rounded-lg flex items-center justify-center group-hover:scale-110 transition-transform"
-                          style={{ backgroundColor: `${category.color}20`, color: category.color }}
-                        >
-                          <IconComponent size={24} />
-                        </div>
-                        <div className="flex-1">
-                          <h3 className="text-lg font-semibold mb-2">{category.name}</h3>
-                          <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                            {category.description}
-                          </p>
-                          <div className="flex flex-wrap gap-1 mt-3">
-                            {category.templates.slice(0, 3).map((template) => (
-                              <span
-                                key={template}
-                                className={`px-2 py-1 text-xs rounded-full ${
-                                  isDarkMode
-                                    ? 'bg-gray-700 text-gray-300'
-                                    : 'bg-gray-100 text-gray-600'
-                                }`}
-                              >
-                                {template}
-                              </span>
-                            ))}
-                            {category.templates.length > 3 && (
-                              <span className={`px-2 py-1 text-xs rounded-full ${
-                                isDarkMode
-                                  ? 'bg-gray-700 text-gray-400'
-                                  : 'bg-gray-100 text-gray-500'
-                              }`}>
-                                +{category.templates.length - 3}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
+            <div className="mt-6 space-y-5">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                What was the challenge?
+                <textarea
+                  value={problem}
+                  onChange={event => setProblem(event.target.value)}
+                  rows={3}
+                  placeholder="Describe the friction, business goal, or customer problem."
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  required
+                />
+              </label>
+
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                How did you approach it?
+                <textarea
+                  value={solution}
+                  onChange={event => setSolution(event.target.value)}
+                  rows={3}
+                  placeholder="Outline key moves, collaboration patterns, or design decisions."
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  required
+                />
+              </label>
+
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                What happened as a result?
+                <textarea
+                  value={outcomes}
+                  onChange={event => setOutcomes(event.target.value)}
+                  rows={3}
+                  placeholder="Metrics, qualitative feedback, or momentum the project unlocked."
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  required
+                />
+              </label>
+
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Tags
+                <textarea
+                  value={tags}
+                  onChange={event => setTags(event.target.value)}
+                  rows={2}
+                  placeholder="Separate with commas or new lines – e.g. product strategy, analytics, design systems"
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
             </div>
-          )}
+          </section>
 
-          {/* Step 2: Template Selection */}
-          {activeStep === 2 && selectedCategory && (
-            <div className="space-y-8">
-              <div className="text-center">
-                <h2 className="text-2xl font-bold mb-2">Choose a Template</h2>
-                <p className={`text-lg ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                  Pick a starting template for your {selectedCategory.name.toLowerCase()} project
-                </p>
-              </div>
+          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Reference material</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              Upload hero images, process shots, or supporting files. You can manage these later in the case study editor.
+            </p>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {selectedCategory.templates.map((template) => (
-                  <button
-                    key={template}
-                    onClick={() => handleTemplateSelect(template)}
-                    className={`p-6 rounded-xl border-2 text-left transition-all hover:shadow-lg group ${
-                      formData.template === template
-                        ? 'border-purple-500 bg-purple-50 dark:bg-purple-950'
-                        : isDarkMode
-                          ? 'border-gray-700 bg-gray-800 hover:border-gray-600'
-                          : 'border-gray-200 bg-white hover:border-gray-300'
-                    }`}
-                  >
-                    <div className="aspect-video rounded-lg mb-4 bg-gradient-to-br from-purple-100 to-blue-100 dark:from-purple-900 dark:to-blue-900 flex items-center justify-center">
-                      <div className="text-4xl opacity-50">📱</div>
-                    </div>
-                    <h3 className="text-lg font-semibold mb-2">{template}</h3>
-                    <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                      Perfect starting point for {template.toLowerCase()} projects
-                    </p>
-                  </button>
-                ))}
+            <div className="mt-6 space-y-4">
+              <label className="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-600 transition hover:border-indigo-400 hover:text-indigo-500 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-400 dark:hover:border-indigo-500">
+                <input type="file" accept="image/*,.pdf,.doc,.docx" multiple className="hidden" onChange={handleAssetUpload} />
+                <ImagePlus className="h-6 w-6" />
+                <span>
+                  Drop files here or <span className="underline">browse</span>
+                </span>
+              </label>
 
-                {/* Custom Template Option */}
-                <button
-                  onClick={() => handleTemplateSelect('Custom')}
-                  className={`p-6 rounded-xl border-2 border-dashed text-left transition-all hover:shadow-lg group ${
-                    formData.template === 'Custom'
-                      ? 'border-purple-500 bg-purple-50 dark:bg-purple-950'
-                      : isDarkMode
-                        ? 'border-gray-700 bg-gray-800 hover:border-gray-600'
-                        : 'border-gray-200 bg-white hover:border-gray-300'
-                  }`}
-                >
-                  <div className="aspect-video rounded-lg mb-4 bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
-                    <Plus size={32} className="text-gray-400" />
-                  </div>
-                  <h3 className="text-lg font-semibold mb-2">Start from Scratch</h3>
-                  <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                    Build your own custom project structure
-                  </p>
-                </button>
-              </div>
-
-              <div className="flex justify-center">
-                <button
-                  onClick={() => setActiveStep(1)}
-                  className={`px-6 py-3 rounded-lg border transition-colors ${
-                    isDarkMode
-                      ? 'border-gray-700 hover:bg-gray-800'
-                      : 'border-gray-200 hover:bg-gray-50'
-                  }`}
-                >
-                  ← Back to Categories
-                </button>
-              </div>
+              {assets.length > 0 && (
+                <ul className="space-y-2 text-sm">
+                  {assets.map(asset => (
+                    <li key={asset.id} className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-800/80">
+                      <span className="truncate">
+                        {asset.name}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveAsset(asset.id)}
+                        className="text-xs text-rose-500 hover:text-rose-600"
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
-          )}
+          </section>
 
-          {/* Step 3: Project Details */}
-          {activeStep === 3 && (
-            <div className="space-y-8">
-              <div className="text-center">
-                <h2 className="text-2xl font-bold mb-2">Project Details</h2>
-                <p className={`text-lg ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                  Tell us about your project
-                </p>
+          <section className="rounded-3xl border border-indigo-200 bg-indigo-50/80 p-6 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/40">
+            <div className="flex items-start gap-3">
+              <div className="rounded-full bg-white p-2 shadow-sm dark:bg-indigo-900/80">
+                <Sparkles className="h-5 w-5 text-indigo-600 dark:text-indigo-300" />
               </div>
-
-              <div className="max-w-2xl mx-auto space-y-6">
-                <div>
-                  <label className="block text-sm font-medium mb-2">Project Name *</label>
+              <div className="space-y-2">
+                <h2 className="text-lg font-semibold text-indigo-900 dark:text-indigo-100">AI narrative boost</h2>
+                <p className="text-sm text-indigo-800/80 dark:text-indigo-200/80">
+                  Keep this enabled to pre-fill the case study editor with an AI generated narrative.
+                </p>
+                <label className="inline-flex items-center gap-2 text-sm text-indigo-900 dark:text-indigo-100">
                   <input
-                    type="text"
-                    value={formData.projectName}
-                    onChange={(e) => setFormData(prev => ({ ...prev, projectName: e.target.value }))}
-                    placeholder="e.g., My Awesome Mobile App"
-                    className={`w-full px-4 py-3 rounded-xl border transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 ${
-                      isDarkMode
-                        ? 'border-gray-700 bg-gray-800 focus:border-purple-500'
-                        : 'border-gray-200 bg-white focus:border-purple-500'
-                    }`}
+                    type="checkbox"
+                    checked={autoNarrative}
+                    onChange={event => setAutoNarrative(event.target.checked)}
+                    className="h-4 w-4 rounded border-indigo-400 text-indigo-600 focus:ring-indigo-500"
                   />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-2">Description</label>
-                  <textarea
-                    value={formData.description}
-                    onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
-                    placeholder="Brief description of your project..."
-                    rows={4}
-                    className={`w-full px-4 py-3 rounded-xl border transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 resize-none ${
-                      isDarkMode
-                        ? 'border-gray-700 bg-gray-800 focus:border-purple-500'
-                        : 'border-gray-200 bg-white focus:border-purple-500'
-                    }`}
-                  />
-                </div>
-
-                <div className="grid grid-cols-2 gap-6">
-                  <div>
-                    <label className="block text-sm font-medium mb-2">Project Color</label>
-                    <div className="flex flex-wrap gap-2">
-                      {colorOptions.map((color) => (
-                        <button
-                          key={color}
-                          onClick={() => setFormData(prev => ({ ...prev, color }))}
-                          className={`w-10 h-10 rounded-full border-2 transition-all ${
-                            formData.color === color ? 'border-gray-400 scale-110' : 'border-transparent'
-                          }`}
-                          style={{ backgroundColor: color }}
-                        />
-                      ))}
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium mb-2">Visibility</label>
-                    <div className="space-y-3">
-                      <label className="flex items-center gap-3 cursor-pointer">
-                        <input
-                          type="radio"
-                          value="public"
-                          checked={formData.visibility === 'public'}
-                          onChange={(e) => setFormData(prev => ({ ...prev, visibility: e.target.value }))}
-                          className="text-purple-600"
-                        />
-                        <div>
-                          <div className="font-medium">Public</div>
-                          <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                            Visible to everyone
-                          </div>
-                        </div>
-                      </label>
-
-                      <label className="flex items-center gap-3 cursor-pointer">
-                        <input
-                          type="radio"
-                          value="private"
-                          checked={formData.visibility === 'private'}
-                          onChange={(e) => setFormData(prev => ({ ...prev, visibility: e.target.value }))}
-                          className="text-purple-600"
-                        />
-                        <div>
-                          <div className="font-medium">Private</div>
-                          <div className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                            Only visible to you
-                          </div>
-                        </div>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="flex gap-4 pt-6">
-                  <button
-                    onClick={() => setActiveStep(2)}
-                    className={`flex-1 py-3 rounded-xl font-medium border transition-colors ${
-                      isDarkMode
-                        ? 'border-gray-700 hover:bg-gray-800'
-                        : 'border-gray-200 hover:bg-gray-50'
-                    }`}
-                  >
-                    ← Back to Templates
-                  </button>
-
-                  <button
-                    onClick={() => setActiveStep(4)}
-                    disabled={!formData.projectName}
-                    className={`flex-1 py-3 rounded-xl font-medium transition-colors ${
-                      formData.projectName
-                        ? 'bg-purple-600 text-white hover:bg-purple-700'
-                        : 'bg-gray-300 text-gray-500 cursor-not-allowed dark:bg-gray-700'
-                    }`}
-                  >
-                    Continue to Files →
-                  </button>
-                </div>
+                  Auto-generate a narrative draft after saving
+                </label>
               </div>
             </div>
-          )}
+          </section>
 
-          {/* Step 4: File Upload */}
-          {activeStep === 4 && (
-            <div className="space-y-8">
-              <div className="text-center">
-                <h2 className="text-2xl font-bold mb-2">Add Your Files</h2>
-                <p className={`text-lg ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                  Upload images, videos, and documents for your project
-                </p>
-              </div>
-
-              <div className="max-w-4xl mx-auto">
-                {/* File Upload Area */}
-                <div className={`border-2 border-dashed rounded-xl p-12 text-center transition-colors ${
-                  isDarkMode
-                    ? 'border-gray-700 bg-gray-800 hover:border-gray-600'
-                    : 'border-gray-200 bg-gray-50 hover:border-gray-300'
-                }`}>
-                  <Upload size={48} className="mx-auto mb-4 text-gray-400" />
-                  <h3 className="text-lg font-semibold mb-2">Drop files here or click to browse</h3>
-                  <p className={`text-sm mb-6 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                    Support for images, videos, PDFs, and more
-                  </p>
-                  <button className="bg-purple-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-purple-700 transition-colors">
-                    Choose Files
-                  </button>
-                </div>
-
-                {/* Quick Actions */}
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8">
-                  <button className={`p-4 rounded-xl border text-left transition-colors ${
-                    isDarkMode
-                      ? 'border-gray-700 bg-gray-800 hover:bg-gray-750'
-                      : 'border-gray-200 bg-white hover:bg-gray-50'
-                  }`}>
-                    <Image size={24} className="mb-2 text-blue-500" />
-                    <h4 className="font-medium mb-1">Add Images</h4>
-                    <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                      Screenshots, designs, photos
-                    </p>
-                  </button>
-
-                  <button className={`p-4 rounded-xl border text-left transition-colors ${
-                    isDarkMode
-                      ? 'border-gray-700 bg-gray-800 hover:bg-gray-750'
-                      : 'border-gray-200 bg-white hover:bg-gray-50'
-                  }`}>
-                    <Video size={24} className="mb-2 text-green-500" />
-                    <h4 className="font-medium mb-1">Add Videos</h4>
-                    <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                      Demos, presentations, clips
-                    </p>
-                  </button>
-
-                  <button className={`p-4 rounded-xl border text-left transition-colors ${
-                    isDarkMode
-                      ? 'border-gray-700 bg-gray-800 hover:bg-gray-750'
-                      : 'border-gray-200 bg-white hover:bg-gray-50'
-                  }`}>
-                    <FileText size={24} className="mb-2 text-purple-500" />
-                    <h4 className="font-medium mb-1">Add Documents</h4>
-                    <p className={`text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
-                      PDFs, wireframes, specs
-                    </p>
-                  </button>
-                </div>
-
-                <div className="flex gap-4 pt-8">
-                  <button
-                    onClick={() => setActiveStep(3)}
-                    className={`flex-1 py-3 rounded-xl font-medium border transition-colors ${
-                      isDarkMode
-                        ? 'border-gray-700 hover:bg-gray-800'
-                        : 'border-gray-200 hover:bg-gray-50'
-                    }`}
-                  >
-                    ← Back to Details
-                  </button>
-
-                  <button
-                    onClick={handleProjectSubmit}
-                    className="flex-1 bg-purple-600 text-white py-3 rounded-xl font-medium hover:bg-purple-700 transition-colors"
-                  >
-                    Create Project & Continue →
-                  </button>
-                </div>
-
-                <div className="text-center mt-6">
-                  <button
-                    onClick={handleProjectSubmit}
-                    className={`text-sm underline ${isDarkMode ? 'text-gray-400 hover:text-white' : 'text-gray-600 hover:text-gray-900'}`}
-                  >
-                    Skip file upload for now
-                  </button>
-                </div>
-              </div>
+          <footer className="flex flex-wrap items-center justify-between gap-4">
+            <p className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+              <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+              Data is stored locally in your browser. Export anytime from the dashboard.
+            </p>
+            <div className="flex items-center gap-2">
+              <Button as={Link} to="/dashboard" variant="ghost">
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                leftIcon={<FolderPlus className="h-4 w-4" />}
+                disabled={!canSubmit}
+                loading={isSubmitting}
+              >
+                Save project
+              </Button>
             </div>
-          )}
-        </div>
+          </footer>
+        </form>
       </main>
     </div>
-  );
-};
+  )
+}
 
-export default NewIntakePage;
+export default NewIntakePage

--- a/src/pages/PortfolioEditorPage.tsx
+++ b/src/pages/PortfolioEditorPage.tsx
@@ -1,255 +1,331 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, Loader2, RefreshCw, Save } from 'lucide-react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import GrapesJSEditor from '../components/GrapesJSEditor'
-import type { GrapesEditor } from '../types/grapes'
-import type { PortfolioDocument } from '../utils/portfolioTemplates'
-import { buildPortfolioTemplate, createPortfolioBlocks } from '../utils/portfolioTemplates'
+import {
+  ArrowLeft,
+  ArrowUp,
+  ArrowDown,
+  CheckCircle2,
+  Layers,
+  Loader2,
+  Save,
+} from 'lucide-react'
+import { Button, Input } from '../components/ui'
+import type { ProjectMeta } from '../intake/schema'
+import {
+  buildPortfolioTemplate,
+  createDefaultPortfolioSettings,
+  type PortfolioSettings,
+} from '../utils/portfolioTemplates'
 import { loadPortfolioDocument, savePortfolioDocument } from '../utils/portfolioStorage'
 import { listProjects } from '../utils/storageManager'
-import type { ProjectMeta } from '../intake/schema'
-
-type StatusMessage = { type: 'success' | 'error'; message: string }
-
-type StoredPortfolioDocument = NonNullable<ReturnType<typeof loadPortfolioDocument>>
+import { useApp } from '../contexts/AppContext'
 
 const PortfolioEditorPage: React.FC = () => {
   const navigate = useNavigate()
-  const editorRef = useRef<GrapesEditor | null>(null)
+  const { addNotification } = useApp()
 
   const [projects, setProjects] = useState<ProjectMeta[]>([])
-  const [initialDoc, setInitialDoc] = useState<PortfolioDocument | null>(null)
-  const [templateDoc, setTemplateDoc] = useState<PortfolioDocument | null>(null)
-  const [document, setDocument] = useState<PortfolioDocument | null>(null)
-  const [storedDoc, setStoredDoc] = useState<StoredPortfolioDocument | null>(null)
+  const [settings, setSettings] = useState<PortfolioSettings | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const [isSaving, setIsSaving] = useState(false)
-  const [status, setStatus] = useState<StatusMessage | null>(null)
-
-  const refreshProjects = useCallback(async () => {
-    setIsLoading(true)
-    try {
-      const loaded = await listProjects()
-      setProjects(loaded)
-      const template = buildPortfolioTemplate(loaded)
-      const saved = loadPortfolioDocument()
-      const initial = saved ? { html: saved.html, css: saved.css } : template
-      setTemplateDoc(template)
-      setInitialDoc(initial)
-      setDocument(initial)
-      setStoredDoc(saved ?? null)
-    } catch (error) {
-      console.error('Failed to load projects for portfolio editor', error)
-      setStatus({ type: 'error', message: 'Unable to load projects. Ensure projects are saved locally before editing the portfolio.' })
-    } finally {
-      setIsLoading(false)
-    }
-  }, [])
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [lastSavedAt, setLastSavedAt] = useState<string | null>(null)
 
   useEffect(() => {
-    void refreshProjects()
-  }, [refreshProjects])
+    const load = async () => {
+      setIsLoading(true)
+      try {
+        const loadedProjects = await listProjects()
+        const storedDocument = loadPortfolioDocument()
+        const initialSettings = storedDocument?.settings
+          ? storedDocument.settings
+          : createDefaultPortfolioSettings(loadedProjects)
 
-  useEffect(() => {
-    if (!status) {
-      return
+        const filteredSelection = initialSettings.featuredProjectSlugs.filter(slug =>
+          loadedProjects.some(project => project.slug === slug),
+        )
+        const fallbackProjects = loadedProjects
+          .filter(project => !filteredSelection.includes(project.slug))
+          .slice(0, Math.max(0, 4 - filteredSelection.length))
+        const mergedSelection = [...filteredSelection, ...fallbackProjects.map(project => project.slug)]
+
+        setProjects(loadedProjects)
+        setSettings({ ...initialSettings, featuredProjectSlugs: mergedSelection })
+        setLastSavedAt(storedDocument?.updatedAt ?? null)
+      } catch (error) {
+        console.error('Failed to load portfolio editor', error)
+        setStatusMessage('Unable to load portfolio projects. Create a project first from the dashboard.')
+      } finally {
+        setIsLoading(false)
+      }
     }
-    const timeout = window.setTimeout(() => setStatus(null), 3600)
-    return () => window.clearTimeout(timeout)
-  }, [status])
-
-  const blocks = useMemo(() => createPortfolioBlocks(projects), [projects])
-
-  const editorKey = useMemo(() => {
-    if (!initialDoc) {
-      return 'portfolio-editor'
-    }
-    return `portfolio-editor-${initialDoc.html.length}-${initialDoc.css.length}`
-  }, [initialDoc])
-
-  const handleEditorReady = useCallback((editor: GrapesEditor) => {
-    editorRef.current = editor
+    void load()
   }, [])
 
-  const handleEditorChange = useCallback((doc: PortfolioDocument) => {
-    setDocument(doc)
-  }, [])
+  const selectedProjects = useMemo(() => {
+    if (!settings) {
+      return []
+    }
+    return settings.featuredProjectSlugs
+      .map(slug => projects.find(project => project.slug === slug))
+      .filter((project): project is ProjectMeta => Boolean(project))
+  }, [projects, settings])
 
-  const handleSave = useCallback(() => {
-    if (!document) {
+  const availableProjects = useMemo(() => {
+    const selected = new Set(settings?.featuredProjectSlugs ?? [])
+    return projects.filter(project => !selected.has(project.slug))
+  }, [projects, settings])
+
+  const previewMarkup = useMemo(() => {
+    if (!settings) {
+      return ''
+    }
+    const doc = buildPortfolioTemplate(projects, settings)
+    return `<style>${doc.css}</style>${doc.html}`
+  }, [projects, settings])
+
+  const handleUpdateSetting = <K extends keyof PortfolioSettings>(key: K, value: PortfolioSettings[K]) => {
+    setSettings(previous => (previous ? { ...previous, [key]: value } : previous))
+  }
+
+  const handleToggleProject = (slug: string) => {
+    setSettings(previous => {
+      if (!previous) {
+        return previous
+      }
+      const isSelected = previous.featuredProjectSlugs.includes(slug)
+      const nextSelection = isSelected
+        ? previous.featuredProjectSlugs.filter(entry => entry !== slug)
+        : [...previous.featuredProjectSlugs, slug]
+      return { ...previous, featuredProjectSlugs: nextSelection }
+    })
+  }
+
+  const handleMoveProject = (slug: string, direction: 'up' | 'down') => {
+    setSettings(previous => {
+      if (!previous) {
+        return previous
+      }
+      const index = previous.featuredProjectSlugs.indexOf(slug)
+      if (index === -1) {
+        return previous
+      }
+      const targetIndex = direction === 'up' ? index - 1 : index + 1
+      if (targetIndex < 0 || targetIndex >= previous.featuredProjectSlugs.length) {
+        return previous
+      }
+      const nextSelection = [...previous.featuredProjectSlugs]
+      const [removed] = nextSelection.splice(index, 1)
+      nextSelection.splice(targetIndex, 0, removed)
+      return { ...previous, featuredProjectSlugs: nextSelection }
+    })
+  }
+
+  const handleSave = async () => {
+    if (!settings) {
       return
     }
-    setIsSaving(true)
     try {
+      const document = buildPortfolioTemplate(projects, settings)
       savePortfolioDocument(document)
-      setStoredDoc({ html: document.html, css: document.css, updatedAt: new Date().toISOString() })
-      setStatus({ type: 'success', message: 'Portfolio saved locally.' })
+      setLastSavedAt(new Date().toISOString())
+      setStatusMessage('Portfolio layout saved locally.')
+      addNotification('success', 'Portfolio layout saved locally.')
     } catch (error) {
       console.error('Failed to save portfolio document', error)
-      setStatus({ type: 'error', message: 'Save failed. Ensure your browser allows local storage.' })
-    } finally {
-      setIsSaving(false)
+      setStatusMessage('Unable to save portfolio. Check local storage availability.')
     }
-  }, [document])
+  }
 
-  const handleReset = useCallback(() => {
-    if (!templateDoc) {
-      return
-    }
-    if (editorRef.current) {
-      editorRef.current.setComponents(templateDoc.html)
-      editorRef.current.setStyle(templateDoc.css)
-    }
-    setDocument(templateDoc)
-    setStatus({ type: 'success', message: 'Portfolio reset to the generated template.' })
-  }, [templateDoc])
-
-  const projectStats = useMemo(() => {
-    const total = projects.length
-    const withCaseStudy = projects.filter(project => Boolean(project.caseStudyHtml)).length
-    return { total, withCaseStudy }
-  }, [projects])
-
-  const caseStudyList = useMemo(() => (
-    <ul className="divide-y divide-gray-200 border border-gray-200 rounded-xl">
-      {projects.length === 0 ? (
-        <li className="p-4 text-sm text-gray-500">No local projects found yet. Create a project to start building your portfolio.</li>
-      ) : (
-        projects.map(project => (
-          <li key={project.slug} className="flex flex-col gap-1 p-4">
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-semibold text-gray-800">{project.title}</span>
-              <span className={`text-xs font-medium uppercase tracking-[0.18em] ${
-                project.caseStudyHtml ? 'text-emerald-600' : 'text-orange-600'
-              }`}>
-                {project.caseStudyHtml ? 'Case study ready' : 'Needs narrative'}
-              </span>
-            </div>
-            <p className="text-sm text-gray-500">{project.summary || project.problem || 'Add a summary to this project.'}</p>
-          </li>
-        ))
-      )}
-    </ul>
-  ), [projects])
+  if (isLoading || !settings) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Preparing portfolio editor…
+      </div>
+    )
+  }
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900">
-      <header className="border-b bg-white">
-        <div className="mx-auto max-w-7xl px-6 py-6">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex items-center gap-4">
-              <button
-                type="button"
-                onClick={() => navigate('/dashboard')}
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                Back to dashboard
-              </button>
-              <div>
-                <h1 className="text-xl font-semibold">Portfolio editor</h1>
-                <p className="text-sm text-gray-500">
-                  Arrange case studies into a shareable portfolio layout and publish when ready.
-                </p>
-              </div>
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <Link
-                to="/portfolio"
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
-              >
-                View live portfolio
-              </Link>
-              <button
-                type="button"
-                onClick={handleReset}
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
-                disabled={!templateDoc}
-              >
-                <RefreshCw className="h-4 w-4" />
-                Reset layout
-              </button>
-              <button
-                type="button"
-                onClick={refreshProjects}
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
-              >
-                <RefreshCw className="h-4 w-4" />
-                Refresh projects
-              </button>
-              <button
-                type="button"
-                onClick={handleSave}
-                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-700 disabled:opacity-50"
-                disabled={isSaving || !document}
-              >
-                {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                Save portfolio
-              </button>
+    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <header className="border-b border-gray-200 bg-white/80 backdrop-blur dark:border-gray-800 dark:bg-gray-900/80">
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-3">
+            <Button variant="outline" onClick={() => navigate('/dashboard')} leftIcon={<ArrowLeft className="h-4 w-4" />}>
+              Dashboard
+            </Button>
+            <div>
+              <h1 className="text-xl font-semibold">Portfolio editor</h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400">Curate your case studies into a publish-ready layout.</p>
+              {lastSavedAt && (
+                <p className="text-xs text-gray-500 dark:text-gray-500">Last saved {new Date(lastSavedAt).toLocaleString()}</p>
+              )}
             </div>
           </div>
-          {status && (
-            <div
-              className={`mt-4 rounded-lg border px-4 py-3 text-sm ${
-                status.type === 'error'
-                  ? 'border-red-200 bg-red-50 text-red-600'
-                  : 'border-emerald-200 bg-emerald-50 text-emerald-700'
-              }`}
-            >
-              {status.message}
-            </div>
-          )}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button as={Link} to="/portfolio" variant="ghost" leftIcon={<Layers className="h-4 w-4" />}>
+              View generated portfolio
+            </Button>
+            <Button variant="primary" leftIcon={<Save className="h-4 w-4" />} onClick={handleSave}>
+              Save layout
+            </Button>
+          </div>
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl px-6 py-6 lg:py-10">
-        {isLoading || !initialDoc ? (
-          <div className="flex h-[70vh] items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white">
-            <div className="flex items-center gap-2 text-sm text-gray-500">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Loading portfolio editor…
-            </div>
-          </div>
-        ) : (
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
-            <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-              <GrapesJSEditor
-                key={editorKey}
-                initialHtml={initialDoc.html}
-                initialCss={initialDoc.css}
-                blocks={blocks}
-                onChange={handleEditorChange}
-                onEditorReady={handleEditorReady}
-                height="calc(100vh - 240px)"
-              />
-            </section>
-            <aside className="flex flex-col gap-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-              <div className="space-y-2">
-                <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Portfolio health</h2>
-                <div className="grid grid-cols-2 gap-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.2em] text-gray-500">Projects</p>
-                    <p className="text-xl font-semibold text-gray-800">{projectStats.total}</p>
-                  </div>
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.2em] text-gray-500">Case studies ready</p>
-                    <p className="text-xl font-semibold text-gray-800">{projectStats.withCaseStudy}</p>
-                  </div>
-                </div>
-                {storedDoc && (
-                  <p className="text-xs text-gray-500">
-                    Last saved {new Date(storedDoc.updatedAt).toLocaleString()}
-                  </p>
-                )}
-              </div>
+      <main className="mx-auto grid max-w-6xl gap-8 px-6 py-8 lg:grid-cols-[1.05fr_0.95fr]">
+        <section className="space-y-6">
+          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Hero and framing</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Set the voice for the top of your portfolio.</p>
 
-              <div className="space-y-3">
-                <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Case studies</h3>
-                {caseStudyList}
-              </div>
-            </aside>
-          </div>
-        )}
+            <div className="mt-6 space-y-4">
+              <Input
+                label="Portfolio title"
+                value={settings.title}
+                onChange={event => handleUpdateSetting('title', event.target.value)}
+                fullWidth
+              />
+              <Input
+                label="Subtitle"
+                value={settings.subtitle}
+                onChange={event => handleUpdateSetting('subtitle', event.target.value)}
+                fullWidth
+              />
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Introduction
+                <textarea
+                  value={settings.introduction}
+                  onChange={event => handleUpdateSetting('introduction', event.target.value)}
+                  rows={4}
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                />
+              </label>
+              <Input
+                label="Section heading"
+                value={settings.highlightHeading ?? ''}
+                onChange={event => handleUpdateSetting('highlightHeading', event.target.value)}
+                placeholder="Selected projects"
+                fullWidth
+              />
+              <Input
+                label="Contact email"
+                value={settings.contactEmail ?? ''}
+                onChange={event => handleUpdateSetting('contactEmail', event.target.value)}
+                placeholder="you@example.com"
+                fullWidth
+              />
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Call to action
+                <textarea
+                  value={settings.callToAction ?? ''}
+                  onChange={event => handleUpdateSetting('callToAction', event.target.value)}
+                  rows={2}
+                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  placeholder="Let’s collaborate on the next launch."
+                />
+              </label>
+            </div>
+          </article>
+
+          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Selected case studies</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Reorder to control how projects appear.</p>
+
+            {selectedProjects.length === 0 ? (
+              <p className="mt-6 text-sm text-gray-500 dark:text-gray-500">Pick a few projects from the list to build your showcase.</p>
+            ) : (
+              <ul className="mt-4 space-y-3">
+                {selectedProjects.map(project => (
+                  <li
+                    key={project.slug}
+                    className="flex items-center justify-between gap-3 rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800/70"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">{project.title}</p>
+                      <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {project.summary || project.solution || project.problem || 'Add a summary in the case study editor.'}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        leftIcon={<ArrowUp className="h-4 w-4" />}
+                        onClick={() => handleMoveProject(project.slug, 'up')}
+                      >
+                        Up
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        leftIcon={<ArrowDown className="h-4 w-4" />}
+                        onClick={() => handleMoveProject(project.slug, 'down')}
+                      >
+                        Down
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleToggleProject(project.slug)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+
+          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Available projects</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              Tap any project to add it to the featured list. Already selected projects stay highlighted above.
+            </p>
+
+            {availableProjects.length === 0 ? (
+              <p className="mt-6 text-sm text-gray-500 dark:text-gray-500">All projects are already featured.</p>
+            ) : (
+              <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+                {availableProjects.map(project => (
+                  <li key={project.slug}>
+                    <button
+                      type="button"
+                      onClick={() => handleToggleProject(project.slug)}
+                      className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-3 text-left text-sm shadow-sm transition hover:border-indigo-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100"
+                    >
+                      <p className="font-medium">{project.title}</p>
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        {project.summary || project.solution || 'Craft the case study to add more context.'}
+                      </p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+        </section>
+
+        <aside className="space-y-6">
+          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
+            <h2 className="text-lg font-semibold">Live preview</h2>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Refresh to regenerate the layout from your current settings.</p>
+            <div className="mt-4 overflow-hidden rounded-2xl border border-gray-200 bg-slate-900/80 p-4 shadow-inner dark:border-gray-700">
+              <div
+                className="max-h-[520px] overflow-y-auto rounded-xl bg-black/50 text-sm"
+                dangerouslySetInnerHTML={{ __html: previewMarkup }}
+              />
+            </div>
+          </section>
+
+          {statusMessage && (
+            <section className="rounded-3xl border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-900 shadow-sm dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-100">
+              <p className="flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4" />
+                {statusMessage}
+              </p>
+            </section>
+          )}
+        </aside>
       </main>
     </div>
   )

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -22,7 +22,10 @@ const PortfolioPage: React.FC = () => {
         const loadedProjects = await listProjects()
         setProjects(loadedProjects)
         const saved = loadPortfolioDocument()
-        if (saved) {
+        if (saved?.settings) {
+          const regenerated = buildPortfolioTemplate(loadedProjects, saved.settings)
+          setDocument({ html: regenerated.html, css: regenerated.css })
+        } else if (saved) {
           setDocument({ html: saved.html, css: saved.css })
         } else {
           const generated = buildPortfolioTemplate(loadedProjects)

--- a/src/utils/aiNarrative.ts
+++ b/src/utils/aiNarrative.ts
@@ -1,0 +1,131 @@
+import type { CaseStudyContent, ProjectMeta } from '../intake/schema'
+import { loadOpenAICredentials } from './openAICredentials'
+
+const MODEL = 'gpt-4o-mini'
+
+type RawCompletion = {
+  choices?: Array<{
+    message?: {
+      content?: string | null
+    }
+  }>
+}
+
+const stripJsonFence = (value: string): string => {
+  const trimmed = value.trim()
+  if (trimmed.startsWith('```')) {
+    const withoutFence = trimmed.replace(/^```(?:json)?/i, '').replace(/```$/i, '')
+    return withoutFence.trim()
+  }
+  return trimmed
+}
+
+const ensureArray = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean)
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(/\r?\n|•|-/)
+      .map(item => item.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+const coerceContent = (input: Partial<CaseStudyContent>, fallback: CaseStudyContent): CaseStudyContent => ({
+  overview: typeof input.overview === 'string' && input.overview.trim() ? input.overview.trim() : fallback.overview,
+  challenge: typeof input.challenge === 'string' && input.challenge.trim() ? input.challenge.trim() : fallback.challenge,
+  approach: ensureArray(input.approach) || fallback.approach,
+  results: ensureArray(input.results) || fallback.results,
+  learnings: typeof input.learnings === 'string' && input.learnings.trim() ? input.learnings.trim() : fallback.learnings,
+  callToAction:
+    typeof input.callToAction === 'string' && input.callToAction.trim()
+      ? input.callToAction.trim()
+      : fallback.callToAction,
+})
+
+export const generateCaseStudyNarrative = async (
+  project: ProjectMeta,
+  current: CaseStudyContent,
+): Promise<CaseStudyContent> => {
+  const credentials = loadOpenAICredentials()
+  if (!credentials) {
+    throw new Error('OpenAI API key not configured. Add it from the settings screen.')
+  }
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${credentials.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      temperature: 0.7,
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You create concise portfolio-ready case studies. Respond with polished yet direct language. Keep bullets short and impactful.',
+        },
+        {
+          role: 'user',
+          content: `Project title: ${project.title}\n` +
+            `Summary: ${project.summary ?? ''}\n` +
+            `Problem: ${project.problem}\n` +
+            `Solution: ${project.solution}\n` +
+            `Outcomes: ${project.outcomes}\n` +
+            `Tags: ${(project.tags ?? []).join(', ')}\n` +
+            `Current overview: ${current.overview}\n` +
+            `Current challenge: ${current.challenge}\n` +
+            `Current approach points: ${current.approach.join(' | ')}\n` +
+            `Current results points: ${current.results.join(' | ')}\n` +
+            `Current learnings: ${current.learnings}\n` +
+            `Current call to action: ${current.callToAction ?? ''}\n` +
+            'Respond in JSON with the keys overview, challenge, approach, results, learnings, callToAction. Keep overview under 90 words.',
+        },
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'case_study',
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              overview: { type: 'string' },
+              challenge: { type: 'string' },
+              approach: { type: 'array', items: { type: 'string' } },
+              results: { type: 'array', items: { type: 'string' } },
+              learnings: { type: 'string' },
+              callToAction: { type: 'string' },
+            },
+            required: ['overview', 'challenge', 'approach', 'results', 'learnings'],
+          },
+        },
+      },
+    }),
+  })
+
+  if (!response.ok) {
+    const detail = await response.text()
+    throw new Error(`Failed to generate narrative: ${detail || response.statusText}`)
+  }
+
+  const payload = (await response.json()) as RawCompletion
+  const message = payload.choices?.[0]?.message?.content
+  if (!message) {
+    throw new Error('The AI response was empty. Try again.')
+  }
+
+  try {
+    const parsed = JSON.parse(stripJsonFence(message)) as Partial<CaseStudyContent>
+    return coerceContent(parsed, current)
+  } catch (error) {
+    console.error('Failed to parse AI narrative response', error, message)
+    throw new Error('Unable to understand the AI response. Please try again.')
+  }
+}

--- a/src/utils/portfolioStorage.ts
+++ b/src/utils/portfolioStorage.ts
@@ -1,4 +1,4 @@
-import type { PortfolioDocument } from './portfolioTemplates'
+import type { PortfolioDocument, PortfolioSettings } from './portfolioTemplates'
 
 const STORAGE_KEY = 'portfolio-forge-document'
 
@@ -23,6 +23,7 @@ export const loadPortfolioDocument = (): StoredPortfolioDocument | null => {
       html: parsed.html,
       css: parsed.css,
       updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
+      settings: isValidSettings(parsed.settings) ? parsed.settings : undefined,
     }
   } catch (error) {
     console.warn('Failed to parse stored portfolio document', error)
@@ -38,8 +39,23 @@ export const savePortfolioDocument = (document: PortfolioDocument): void => {
     html: document.html,
     css: document.css,
     updatedAt: new Date().toISOString(),
+    settings: document.settings,
   }
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+}
+
+const isValidSettings = (value: unknown): value is PortfolioSettings => {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const candidate = value as PortfolioSettings
+  if (typeof candidate.title !== 'string' || typeof candidate.subtitle !== 'string' || typeof candidate.introduction !== 'string') {
+    return false
+  }
+  if (!Array.isArray(candidate.featuredProjectSlugs)) {
+    return false
+  }
+  return true
 }
 
 export const clearPortfolioDocument = (): void => {

--- a/src/utils/portfolioTemplates.ts
+++ b/src/utils/portfolioTemplates.ts
@@ -1,9 +1,19 @@
-import type { ProjectMeta } from '../intake/schema'
-import type { GrapesBlockDefinition } from '../types/grapes'
+import type { CaseStudyContent, ProjectMeta } from '../intake/schema'
+
+export type PortfolioSettings = {
+  title: string
+  subtitle: string
+  introduction: string
+  featuredProjectSlugs: string[]
+  highlightHeading?: string
+  contactEmail?: string
+  callToAction?: string
+}
 
 export type PortfolioDocument = {
   html: string
   css: string
+  settings?: PortfolioSettings
 }
 
 const escapeHtml = (value: string): string =>
@@ -14,392 +24,271 @@ const escapeHtml = (value: string): string =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;')
 
-const truncate = (value: string, length: number): string => {
-  if (value.length <= length) {
-    return value
+const listToHtml = (items: string[], className: string): string => {
+  if (!items || items.length === 0) {
+    return ''
   }
-  return `${value.slice(0, length - 1)}…`
-}
-
-const summarizeProject = (project: ProjectMeta): string => {
-  const summary = project.summary || project.solution || project.problem
-  if (!summary) {
-    return 'Add a short summary that introduces this case study to prospective clients.'
-  }
-  return summary
-}
-
-const buildTagGroup = (tags: string[]): string =>
-  tags
-    .slice(0, 4)
-    .map(tag => `<span class="portfolio-tag">${escapeHtml(tag)}</span>`)
+  const list = items
+    .map(item => `<li>${escapeHtml(item)}</li>`)
     .join('')
+  return `<ul class="${className}">${list}</ul>`
+}
 
-const baseCss = `
+const resolveCaseStudyContent = (project: ProjectMeta): CaseStudyContent | null => {
+  if (project.caseStudyContent) {
+    return project.caseStudyContent
+  }
+  return null
+}
+
+const BASE_CSS = `
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
-  --portfolio-bg: radial-gradient(circle at top left, rgba(76, 29, 149, 0.16), rgba(17, 24, 39, 1));
-  --portfolio-surface: rgba(15, 23, 42, 0.85);
-  --portfolio-border: rgba(148, 163, 184, 0.24);
-  --portfolio-primary: #6366f1;
-  --portfolio-primary-soft: rgba(99, 102, 241, 0.16);
-  --portfolio-text: #e2e8f0;
-  --portfolio-muted: #94a3b8;
 }
 
 body {
   margin: 0;
-  min-height: 100vh;
-  background: var(--portfolio-bg);
-  color: var(--portfolio-text);
-  font-family: inherit;
+  background: radial-gradient(circle at top left, #0f172a, #020617);
+  color: #e2e8f0;
 }
 
 .portfolio {
-  max-width: 1200px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 72px 24px 120px;
+  padding: 80px 24px 120px;
   display: grid;
   gap: 64px;
 }
 
-.portfolio-hero {
-  position: relative;
-  overflow: hidden;
-  padding: 64px;
-  border-radius: 40px;
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.22), rgba(14, 116, 144, 0.18));
-  border: 1px solid rgba(99, 102, 241, 0.28);
-  box-shadow: 0 30px 80px -40px rgba(15, 23, 42, 0.8);
+.portfolio__hero {
+  display: grid;
+  gap: 24px;
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 32px;
+  padding: 56px;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  box-shadow: 0 40px 80px -60px rgba(15, 23, 42, 0.9);
 }
 
-.portfolio-hero__eyebrow {
-  font-size: 0.75rem;
-  letter-spacing: 0.18em;
+.portfolio__eyebrow {
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.82);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  color: rgba(148, 163, 184, 0.85);
 }
 
-.portfolio-hero__title {
-  margin: 12px 0 16px;
-  font-size: clamp(2.4rem, 5vw, 3.6rem);
+.portfolio__title {
+  margin: 0;
+  font-size: clamp(2.6rem, 5vw, 3.6rem);
   font-weight: 700;
-  line-height: 1.08;
 }
 
-.portfolio-hero__description {
-  max-width: 640px;
-  font-size: 1.125rem;
-  color: rgba(241, 245, 249, 0.86);
+.portfolio__subtitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: rgba(199, 210, 254, 0.88);
 }
 
-.portfolio-hero__actions {
-  margin-top: 32px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+.portfolio__introduction {
+  margin: 0;
+  font-size: 1.05rem;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.7;
+  max-width: 720px;
 }
 
-.portfolio-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 22px;
-  border-radius: 999px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  cursor: pointer;
-  border: none;
-}
-
-.portfolio-button--primary {
-  background: rgba(255, 255, 255, 0.18);
-  color: white;
-  box-shadow: 0 20px 60px -40px rgba(59, 130, 246, 0.8);
-}
-
-.portfolio-button--secondary {
-  background: rgba(15, 23, 42, 0.6);
-  color: var(--portfolio-primary);
-  border: 1px solid rgba(99, 102, 241, 0.32);
-}
-
-.portfolio-grid {
+.portfolio__projects {
   display: grid;
   gap: 32px;
 }
 
-.portfolio-grid__cards {
+.portfolio__heading {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(180, 198, 255, 0.9);
+}
+
+.portfolio__grid {
   display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .portfolio-card {
-  position: relative;
-  padding: 28px;
-  border-radius: 28px;
-  background: var(--portfolio-surface);
-  border: 1px solid var(--portfolio-border);
-  box-shadow: 0 16px 60px -40px rgba(15, 23, 42, 0.65);
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 24px;
+  padding: 32px;
   display: grid;
   gap: 18px;
+  border: 1px solid rgba(71, 85, 105, 0.4);
+  box-shadow: 0 24px 60px -48px rgba(2, 6, 23, 0.85);
 }
 
 .portfolio-card__title {
+  margin: 0;
   font-size: 1.2rem;
   font-weight: 600;
 }
 
 .portfolio-card__summary {
-  color: var(--portfolio-muted);
-  font-size: 0.95rem;
-  line-height: 1.5;
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.6;
 }
 
-.portfolio-tag-group {
+.portfolio-card__tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
 }
 
-.portfolio-tag {
+.portfolio-card__tags li {
   padding: 6px 12px;
   border-radius: 999px;
-  background: rgba(99, 102, 241, 0.14);
-  color: rgba(226, 232, 240, 0.92);
+  background: rgba(99, 102, 241, 0.16);
+  color: rgba(199, 210, 254, 0.92);
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.portfolio-showcase {
-  display: grid;
-  gap: 32px;
-}
-
-.portfolio-case-study {
-  padding: 40px;
-  border-radius: 32px;
-  background: rgba(15, 23, 42, 0.72);
-  border: 1px solid rgba(99, 102, 241, 0.18);
-  backdrop-filter: blur(8px);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 24px 80px -50px rgba(15, 23, 42, 0.9);
-}
-
-.portfolio-case-study__header {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 24px;
-}
-
-.portfolio-case-study__title {
-  font-size: 1.6rem;
-  font-weight: 600;
-}
-
-.portfolio-case-study__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.portfolio-case-study__body {
-  border-radius: 24px;
-  overflow: hidden;
-  border: 1px solid rgba(99, 102, 241, 0.12);
-  background: rgba(15, 23, 42, 0.55);
-}
-
-.portfolio-case-study__body > * {
+.portfolio-card__list {
   margin: 0;
+  padding-left: 18px;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.55;
 }
 
-@media (max-width: 960px) {
-  .portfolio-hero {
-    padding: 48px 32px;
-  }
-  .portfolio-case-study {
-    padding: 32px;
-  }
+.portfolio__contact {
+  display: grid;
+  gap: 12px;
+  background: rgba(37, 99, 235, 0.16);
+  border-radius: 24px;
+  padding: 32px;
+  border: 1px solid rgba(59, 130, 246, 0.32);
+}
+
+.portfolio__contact h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(191, 219, 254, 0.92);
+}
+
+.portfolio__contact p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.portfolio__cta {
+  font-weight: 600;
+  color: rgba(191, 219, 254, 0.94);
 }
 `
 
-const createSvg = (path: string) =>
-  `<?xml version="1.0" encoding="UTF-8"?>\n<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="${path}" fill="currentColor"/></svg>`
+const buildProjectCard = (project: ProjectMeta): string => {
+  const content = resolveCaseStudyContent(project)
+  const summary = content?.overview || project.summary || project.solution || project.problem
+  const approach = content ? listToHtml(content.approach, 'portfolio-card__list') : ''
+  const results = content ? listToHtml(content.results, 'portfolio-card__list') : ''
+  const learnings = content?.learnings
+    ? `<p class="portfolio-card__summary"><strong>Learnings:</strong> ${escapeHtml(content.learnings)}</p>`
+    : ''
 
-export const buildPortfolioTemplate = (projects: ProjectMeta[]): PortfolioDocument => {
-  const cards = projects.map(project => {
-    const summary = truncate(summarizeProject(project), 160)
-    const tags = buildTagGroup(project.tags ?? [])
-    return `
-      <article class="portfolio-card" data-project="${escapeHtml(project.slug)}">
-        <h3 class="portfolio-card__title">${escapeHtml(project.title)}</h3>
-        <p class="portfolio-card__summary">${escapeHtml(summary)}</p>
-        <div class="portfolio-tag-group">${tags}</div>
-      </article>
-    `
-  })
+  return `
+<div class="portfolio-card">
+  <div>
+    <h3 class="portfolio-card__title">${escapeHtml(project.title)}</h3>
+    ${summary ? `<p class="portfolio-card__summary">${escapeHtml(summary)}</p>` : ''}
+  </div>
+  ${project.tags && project.tags.length > 0
+    ? `<ul class="portfolio-card__tags">${project.tags
+        .slice(0, 6)
+        .map(tag => `<li>${escapeHtml(tag)}</li>`)
+        .join('')}</ul>`
+    : ''}
+  ${approach ? `<div><strong>Approach</strong>${approach}</div>` : ''}
+  ${results ? `<div><strong>Impact</strong>${results}</div>` : ''}
+  ${learnings}
+</div>`
+}
 
-  const caseStudies = projects.map(project => {
-    const tags = buildTagGroup(project.tags ?? [])
-    const caseContent = project.caseStudyHtml ?? '<p>Add your case study narrative using the project editor.</p>'
-    return `
-      <article class="portfolio-case-study" data-project="${escapeHtml(project.slug)}">
-        <div class="portfolio-case-study__header">
-          <div>
-            <h3 class="portfolio-case-study__title">${escapeHtml(project.title)}</h3>
-            <div class="portfolio-tag-group">${tags}</div>
-          </div>
-        </div>
-        <div class="portfolio-case-study__body">
-          ${caseContent}
-        </div>
-      </article>
-    `
-  })
+export const createDefaultPortfolioSettings = (projects: ProjectMeta[]): PortfolioSettings => ({
+  title: 'Portfolio showcase',
+  subtitle: projects.length > 0 ? `Selected work featuring ${projects[0].title}` : 'Selected work',
+  introduction:
+    'A curated snapshot of projects that balance craft, measurable outcomes, and collaborative momentum.',
+  featuredProjectSlugs: projects.slice(0, 4).map(project => project.slug),
+  highlightHeading: 'Selected projects',
+  contactEmail: '',
+  callToAction: 'Let’s collaborate on the next build.',
+})
+
+export const buildPortfolioTemplate = (
+  projects: ProjectMeta[],
+  settings?: PortfolioSettings,
+): PortfolioDocument => {
+  const resolvedSettings = settings ?? createDefaultPortfolioSettings(projects)
+  const featuredProjects = resolvedSettings.featuredProjectSlugs
+    .map(slug => projects.find(project => project.slug === slug))
+    .filter((project): project is ProjectMeta => Boolean(project))
+
+  const fallbackProjects = projects
+    .filter(project => !resolvedSettings.featuredProjectSlugs.includes(project.slug))
+    .slice(0, Math.max(0, 4 - featuredProjects.length))
+
+  const allProjects = featuredProjects.length > 0 ? featuredProjects : fallbackProjects
+
+  const projectsMarkup =
+    allProjects.length === 0
+      ? '<p class="portfolio-card__summary">Add projects to your portfolio to populate this section.</p>'
+      : allProjects.map(buildProjectCard).join('')
+
+  const heroSubtitle = resolvedSettings.subtitle
+    ? `<p class="portfolio__subtitle">${escapeHtml(resolvedSettings.subtitle)}</p>`
+    : ''
+  const highlightHeading = resolvedSettings.highlightHeading
+    ? `<h2 class="portfolio__heading">${escapeHtml(resolvedSettings.highlightHeading)}</h2>`
+    : ''
+  const contactBlock =
+    resolvedSettings.contactEmail || resolvedSettings.callToAction
+      ? `<section class="portfolio__contact">
+          <h3>Available for new collaborations</h3>
+          ${resolvedSettings.callToAction ? `<p class="portfolio__cta">${escapeHtml(resolvedSettings.callToAction)}</p>` : ''}
+          ${resolvedSettings.contactEmail ? `<p>${escapeHtml(resolvedSettings.contactEmail)}</p>` : ''}
+        </section>`
+      : ''
 
   const html = `
-    <main class="portfolio">
-      <section class="portfolio-hero">
-        <span class="portfolio-hero__eyebrow">Portfolio</span>
-        <h1 class="portfolio-hero__title">Selected work & case studies</h1>
-        <p class="portfolio-hero__description">
-          A collection of collaborative product design and development projects, each grounded in outcomes and measurable impact.
-        </p>
-        <div class="portfolio-hero__actions">
-          <button class="portfolio-button portfolio-button--primary">Book a working session</button>
-          <button class="portfolio-button portfolio-button--secondary">Download resume</button>
-        </div>
-      </section>
+<main class="portfolio">
+  <header class="portfolio__hero">
+    <span class="portfolio__eyebrow">Portfolio</span>
+    <h1 class="portfolio__title">${escapeHtml(resolvedSettings.title)}</h1>
+    ${heroSubtitle}
+    <p class="portfolio__introduction">${escapeHtml(resolvedSettings.introduction)}</p>
+  </header>
 
-      <section class="portfolio-grid">
-        <div>
-          <h2>Highlights</h2>
-          <p class="portfolio-card__summary">Explore a curated mix of engagements spanning research, product design, and engineering.</p>
-        </div>
-        <div class="portfolio-grid__cards">
-          ${cards.join('')}
-        </div>
-      </section>
+  <section class="portfolio__projects">
+    ${highlightHeading}
+    <div class="portfolio__grid">
+      ${projectsMarkup}
+    </div>
+  </section>
 
-      <section class="portfolio-showcase">
-        <div>
-          <h2>Case studies</h2>
-          <p class="portfolio-card__summary">Deep dives into the process, strategy, and impact behind the selected projects.</p>
-        </div>
-        <div class="portfolio-showcase__list">
-          ${caseStudies.join('')}
-        </div>
-      </section>
-    </main>
-  `
-
-  const cssFragments = [baseCss, ...projects.map(project => project.caseStudyCss ?? '').filter(Boolean)]
+  ${contactBlock}
+</main>
+`
 
   return {
     html,
-    css: cssFragments.join('\n\n'),
+    css: BASE_CSS,
+    settings: resolvedSettings,
   }
-}
-
-export const createPortfolioBlocks = (projects: ProjectMeta[]): GrapesBlockDefinition[] => {
-  const blocks: GrapesBlockDefinition[] = [
-    {
-      id: 'portfolio-hero',
-      label: 'Portfolio hero',
-      category: 'Structure',
-      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Z'),
-      content: `
-        <section class="portfolio-hero">
-          <span class="portfolio-hero__eyebrow">Portfolio</span>
-          <h1 class="portfolio-hero__title">Headline for your body of work</h1>
-          <p class="portfolio-hero__description">Describe your focus areas, strengths, and the value you bring to product teams.</p>
-          <div class="portfolio-hero__actions">
-            <button class="portfolio-button portfolio-button--primary">Book a conversation</button>
-            <button class="portfolio-button portfolio-button--secondary">Download resume</button>
-          </div>
-        </section>
-      `,
-    },
-    {
-      id: 'portfolio-highlights',
-      label: 'Highlights grid',
-      category: 'Structure',
-      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Zm8 0h2v2h-2V5Zm0 4h2v2h-2V9Zm0 4h2v2h-2v-2Z'),
-      content: `
-        <section class="portfolio-grid">
-          <div>
-            <h2>Highlights</h2>
-            <p class="portfolio-card__summary">Pair a short narrative with the types of projects you love shipping.</p>
-          </div>
-          <div class="portfolio-grid__cards">
-            <article class="portfolio-card">
-              <h3 class="portfolio-card__title">Project title</h3>
-              <p class="portfolio-card__summary">Add a sentence about the outcome and your role.</p>
-              <div class="portfolio-tag-group">
-                <span class="portfolio-tag">UX Strategy</span>
-                <span class="portfolio-tag">Design Systems</span>
-              </div>
-            </article>
-            <article class="portfolio-card">
-              <h3 class="portfolio-card__title">Project title</h3>
-              <p class="portfolio-card__summary">Highlight measurable impact or shipped features.</p>
-              <div class="portfolio-tag-group">
-                <span class="portfolio-tag">Product Design</span>
-                <span class="portfolio-tag">Leadership</span>
-              </div>
-            </article>
-          </div>
-        </section>
-      `,
-    },
-    {
-      id: 'portfolio-cta',
-      label: 'Contact banner',
-      category: 'Structure',
-      media: createSvg('M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2Zm2 6h4v2H6v-2Zm0 4h8v2H6v-2Zm10-8h2v2h-2V6Z'),
-      content: `
-        <section class="portfolio-hero">
-          <span class="portfolio-hero__eyebrow">Let’s collaborate</span>
-          <h2 class="portfolio-hero__title">Tell readers how to reach you</h2>
-          <p class="portfolio-hero__description">Share availability, preferred contact channels, or upcoming talks and workshops.</p>
-          <div class="portfolio-hero__actions">
-            <button class="portfolio-button portfolio-button--primary">Start a project</button>
-            <button class="portfolio-button portfolio-button--secondary">Download case studies</button>
-          </div>
-        </section>
-      `,
-    },
-  ]
-
-  projects.forEach(project => {
-    const tags = buildTagGroup(project.tags ?? [])
-    const caseContent = project.caseStudyHtml ?? '<p>Add the case study narrative from the project editor.</p>'
-    blocks.push({
-      id: `portfolio-case-${project.slug}`,
-      label: `Case study: ${project.title}`,
-      category: 'Case studies',
-      media: createSvg('M4 5a3 3 0 0 1 3-3h10a3 3 0 0 1 3 3v14a1 1 0 0 1-1.555.832L15 17l-3.445 2.832A1 1 0 0 1 10 19V5H7a3 3 0 0 0-3 3v11a1 1 0 0 1-2 0V5Zm5 0v14l3-2.4 3 2.4V5H9Zm2 4h4v2h-4V9Zm0 4h4v2h-4v-2Z'),
-      content: `
-        <article class="portfolio-case-study" data-project="${escapeHtml(project.slug)}">
-          <div class="portfolio-case-study__header">
-            <div>
-              <h3 class="portfolio-case-study__title">${escapeHtml(project.title)}</h3>
-              <div class="portfolio-tag-group">${tags}</div>
-            </div>
-          </div>
-          <div class="portfolio-case-study__body">
-            ${caseContent}
-          </div>
-        </article>
-      `,
-    })
-  })
-
-  return blocks
 }

--- a/src/utils/simpleCaseStudy.ts
+++ b/src/utils/simpleCaseStudy.ts
@@ -1,0 +1,231 @@
+import type { CaseStudyContent, ProjectAsset, ProjectMeta } from '../intake/schema'
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
+const toSentence = (value?: string | null): string => {
+  if (!value) {
+    return ''
+  }
+  return value.trim()
+}
+
+const normaliseList = (values?: string[] | null): string[] => {
+  if (!values || values.length === 0) {
+    return []
+  }
+  return values
+    .map(item => item.trim())
+    .filter(item => item.length > 0)
+}
+
+const DEFAULT_CSS = `
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, #0f172a, #020617);
+  color: #e2e8f0;
+  font-family: inherit;
+}
+
+.case-study {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 72px 20px 120px;
+  display: grid;
+  gap: 56px;
+}
+
+.case-study__card {
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: 24px;
+  padding: 40px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 40px 80px -60px rgba(2, 6, 23, 0.9);
+  backdrop-filter: blur(12px);
+}
+
+.case-study__header {
+  display: grid;
+  gap: 20px;
+}
+
+.case-study__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.case-study__title {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  font-weight: 700;
+  margin: 0;
+  line-height: 1.08;
+}
+
+.case-study__summary {
+  font-size: 1.125rem;
+  color: rgba(226, 232, 240, 0.82);
+  line-height: 1.6;
+}
+
+.case-study__grid {
+  display: grid;
+  gap: 32px;
+}
+
+.case-study__section {
+  display: grid;
+  gap: 16px;
+}
+
+.case-study__section h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #cbd5f5;
+}
+
+.case-study__body {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.82);
+  line-height: 1.65;
+}
+
+.case-study__list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 10px;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.case-study__cta {
+  border-radius: 18px;
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  padding: 28px;
+  display: grid;
+  gap: 12px;
+  background: rgba(67, 56, 202, 0.16);
+}
+
+.case-study__cta-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(199, 210, 254, 0.92);
+}
+
+.case-study__cta p {
+  margin: 0;
+  color: rgba(224, 231, 255, 0.88);
+}
+`
+
+const renderList = (items: string[]): string => {
+  if (items.length === 0) {
+    return ''
+  }
+  const listItems = items
+    .map(item => `<li>${escapeHtml(item)}</li>`)
+    .join('')
+  return `<ul class="case-study__list">${listItems}</ul>`
+}
+
+const selectHeroAsset = (assets: ProjectAsset[]): string | null => {
+  const heroAsset = assets.find(asset => asset.isHeroImage)
+  if (heroAsset?.dataUrl) {
+    return heroAsset.dataUrl
+  }
+  const firstImage = assets.find(asset => asset.mimeType.startsWith('image/') && asset.dataUrl)
+  return firstImage?.dataUrl ?? null
+}
+
+export const buildCaseStudyDocument = (
+  project: ProjectMeta,
+  content: CaseStudyContent,
+): { html: string; css: string } => {
+  const summary = toSentence(content.overview || project.summary || project.solution)
+  const heroImage = selectHeroAsset(project.assets)
+  const heroMarkup = heroImage
+    ? `<figure style="margin:0;border-radius:20px;overflow:hidden;background:rgba(15,23,42,0.6);border:1px solid rgba(148,163,184,0.18);">
+        <img src="${heroImage}" alt="${escapeHtml(project.title)} hero" style="width:100%;display:block;object-fit:cover;max-height:420px;">
+      </figure>`
+    : ''
+
+  const html = `
+<article class="case-study">
+  <header class="case-study__card case-study__header">
+    <span class="case-study__eyebrow">Case Study</span>
+    <h1 class="case-study__title">${escapeHtml(project.title)}</h1>
+    ${summary ? `<p class="case-study__summary">${escapeHtml(summary)}</p>` : ''}
+    ${heroMarkup}
+    ${project.tags && project.tags.length > 0
+      ? `<div style="display:flex;flex-wrap:wrap;gap:8px;">${project.tags
+          .slice(0, 6)
+          .map(tag => `<span style="padding:6px 12px;border-radius:999px;background:rgba(99,102,241,0.16);color:#c7d2fe;font-size:0.75rem;letter-spacing:0.08em;text-transform:uppercase;">${escapeHtml(tag)}</span>`)
+          .join('')}</div>`
+      : ''}
+  </header>
+
+  <section class="case-study__card case-study__grid">
+    <div class="case-study__section">
+      <h3>The challenge</h3>
+      ${content.challenge ? `<p class="case-study__body">${escapeHtml(content.challenge)}</p>` : '<p class="case-study__body">Describe the problem you set out to solve.</p>'}
+    </div>
+    <div class="case-study__section">
+      <h3>Approach</h3>
+      ${renderList(normaliseList(content.approach)) || '<p class="case-study__body">Outline the steps you took and how you collaborated.</p>'}
+    </div>
+    <div class="case-study__section">
+      <h3>Results</h3>
+      ${renderList(normaliseList(content.results)) || '<p class="case-study__body">Share measurable impact and qualitative wins.</p>'}
+    </div>
+    <div class="case-study__section">
+      <h3>What I learned</h3>
+      ${content.learnings ? `<p class="case-study__body">${escapeHtml(content.learnings)}</p>` : '<p class="case-study__body">Capture the insights and lessons that will inform your next project.</p>'}
+    </div>
+  </section>
+
+  ${content.callToAction
+    ? `<section class="case-study__card case-study__cta">
+        <h3 class="case-study__cta-title">Next steps</h3>
+        <p>${escapeHtml(content.callToAction)}</p>
+      </section>`
+    : ''}
+</article>
+`
+
+  return {
+    html,
+    css: DEFAULT_CSS,
+  }
+}
+
+export const buildDefaultCaseStudyContent = (project: ProjectMeta): CaseStudyContent => {
+  const approach = project.solution
+    ? project.solution.split(/\r?\n|•|-/).map(part => part.trim()).filter(Boolean)
+    : []
+  const results = project.outcomes
+    ? project.outcomes.split(/\r?\n|•|-/).map(part => part.trim()).filter(Boolean)
+    : []
+
+  return {
+    overview: project.summary ?? '',
+    challenge: project.problem ?? '',
+    approach,
+    results,
+    learnings: '',
+    callToAction: undefined,
+  }
+}


### PR DESCRIPTION
## Summary
- replace the dashboard UI with a local-storage first control centre that supports import/export, storage stats, and compatibility helpers
- rebuild the intake flow to capture project metadata, manage uploads, and seed structured case study content
- introduce a lightweight case study editor with AI narrative generation, live preview, and asset management alongside a settings-driven portfolio builder

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce360c64c0832f8fe767514eda6bba