### PR TITLE
Implement project intake workflow and normalize metadata links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,12 @@ Projects live in versioned folders under `projects/`:
 ```
 projects/
   2025_Acme_Redesign/
-    brief.md          # Narrative following Problem → Actions → Results
-    metadata.json     # Machine-readable fields for generation pipelines
-    cover.jpg         # Optional hero asset
-    assets/           # Reference images, decks, research docs, etc.
-    deliverables/     # Final exports shipped to the client/stakeholders
+    01_Narrative.md    # PCSI draft (Problem, Challenge, Solution, Impact)
+    02_Metadata.json   # Structured fields for downstream automation
+    03_Assets/         # Uploaded research, screenshots, decks, etc.
+    06_Exports/        # Processed deliverables and the required cover.jpg
+    metadata.json      # Legacy copy kept for backwards compatibility
+    brief.md           # Legacy narrative kept in sync with 01_Narrative.md
 ```
 
 Use the helper script to bootstrap new entries:

--- a/intake.schema.json
+++ b/intake.schema.json
@@ -63,6 +63,13 @@
           "minLength": 10,
           "examples": ["Users were abandoning checkout at a 67% rate due to complex multi-step process and poor mobile experience..."]
         },
+        "challenge": {
+          "type": "string",
+          "title": "Context & Constraints",
+          "description": "What made the problem difficult? Consider constraints, stakeholders, or timeline.",
+          "minLength": 5,
+          "examples": ["Aggressive two-week timeline with limited engineering support and strict compliance requirements."]
+        },
         "solution": {
           "type": "string",
           "title": "Solution Created",
@@ -70,7 +77,7 @@
           "minLength": 10,
           "examples": ["Redesigned checkout flow with single-page layout, mobile-first approach, and one-click payment options..."]
         },
-        "outcomes": {
+        "impact": {
           "type": "string",
           "title": "Outcomes & Impact",
           "description": "Measurable results, learnings, or long-term impact",
@@ -78,7 +85,7 @@
           "examples": ["Reduced cart abandonment to 23%, increased mobile conversions by 145%, generated additional $50K monthly revenue..."]
         }
       },
