### PR TITLE
Fix brief syncing and AI narrative fallbacks

### DIFF
--- a/src/utils/aiNarrative.ts
+++ b/src/utils/aiNarrative.ts
@@ -35,17 +35,22 @@ const ensureArray = (value: unknown): string[] => {
   return []
 }
 
-const coerceContent = (input: Partial<CaseStudyContent>, fallback: CaseStudyContent): CaseStudyContent => ({
-  overview: typeof input.overview === 'string' && input.overview.trim() ? input.overview.trim() : fallback.overview,
-  challenge: typeof input.challenge === 'string' && input.challenge.trim() ? input.challenge.trim() : fallback.challenge,
-  approach: ensureArray(input.approach) || fallback.approach,
-  results: ensureArray(input.results) || fallback.results,
-  learnings: typeof input.learnings === 'string' && input.learnings.trim() ? input.learnings.trim() : fallback.learnings,
-  callToAction:
-    typeof input.callToAction === 'string' && input.callToAction.trim()
-      ? input.callToAction.trim()
-      : fallback.callToAction,
-})
+const coerceContent = (input: Partial<CaseStudyContent>, fallback: CaseStudyContent): CaseStudyContent => {
+  const approach = ensureArray(input.approach)
+  const results = ensureArray(input.results)
+
+  return {
+    overview: typeof input.overview === 'string' && input.overview.trim() ? input.overview.trim() : fallback.overview,
+    challenge: typeof input.challenge === 'string' && input.challenge.trim() ? input.challenge.trim() : fallback.challenge,
+    approach: approach.length > 0 ? approach : fallback.approach,
+    results: results.length > 0 ? results : fallback.results,
+    learnings: typeof input.learnings === 'string' && input.learnings.trim() ? input.learnings.trim() : fallback.learnings,
+    callToAction:
+      typeof input.callToAction === 'string' && input.callToAction.trim()
+        ? input.callToAction.trim()
+        : fallback.callToAction,
+  }
+}
 
 export const generateCaseStudyNarrative = async (
   project: ProjectMeta,


### PR DESCRIPTION
## Summary
- define a single brief file constant and reuse it when reading or writing project briefs
- ensure metadata updates preserve existing PCSI values instead of copying case data into the wrong fields
- tighten AI narrative coercion so empty approach/results arrays fall back to the previous content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cea413e88c832f83bf3cee39ac9d94