### PR TITLE
Align server Prisma schema with project sync fields

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -6,116 +6,141 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = "file:./dev.db"
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model Project {
-  id          String   @id @default(cuid())
-  name        String
-  title       String?
-  slug        String?
-  description String?
-  summary     String?
-  workType    String?
-  category    String?
-  organization String?
-  year        Int?
-  tags        String?
-  highlights  String?
-  syncStatus  String?
-  lastSyncedAt DateTime?
-  fsLastModified DateTime?
+  id                String   @id @default(cuid())
+  userId            String?
+  slug              String   @unique
+  folder            String   @unique
+  title             String
+  summary           String?
+  description       String?
+  organization      String?
+  workType          String?
+  year              Int?
+  role              String?
+  seniority         String?
+  categories        String[] @default([])
+  skills            String[] @default([])
+  tools             String[] @default([])
+  tags              String[] @default([])
+  highlights        String[] @default([])
+  links             Json?
+  nda               Boolean?
+  coverImage        String?
+  caseProblem       String?
+  caseActions       String?
+  caseResults       String?
+  schemaVersion     String?
+  metadataChecksum  String?
+  briefChecksum     String?
   metadataUpdatedAt DateTime?
-  briefUpdatedAt DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  userId      String
+  briefUpdatedAt    DateTime?
+  fsLastModified    DateTime?
+  lastSyncedAt      DateTime?
+  syncStatus        String   @default("clean")
+  syncWarnings      Json?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
-  files     ProjectFile[]
-  analyses  ProjectAnalysis[]
-  assets    ProjectAsset[]
+  assets       ProjectAsset[]
   deliverables ProjectDeliverable[]
+  files        ProjectFile[]
+  analysis     ProjectAnalysis?
 
   @@map("projects")
 }
 
 model ProjectAsset {
-  id        String   @id @default(cuid())
-  projectId String
-  name      String
-  path      String
-  type      String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id             String   @id @default(cuid())
+  projectId      String
+  relativePath   String
+  label          String?
+  type           String
+  size           Int?
+  checksum       String?
+  lastModifiedAt DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
+  @@unique([projectId, relativePath])
   @@map("project_assets")
 }
 
 model ProjectDeliverable {
-  id        String   @id @default(cuid())
-  projectId String
-  name      String
-  description String?
-  path      String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id             String   @id @default(cuid())
+  projectId      String
+  relativePath   String
+  label          String?
+  format         String?
+  size           Int?
+  checksum       String?
+  lastModifiedAt DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
+  @@unique([projectId, relativePath])
   @@map("project_deliverables")
 }
 
 model ProjectFile {
-  id        String   @id @default(cuid())
-  projectId String
-  name      String
-  filename  String
-  filepath  String
-  url       String?
-  mimeType  String
-  size      Int
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id           String   @id @default(cuid())
+  projectId    String
+  name         String
+  filename     String
+  originalName String
+  mimeType     String
+  size         Int
+  url          String
+  thumbnailUrl String?
+  description  String?
+  tags         String[] @default([])
+  featured     Boolean  @default(false)
+  order        Int      @default(0)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  project   Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  analysis  FileAnalysis?
+  project  Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  analysis FileAnalysis?
 
   @@map("project_files")
 }
 
 model ProjectAnalysis {
-  id          String   @id @default(cuid())
-  projectId   String   @unique
-  status      String   // 'pending', 'processing', 'completed', 'failed'
-  result      String?  // JSON string
-  error       String?
-  confidence  Float?
-  processingTime Float?
-  filesAnalyzed Int?
-  insightsFound Int?
-  primaryProblem String?
-  problemConfidence Float?
-  problemEvidence String?
-  problemAlternatives String?
-  primarySolution String?
-  solutionConfidence Float?
-  solutionElements String?
-  designPatterns String?
-  primaryImpact String?
-  impactConfidence Float?
-  metrics String?
-  businessValue String?
-  story String?
-  challenges String?
-  process String?
-  suggestedTitle String?
-  suggestedCategory String?
-  suggestedTags String?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id                  String   @id @default(cuid())
+  projectId           String   @unique
+  status              String   @default("pending") // pending, analyzing, completed, failed
+  confidence          Float?
+  processingTime      Float?
+  filesAnalyzed       Int      @default(0)
+  insightsFound       Int      @default(0)
+  primaryProblem      String?
+  problemConfidence   Float?
+  problemEvidence     Json?
+  problemAlternatives Json?
+  primarySolution     String?
+  solutionConfidence  Float?
+  solutionElements    Json?
+  designPatterns      String[] @default([])
+  primaryImpact       String?
+  impactConfidence    Float?
+  metrics             Json?
+  businessValue       String?
+  story               String?
+  challenges          String[] @default([])
+  process             String[] @default([])
+  suggestedTitle      String?
+  suggestedCategory   String?
+  suggestedTags       String[] @default([])
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
@@ -123,18 +148,16 @@ model ProjectAnalysis {
 }
 
 model FileAnalysis {
-  id       String  @id @default(cuid())
-  fileId   String  @unique
-  status   String  // 'pending', 'processing', 'completed', 'failed'
-  result   String? // JSON string
-  error    String?
-  insights String?
-  extractedText String?
-  metadata String?
-  contentType String?
+  id             String   @id @default(cuid())
+  fileId         String   @unique
+  status         String   @default("pending")
+  contentType    String?
+  insights       Json?
+  extractedText  String?
+  metadata       Json?
   processingTime Float?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   file ProjectFile @relation(fields: [fileId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## Summary
- switch the server Prisma datasource to PostgreSQL so the backend can store JSON and array fields required by the sync service
- expand the Project, ProjectAsset, ProjectDeliverable, ProjectFile, ProjectAnalysis, and FileAnalysis models to include folder slugs, structured arrays, and JSON columns used throughout the project sync logic

## Testing
- npx prisma generate
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce9e21c6f8832f997409c4f38a3c1e