-      "required": ["problem", "solution", "outcomes"],
+      "required": ["problem", "challenge", "solution", "impact"],
       "additionalProperties": false
     },
     "projectDetails": {
@@ -278,8 +285,9 @@
       },
       "narrativeHooks": {
         "problem": "Mobile checkout abandonment was at 67% due to a complex 4-step process that wasn't optimized for small screens. Users struggled with form validation, payment selection, and address entry.",
+        "challenge": "Aggressive timeline with only two engineers available and strict compliance requirements for payments.",
         "solution": "Redesigned the entire checkout flow as a single-page experience with progressive disclosure, smart form validation, auto-complete features, and one-click payment options integrated with Apple Pay and Google Pay.",
-        "outcomes": "Reduced mobile cart abandonment from 67% to 23%, increased mobile conversion rate by 78%, and generated an additional $85K in monthly revenue. The design became the template for the company's other properties."
+        "impact": "Reduced mobile cart abandonment from 67% to 23%, increased mobile conversion rate by 78%, and generated an additional $85K in monthly revenue. The design became the template for the company's other properties."
       },
       "projectDetails": {
         "role": "designer",

--- a/scripts/new_project.py
+++ b/scripts/new_project.py
@@ -48,11 +48,8 @@ def main():
         raise SystemExit(f"Folder already exists: {proj}")
 
     # structure
-    ensure(proj / "assets/images")
-    ensure(proj / "assets/video")
-    ensure(proj / "assets/docs")
-    ensure(proj / "assets/other")
-    ensure(proj / "deliverables")
+    ensure(proj / "03_Assets")
+    ensure(proj / "06_Exports")
 
     # metadata
     categories = [s.strip() for s in args.categories.split(",") if s.strip()]
@@ -62,7 +59,7 @@ def main():
     highlights = [s.strip() for s in args.highlights.split(",") if s.strip()]
 
     metadata = {
-        "schema_version": "2.0.0",
+        "schema_version": "3.0.0",
         "title": args.title,
         "organization": args.organization,
         "work_type": args.work_type,
@@ -74,29 +71,57 @@ def main():
         "tools": tools,
         "tags": tags,
         "highlights": highlights,
-        "links": { "live": args.link_live, "repo": args.link_repo, "video": args.link_video },
+        "links": {
+            "live": args.link_live,
+            "repo": args.link_repo,
+            "video": args.link_video,
+        },
         "privacy": { "nda": bool(args.nda) },
-        "case": { "problem": "", "actions": "", "results": "" },
-        "cover_image": "",
-        "created_at": datetime.utcnow().isoformat() + "Z"
+        "pcsi": { "problem": "", "challenge": "", "solution": "", "impact": "" },
+        "case": { "problem": "", "challenge": "", "actions": "", "results": "" },
+        "cover_image": "06_Exports/cover.jpg",
+        "assets": [],
+        "created_at": datetime.utcnow().isoformat() + "Z",
+        "updated_at": datetime.utcnow().isoformat() + "Z",
     }
-    write(proj / "metadata.json", json.dumps(metadata, indent=2))
+    write(proj / "02_Metadata.json", json.dumps(metadata, indent=2) + "\n")
+    write(proj / "metadata.json", json.dumps(metadata, indent=2) + "\n")
 
-    # brief.md
-    brief = [
+    # narrative
+    snapshot = []
+    if args.organization:
+        snapshot.append(f"- **Organization:** {args.organization}")
+    if args.role:
+        snapshot.append(f"- **Role:** {args.role} ({args.seniority})")
+    if categories:
+        snapshot.append(f"- **Categories:** {', '.join(categories)}")
+    if tools:
+        snapshot.append(f"- **Tools:** {', '.join(tools)}")
+
+    narrative = [
         f"# {args.title}",
         "",
-        f"**Organization:** {args.organization}  " if args.organization else "",
-        f"**Year:** {year}  ",
-        f"**Role:** {args.role} ({args.seniority})  " if args.role else "",
-        f"**Categories:** {', '.join(categories)}" if categories else "",
+        "## Problem",
+        "<What was broken or missing?>",
         "",
-        "## Problem", "*—*","",
-        "## Actions", "*—*","",
-        "## Results", "*—*","",
-        ("## Highlights\n- " + "\n- ".join(highlights)) if highlights else ""
+        "## Challenge",
+        "<Context or constraints you faced>",
+        "",
+        "## Solution",
+        "<What did you build or change?>",
+        "",
+        "## Impact",
+        "<How did things improve? Add data if possible.>",
     ]
-    write(proj / "brief.md", "\n".join([line for line in brief if line != ""]))
+
+    if snapshot:
+        narrative.extend(["", "### Project Snapshot", *snapshot])
+
+    if highlights:
+        narrative.extend(["", "### Highlights", *[f"- {item}" for item in highlights]])
+
+    write(proj / "01_Narrative.md", "\n".join(narrative) + "\n")
+    write(proj / "brief.md", "\n".join(narrative) + "\n")
 
     print(f"✅ Created {proj}")
 

--- a/server/src/routes/intake.ts
+++ b/server/src/routes/intake.ts
@@ -1,0 +1,74 @@
+import express from 'express'
+import type { Express } from 'express'
+import type multer from 'multer'
+import { requireAuth, type AuthenticatedRequest } from '../middleware/auth'
+import ProjectIntakeService, { type IntakeSubmission } from '../services/projectIntakeService'
+
+interface AppLocals {
+  projectIntakeService?: ProjectIntakeService
+}
+
+const routerFactory = (upload: multer.Multer) => {
+  const router = express.Router()
+  const intakeUpload = upload.fields([
+    { name: 'cover', maxCount: 1 },
+    { name: 'assets', maxCount: 20 },
+  ])
+
+  router.post('/projects', requireAuth, intakeUpload, async (req: AuthenticatedRequest, res) => {
+    try {
+      const { projectIntakeService } = req.app.locals as AppLocals
+      if (!projectIntakeService) {
+        res.status(500).json({ error: 'Project intake service not initialised' })
+        return
+      }
+
+      const rawPayload = req.body?.payload
+      if (!rawPayload || typeof rawPayload !== 'string') {
+        res.status(400).json({ error: 'Missing intake payload' })
+        return
+      }
+
+      let submission: IntakeSubmission
+      try {
+        submission = JSON.parse(rawPayload) as IntakeSubmission
+      } catch (error) {
+        console.error('Failed to parse intake payload', error)
+        res.status(400).json({ error: 'Invalid intake payload JSON' })
+        return
+      }
+
+      const files = req.files
+      let cover: Express.Multer.File | undefined
+      let assets: Express.Multer.File[] | undefined
+
+      if (Array.isArray(files)) {
+        assets = files
+      } else if (files && typeof files === 'object') {
+        const typed = files as Record<string, Express.Multer.File[]>
+        cover = typed.cover?.[0]
+        assets = typed.assets ?? []
+      } else if (req.file) {
+        cover = req.file
+      }
+
+      const result = await projectIntakeService.createProject(submission, {
+        cover,
+        assets,
+      })
+
+      res.status(201).json({ project: result })
+    } catch (error) {
+      console.error('Failed to process intake submission', error)
+      if (error instanceof Error) {
+        res.status(400).json({ error: error.message })
+        return
+      }
+      res.status(500).json({ error: 'Unknown error processing intake submission' })
+    }
+  })
+
+  return router
+}
+
+export default routerFactory

--- a/server/src/services/projectIntakeService.ts
+++ b/server/src/services/projectIntakeService.ts
@@ -1,0 +1,339 @@
+import fs from 'fs/promises'
+import path from 'path'
+import sharp from 'sharp'
+import type { Express } from 'express'
+import { slugify } from './projectSyncService'
+import ProjectSyncService from './projectSyncService'
+import type { SyncProjectResult } from '../types/projectSync'
+
+export type IntakeCollaborator = {
+  name: string
+  role?: string
+  company?: string
+}
+
+export type IntakeMetric = {
+  label: string
+  value: string
+}
+
+export type IntakeLink = {
+  type?: string
+  label?: string
+  url: string
+}
+
+export type IntakeTimeframe = {
+  start?: string
+  end?: string
+  duration?: string
+  notes?: string
+}
+
+export type IntakeSubmission = {
+  title: string
+  summary?: string
+  problem: string
+  challenge?: string
+  solution: string
+  impact: string
+  tags?: string[]
+  tools?: string[]
+  technologies?: string[]
+  role?: string
+  status?: string
+  collaborators?: IntakeCollaborator[]
+  timeframe?: IntakeTimeframe
+  metrics?: IntakeMetric[]
+  highlights?: string[]
+  links?: IntakeLink[]
+  autoGenerateNarrative?: boolean
+  nda?: boolean
+}
+
+type IntakeFilePayload = {
+  cover?: Express.Multer.File
+  assets?: Express.Multer.File[]
+}
+
+export type IntakeCreationResult = {
+  folder: string
+  slug: string
+  metadataPath: string
+  narrativePath: string
+  coverImage?: string
+  metadata: Record<string, unknown>
+  sync?: SyncProjectResult
+}
+
+type ProjectIntakeServiceOptions = {
+  projectRoot: string
+  syncService: ProjectSyncService
+}
+
+const ASSETS_DIR = '03_Assets'
+const EXPORTS_DIR = '06_Exports'
+const NARRATIVE_FILE = '01_Narrative.md'
+const STRUCTURED_METADATA_FILE = '02_Metadata.json'
+const LEGACY_METADATA_FILE = 'metadata.json'
+
+const ensureDirectory = async (directoryPath: string) => {
+  await fs.mkdir(directoryPath, { recursive: true })
+}
+
+const sanitiseFilename = (filename: string): { base: string; extension: string } => {
+  const extension = path.extname(filename).toLowerCase()
+  const base = path
+    .basename(filename, extension)
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '') || 'asset'
+  return { base, extension }
+}
+
+const createUniqueFilename = async (directory: string, original: string): Promise<string> => {
+  const { base, extension } = sanitiseFilename(original)
+  let attempt = 0
+  while (attempt < 1000) {
+    const suffix = attempt === 0 ? '' : `-${attempt}`
+    const candidate = `${base}${suffix}${extension}`
+    try {
+      await fs.access(path.join(directory, candidate))
+    } catch {
+      return candidate
+    }
+    attempt += 1
+  }
+  const fallback = `${base}-${Date.now()}${extension}`
+  return fallback
+}
+
+const determineYear = (submission: IntakeSubmission): string => {
+  const candidates = [
+    submission.timeframe?.start,
+    submission.timeframe?.end,
+    submission.timeframe?.duration,
+  ]
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    const match = candidate.match(/(19|20)\d{2}/)
+    if (match) {
+      return match[0]
+    }
+  }
+  return String(new Date().getFullYear())
+}
+
+const inferAssetKind = (file: Express.Multer.File): string => {
+  if (!file.mimetype) {
+    return 'asset'
+  }
+  if (file.mimetype.startsWith('image/')) return 'image'
+  if (file.mimetype.startsWith('video/')) return 'video'
+  if (file.mimetype.startsWith('audio/')) return 'audio'
+  if (file.mimetype === 'application/pdf') return 'document'
+  if (file.mimetype.startsWith('application/')) return 'document'
+  return 'asset'
+}
+
+const buildNarrative = (submission: IntakeSubmission, metadata: Record<string, unknown>): string => {
+  const lines: string[] = []
+  lines.push(`# ${submission.title.trim()}`)
+  if (submission.summary?.trim()) {
+    lines.push('', submission.summary.trim())
+  }
+  lines.push('', '## Problem', submission.problem.trim())
+  if (submission.challenge?.trim()) {
+    lines.push('', '## Challenge', submission.challenge.trim())
+  }
+  lines.push('', '## Solution', submission.solution.trim())
+  lines.push('', '## Impact', submission.impact.trim())
+
+  const snapshot: string[] = []
+  if (submission.role) snapshot.push(`- **Role:** ${submission.role}`)
+  if (submission.status) snapshot.push(`- **Status:** ${submission.status}`)
+  if (submission.timeframe?.duration || submission.timeframe?.start || submission.timeframe?.end) {
+    const parts: string[] = []
+    if (submission.timeframe?.start) parts.push(`Start: ${submission.timeframe.start}`)
+    if (submission.timeframe?.end) parts.push(`End: ${submission.timeframe.end}`)
+    if (submission.timeframe?.duration) parts.push(`Duration: ${submission.timeframe.duration}`)
+    snapshot.push(`- **Timeframe:** ${parts.join(' · ')}`)
+  }
+  if (submission.tools?.length) snapshot.push(`- **Tools:** ${submission.tools.join(', ')}`)
+  if (submission.collaborators?.length) {
+    const collaboratorNames = submission.collaborators.map(entry => entry.role ? `${entry.name} (${entry.role})` : entry.name)
+    snapshot.push(`- **Collaborators:** ${collaboratorNames.join(', ')}`)
+  }
+  if (snapshot.length > 0) {
+    lines.push('', '### Project Snapshot', ...snapshot)
+  }
+
+  const metrics = submission.metrics?.filter(entry => entry.label && entry.value)
+  if (metrics && metrics.length > 0) {
+    lines.push('', '### Outcomes & Metrics')
+    metrics.forEach(metric => {
+      lines.push(`- **${metric.label.trim()}** — ${metric.value.trim()}`)
+    })
+  }
+
+  if (submission.links?.length) {
+    lines.push('', '### Links & References')
+    submission.links.forEach(link => {
+      if (!link.url) return
+      const label = link.label || link.type || 'Link'
+      lines.push(`- [${label}](${link.url})`)
+    })
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+export default class ProjectIntakeService {
+  private readonly projectRoot: string
+  private readonly syncService: ProjectSyncService
+
+  constructor(options: ProjectIntakeServiceOptions) {
+    this.projectRoot = options.projectRoot
+    this.syncService = options.syncService
+  }
+
+  async createProject(submission: IntakeSubmission, files: IntakeFilePayload): Promise<IntakeCreationResult> {
+    const title = submission.title?.trim()
+    if (!title) {
+      throw new Error('Project title is required')
+    }
+
+    if (!submission.problem?.trim() || !submission.solution?.trim() || !submission.impact?.trim()) {
+      throw new Error('Problem, solution, and impact fields are required')
+    }
+
+    const slug = slugify(title)
+    const year = determineYear(submission)
+    const baseFolder = `${year}_${slug}`
+
+    let folder = baseFolder
+    let attempt = 1
+    while (attempt < 50) {
+      const candidatePath = path.join(this.projectRoot, folder)
+      try {
+        await fs.access(candidatePath)
+        folder = `${baseFolder}-${attempt}`
+        attempt += 1
+      } catch {
+        break
+      }
+    }
+
+    const projectPath = path.join(this.projectRoot, folder)
+    await ensureDirectory(projectPath)
+
+    const assetsDir = path.join(projectPath, ASSETS_DIR)
+    const exportsDir = path.join(projectPath, EXPORTS_DIR)
+
+    await Promise.all([
+      ensureDirectory(assetsDir),
+      ensureDirectory(exportsDir),
+    ])
+
+    const createdAt = new Date().toISOString()
+    const assets: Array<{ label: string; relative_path: string; type: string }> = []
+
+    let coverImage: string | undefined
+    const coverFile = files.cover
+    if (coverFile) {
+      const coverPath = path.join(exportsDir, 'cover.jpg')
+      const coverBuffer = await sharp(coverFile.buffer)
+        .rotate()
+        .jpeg({ quality: 88 })
+        .toBuffer()
+      await fs.writeFile(coverPath, coverBuffer)
+      coverImage = path.join(EXPORTS_DIR, 'cover.jpg')
+      assets.push({
+        label: 'Cover Image',
+        relative_path: coverImage,
+        type: 'image',
+      })
+    }
+
+    if (files.assets && files.assets.length > 0) {
+      for (const asset of files.assets) {
+        const filename = await createUniqueFilename(assetsDir, asset.originalname || asset.fieldname)
+        const targetPath = path.join(assetsDir, filename)
+        await fs.writeFile(targetPath, asset.buffer)
+        assets.push({
+          label: asset.originalname || filename,
+          relative_path: path.join(ASSETS_DIR, filename),
+          type: inferAssetKind(asset),
+        })
+      }
+    }
+
+    const metadata = {
+      schema_version: '3.0.0',
+      title,
+      summary: submission.summary ?? '',
+      slug,
+      tags: submission.tags ?? [],
+      tools: submission.tools ?? submission.technologies ?? [],
+      technologies: submission.technologies ?? submission.tools ?? [],
+      role: submission.role ?? '',
+      status: submission.status ?? 'draft',
+      collaborators: submission.collaborators ?? [],
+      timeframe: submission.timeframe ?? {},
+      metrics: submission.metrics ?? [],
+      highlights: submission.highlights ?? [],
+      links: submission.links ?? [],
+      nda: submission.nda ?? false,
+      auto_generate_narrative: submission.autoGenerateNarrative ?? false,
+      pcsi: {
+        problem: submission.problem.trim(),
+        challenge: submission.challenge?.trim() ?? '',
+        solution: submission.solution.trim(),
+        impact: submission.impact.trim(),
+      },
+      case: {
+        problem: submission.problem.trim(),
+        challenge: submission.challenge?.trim() ?? '',
+        actions: submission.solution.trim(),
+        results: submission.impact.trim(),
+      },
+      cover_image: coverImage ?? '',
+      assets,
+      created_at: createdAt,
+      updated_at: createdAt,
+    }
+
+    const metadataPath = path.join(projectPath, STRUCTURED_METADATA_FILE)
+    const legacyMetadataPath = path.join(projectPath, LEGACY_METADATA_FILE)
+    await Promise.all([
+      fs.writeFile(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf-8'),
+      fs.writeFile(legacyMetadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf-8'),
+    ])
+
+    const narrative = buildNarrative(submission, metadata)
+    const narrativePath = path.join(projectPath, NARRATIVE_FILE)
+    const legacyBriefPath = path.join(projectPath, 'brief.md')
+    await Promise.all([
+      fs.writeFile(narrativePath, narrative, 'utf-8'),
+      fs.writeFile(legacyBriefPath, narrative, 'utf-8'),
+    ])
+
+    let sync: SyncProjectResult | undefined
+    try {
+      sync = await this.syncService.syncProject(folder)
+    } catch (error) {
+      console.warn(`Failed to sync new project ${folder}:`, error)
+    }
+
+    return {
+      folder,
+      slug,
+      metadataPath,
+      narrativePath,
+      coverImage,
+      metadata,
+      sync,
+    }
+  }
+}

--- a/server/src/types/projectSync.ts
+++ b/server/src/types/projectSync.ts
@@ -1,5 +1,11 @@
 import { Project, ProjectAsset, ProjectDeliverable } from '@prisma/client';
 
+export type ParsedMetadataLink = {
+  type?: string;
+  label?: string;
+  url: string;
+};
+
 export type ParsedMetadata = {
   schemaVersion?: string;
   title: string;
@@ -14,13 +20,20 @@ export type ParsedMetadata = {
   tools: string[];
   tags: string[];
   highlights: string[];
-  links?: Record<string, unknown> | null;
+  links: ParsedMetadataLink[];
   nda?: boolean;
   coverImage?: string | null;
   case?: {
     problem?: string | null;
+    challenge?: string | null;
     actions?: string | null;
     results?: string | null;
+  } | null;
+  pcsi?: {
+    problem?: string | null;
+    challenge?: string | null;
+    solution?: string | null;
+    impact?: string | null;
   } | null;
 };
 

--- a/src/intake/IntakeForm.css
+++ b/src/intake/IntakeForm.css
@@ -193,6 +193,66 @@
   display: none;
 }
 
+.upload-flow__assets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.upload-flow__assets h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.upload-flow__assets-hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4b5563;
+}
+
+.upload-flow__asset-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.upload-flow__asset-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.upload-flow__asset-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #1f2937;
+}
+
+.upload-flow__asset-meta svg {
+  color: #7c3aed;
+}
+
+.upload-flow__asset-meta strong {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.upload-flow__asset-sub {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
 .upload-flow__error {
   margin-top: 1rem;
   padding: 0.75rem 1rem;

--- a/src/intake/schema.ts
+++ b/src/intake/schema.ts
@@ -122,6 +122,7 @@ export type ProjectMeta = {
   
   // Narrative Hooks (the three key questions)
   problem: string // What was the problem you identified?
+  challenge?: string // Context or constraints captured during intake
   solution: string // What solution did you create?
   outcomes: string // What were the outcomes/impact?
   
@@ -192,6 +193,7 @@ export const newProject = (title: string): ProjectMeta => ({
   title,
   slug: title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g,''),
   problem: "",
+  challenge: "",
   solution: "",
   outcomes: "",
   tags: [],

--- a/src/utils/fileStore.ts
+++ b/src/utils/fileStore.ts
@@ -113,6 +113,7 @@ const readStore = (): Store => {
       slug,
       summary: typeof meta.summary === 'string' ? meta.summary : undefined,
       problem: typeof meta.problem === 'string' ? meta.problem : '',
+      challenge: typeof meta.challenge === 'string' ? meta.challenge : '',
       solution: typeof meta.solution === 'string' ? meta.solution : '',
       outcomes: typeof meta.outcomes === 'string' ? meta.outcomes : '',
       tags,
@@ -200,6 +201,7 @@ export function saveProject(meta: ProjectMeta) {
     createdAt: meta.createdAt,
     updatedAt: timestamp,
     tags: Array.isArray(meta.tags) ? meta.tags : [],
+    challenge: typeof meta.challenge === 'string' ? meta.challenge : undefined,
     technologies: Array.isArray(meta.technologies)
       ? meta.technologies.filter(Boolean)
       : undefined,

--- a/templates/brief.md
+++ b/templates/brief.md
@@ -8,11 +8,14 @@
 ## Problem
 <What was broken or missing?>
 
-## Actions
-<What did you do? Focus on your contribution.>
+## Challenge
+<Context or constraints that made this tricky>
 
-## Results
-<Impact in plain language. Add numbers if you have them.>
+## Solution
+<What you delivered. Emphasise your contribution.>
+
+## Impact
+<Outcomes and measurable results.>
 
 ## Highlights
 - <One-liner impact>

--- a/templates/metadata.json
+++ b/templates/metadata.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "2.0.0",
+  "schema_version": "3.0.0",
   "title": "<Project Title>",
   "organization": "<Org>",
   "work_type": "Employment|Freelance|Personal",
@@ -34,11 +34,31 @@
   "privacy": {
     "nda": false
   },
-  "case": {
-    "problem": "<...>",
-    "actions": "<...>",
-    "results": "<...>"
+  "pcsi": {
+    "problem": "<What problem were you solving?>",
+    "challenge": "<Context, constraints, or blockers>",
+    "solution": "<What you delivered>",
+    "impact": "<Outcomes and measurable results>"
   },
-  "cover_image": "cover.jpg",
-  "created_at": "<auto>"
+  "case": {
+    "problem": "",
+    "challenge": "",
+    "actions": "",
+    "results": ""
+  },
+  "timeframe": {
+    "start": "<Jan 2025>",
+    "end": "<Mar 2025>",
+    "duration": "<12 weeks>"
+  },
+  "collaborators": [
+    { "name": "Jane Doe", "role": "Research" }
+  ],
+  "metrics": [
+    { "label": "Conversion", "value": "+32%" }
+  ],
+  "cover_image": "06_Exports/cover.jpg",
+  "assets": [],
+  "created_at": "<auto>",
+  "updated_at": "<auto>"
 }

--- a/tests/projectIntakeService.test.ts
+++ b/tests/projectIntakeService.test.ts
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, it } from 'node:test'
+import type { Express } from 'express'
+import ProjectIntakeService, { type IntakeSubmission } from '../server/src/services/projectIntakeService'
+import type ProjectSyncService from '../server/src/services/projectSyncService'
+import type { SyncProjectResult } from '../server/src/types/projectSync'
+
+const pngPixel = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X9WMAAAAASUVORK5CYII=',
+  'base64',
+)
+
+const createUpload = (overrides: Partial<Express.Multer.File> = {}): Express.Multer.File => ({
+  fieldname: 'file',
+  originalname: 'upload.png',
+  encoding: '7bit',
+  mimetype: 'image/png',
+  size: pngPixel.length,
+  destination: '',
+  filename: 'upload.png',
+  path: '',
+  buffer: pngPixel,
+  stream: null as unknown as NodeJS.ReadableStream,
+  ...overrides,
+})
+
+describe('ProjectIntakeService', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop()!
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+    }
+  })
+
+  it('creates structured folders, metadata, and narrative files', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'intake-service-'))
+    tempDirs.push(projectRoot)
+
+    const fakeSyncResult = { folder: 'fake', created: false, warnings: [], conflicts: [], metadataPath: '', briefPath: null } as unknown as SyncProjectResult
+    const fakeSyncService = {
+      syncProject: async () => fakeSyncResult,
+    } as unknown as ProjectSyncService
+
+    const service = new ProjectIntakeService({ projectRoot, syncService: fakeSyncService })
+
+    const submission: IntakeSubmission = {
+      title: 'Launch Campaign',
+      summary: 'Relaunched the mobile experience with measurable impact.',
+      problem: 'Retention dropped after a redesign.',
+      challenge: 'Aggressive timeline and limited engineering support.',
+      solution: 'Introduced a progressive rollout with cross-functional task force.',
+      impact: 'Lifted retention by 18% and boosted NPS by 22 points.',
+      tags: ['mobile', 'growth'],
+      tools: ['Figma', 'Amplitude'],
+      role: 'designer',
+      status: 'draft',
+      collaborators: [{ name: 'Sam Lopez', role: 'PM' }],
+      timeframe: { start: 'Jan 2024', end: 'Mar 2024', duration: '12 weeks' },
+      metrics: [{ label: 'Retention', value: '+18%' }],
+      highlights: ['Retention: +18%', 'NPS: +22'],
+      links: [{ type: 'other', url: 'https://example.com' }],
+      autoGenerateNarrative: true,
+    }
+
+    const result = await service.createProject(submission, {
+      cover: createUpload({ fieldname: 'cover', originalname: 'hero.png' }),
+      assets: [
+        createUpload({ originalname: 'dashboard.png' }),
+        createUpload({ originalname: 'research.pdf', mimetype: 'application/pdf' }),
+      ],
+    })
+
+    const projectPath = path.join(projectRoot, result.folder)
+    const narrative = await fs.readFile(path.join(projectPath, '01_Narrative.md'), 'utf8')
+    const metadata = JSON.parse(await fs.readFile(result.metadataPath, 'utf8')) as Record<string, unknown>
+
+    assert.ok(narrative.includes('## Challenge'), 'narrative includes challenge section')
+    assert.ok(narrative.includes('## Impact'), 'narrative includes impact section')
+    assert.equal(metadata.pcsi && (metadata.pcsi as Record<string, unknown>).challenge, submission.challenge)
+    assert.equal(metadata.cover_image, '06_Exports/cover.jpg')
+    assert.equal(Array.isArray(metadata.assets) && (metadata.assets as unknown[]).length, 3)
+
+    const exportsCover = await fs.stat(path.join(projectPath, '06_Exports/cover.jpg'))
+    assert.ok(exportsCover.isFile(), 'cover image exists in exports folder')
+
+    assert.equal(result.coverImage, '06_Exports/cover.jpg')
+    assert.equal(result.sync, fakeSyncResult)
+  })
+})

--- a/tests/projectsTree.test.ts
+++ b/tests/projectsTree.test.ts
@@ -13,19 +13,37 @@ describe('projects/ directory health', () => {
         continue;
       }
 
-      const metadataPath = path.join(projectsRoot, entry.name, 'metadata.json');
-      const briefPath = path.join(projectsRoot, entry.name, 'brief.md');
+      const metadataCandidates = ['02_Metadata.json', 'metadata.json'];
+      const briefCandidates = ['01_Narrative.md', 'brief.md'];
 
-      try {
-        await fs.access(metadataPath);
-      } catch {
-        assert.fail(`Missing metadata.json in projects/${entry.name}`);
+      const hasMetadata = await Promise.all(
+        metadataCandidates.map(async file => {
+          try {
+            await fs.access(path.join(projectsRoot, entry.name, file));
+            return true;
+          } catch {
+            return false;
+          }
+        }),
+      ).then(results => results.some(Boolean));
+
+      const hasNarrative = await Promise.all(
+        briefCandidates.map(async file => {
+          try {
+            await fs.access(path.join(projectsRoot, entry.name, file));
+            return true;
+          } catch {
+            return false;
+          }
+        }),
+      ).then(results => results.some(Boolean));
+
+      if (!hasMetadata) {
+        assert.fail(`Missing metadata file (metadata.json or 02_Metadata.json) in projects/${entry.name}`);
       }
 
-      try {
-        await fs.access(briefPath);
-      } catch {
-        assert.fail(`Missing brief.md in projects/${entry.name}`);
+      if (!hasNarrative) {
+        assert.fail(`Missing narrative file (brief.md or 01_Narrative.md) in projects/${entry.name}`);
       }
     }
   });

--- a/tests/storageManager.test.ts
+++ b/tests/storageManager.test.ts
@@ -13,6 +13,7 @@ const createProject = (overrides: Partial<ProjectMeta> = {}): ProjectMeta => ({
   slug: 'test-project',
   summary: 'Summary',
   problem: 'Problem',
+  challenge: 'Challenge',
   solution: 'Solution',
   outcomes: 'Outcomes',
   tags: ['test'],


### PR DESCRIPTION
## Summary
- add a project intake service and API route that scaffold folders, metadata, narratives, and assets for new submissions
- expand the intake form UI and schema to collect PCSI fields, timeframe details, and multiple uploads while posting to the new API
- refresh project templates/tests and normalize metadata link handling to the new array format to keep Prisma data in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce3a66b648832fbec1529811317b5b