### PR TITLE
Revamp frontend layout and styling

### DIFF
--- a/src/components/NotificationContainer.tsx
+++ b/src/components/NotificationContainer.tsx
@@ -4,36 +4,27 @@ import { useApp } from '../contexts/AppContext'
 import type { NotificationType } from '../contexts/AppContext'
 import Button from './ui/Button'
 
+const ICONS: Record<NotificationType, React.ReactNode> = {
+  success: <CheckCircle width={18} height={18} />,
+  error: <XCircle width={18} height={18} />,
+  warning: <AlertTriangle width={18} height={18} />,
+  info: <Info width={18} height={18} />,
+}
+
 const NotificationContainer: React.FC = () => {
   const { state, removeNotification } = useApp()
 
-  const getIcon = useCallback((type: NotificationType) => {
+  const resolveClassName = useCallback((type: NotificationType) => {
     switch (type) {
       case 'success':
-        return <CheckCircle className="h-5 w-5 text-green-400" />
+        return 'toast toast--success'
       case 'error':
-        return <XCircle className="h-5 w-5 text-red-400" />
+        return 'toast toast--error'
       case 'warning':
-        return <AlertTriangle className="h-5 w-5 text-yellow-400" />
+        return 'toast toast--warning'
       case 'info':
-        return <Info className="h-5 w-5 text-blue-400" />
       default:
-        return <Info className="h-5 w-5 text-blue-400" />
-    }
-  }, [])
-
-  const getColorClasses = useCallback((type: NotificationType) => {
-    switch (type) {
-      case 'success':
-        return 'bg-green-50 border-green-200 text-green-800 dark:bg-green-900 dark:border-green-700 dark:text-green-200'
-      case 'error':
-        return 'bg-red-50 border-red-200 text-red-800 dark:bg-red-900 dark:border-red-700 dark:text-red-200'
-      case 'warning':
-        return 'bg-yellow-50 border-yellow-200 text-yellow-800 dark:bg-yellow-900 dark:border-yellow-700 dark:text-yellow-200'
-      case 'info':
-        return 'bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-900 dark:border-blue-700 dark:text-blue-200'
-      default:
-        return 'bg-gray-50 border-gray-200 text-gray-800 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200'
+        return 'toast toast--info'
     }
   }, [])
 
@@ -42,32 +33,22 @@ const NotificationContainer: React.FC = () => {
   }
 
   return (
-    <div className="fixed top-4 right-4 z-50 space-y-2 max-w-sm w-full">
+    <div className="toast-container">
       {state.notifications.map(notification => (
-        <div
-          key={notification.id}
-          className={`border rounded-lg p-4 shadow-lg animate-in slide-in-from-top-2 duration-300 ${getColorClasses(notification.type)}`}
-        >
-          <div className="flex items-start">
-            <div className="flex-shrink-0">
-              {getIcon(notification.type)}
-            </div>
-            <div className="ml-3 flex-1">
-              <p className="text-sm font-medium">
-                {notification.message}
-              </p>
-            </div>
-            <div className="ml-4 flex-shrink-0">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => removeNotification(notification.id)}
-                className="text-current hover:bg-black hover:bg-opacity-10 dark:hover:bg-white dark:hover:bg-opacity-10"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
+        <div key={notification.id} className={resolveClassName(notification.type)}>
+          <span aria-hidden className="btn__icon">{ICONS[notification.type]}</span>
+          <div className="toast__content">
+            <p className="toast__message">{notification.message}</p>
+            <p className="toast__meta">{new Date(notification.timestamp).toLocaleTimeString()}</p>
           </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => removeNotification(notification.id)}
+            aria-label="Dismiss notification"
+          >
+            <X width={16} height={16} />
+          </Button>
         </div>
       ))}
     </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,30 +1,27 @@
-import React from 'react';
-import { Sun, Moon } from 'lucide-react';
-import { useApp } from '../contexts/AppContext';
-import Button from './ui/Button';
+import React from 'react'
+import { Sun, Moon } from 'lucide-react'
+import { useApp } from '../contexts/AppContext'
 
 const ThemeToggle: React.FC = () => {
-  const { state, setTheme } = useApp();
+  const { state, setTheme } = useApp()
 
   const toggleTheme = () => {
-    setTheme(state.theme === 'light' ? 'dark' : 'light');
-  };
+    setTheme(state.theme === 'light' ? 'dark' : 'light')
+  }
+
+  const isLight = state.theme === 'light'
 
   return (
-    <Button
-      variant="ghost"
-      size="sm"
+    <button
+      type="button"
+      className="theme-toggle"
       onClick={toggleTheme}
-      className="relative"
-      aria-label={`Switch to ${state.theme === 'light' ? 'dark' : 'light'} theme`}
+      aria-label={`Switch to ${isLight ? 'dark' : 'light'} theme`}
     >
-      {state.theme === 'light' ? (
-        <Moon className="h-5 w-5 text-gray-600 dark:text-gray-400" />
-      ) : (
-        <Sun className="h-5 w-5 text-yellow-500" />
-      )}
-    </Button>
-  );
-};
+      {isLight ? <Moon width={16} height={16} /> : <Sun width={16} height={16} />}
+      <span>{isLight ? 'Dark' : 'Light'} mode</span>
+    </button>
+  )
+}
 
-export default React.memo(ThemeToggle);
+export default React.memo(ThemeToggle)

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,15 +1,32 @@
-import React, { forwardRef, ButtonHTMLAttributes, useMemo } from 'react';
-import { Loader2 } from 'lucide-react';
+import React, { forwardRef, ButtonHTMLAttributes } from 'react'
+import { Loader2 } from 'lucide-react'
+
+type Variant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger'
+type Size = 'sm' | 'md' | 'lg'
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger';
-  size?: 'sm' | 'md' | 'lg';
-  loading?: boolean;
-  leftIcon?: React.ReactNode;
-  rightIcon?: React.ReactNode;
-  fullWidth?: boolean;
-  as?: React.ElementType;
-  to?: string;
+  variant?: Variant
+  size?: Size
+  loading?: boolean
+  leftIcon?: React.ReactNode
+  rightIcon?: React.ReactNode
+  fullWidth?: boolean
+  as?: React.ElementType
+  to?: string
+}
+
+const VARIANT_CLASS: Record<Variant, string> = {
+  primary: 'btn--primary',
+  secondary: 'btn--secondary',
+  outline: 'btn--outline',
+  ghost: 'btn--ghost',
+  danger: 'btn--danger',
+}
+
+const SIZE_CLASS: Record<Size, string> = {
+  sm: 'btn--sm',
+  md: '',
+  lg: 'btn--lg',
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -28,119 +45,37 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       to,
       ...props
     },
-    ref
+    ref,
   ) => {
-    // Base styles
-    const baseStyles = [
-      'inline-flex',
-      'items-center',
-      'justify-center',
-      'gap-2',
-      'border',
-      'border-transparent',
-      'font-medium',
-      'rounded-lg',
-      'transition-all',
-      'duration-200',
-      'focus:outline-none',
-      'focus:ring-2',
-      'focus:ring-offset-2',
-      'disabled:opacity-50',
-      'disabled:cursor-not-allowed',
-      'disabled:pointer-events-none',
-    ];
-
-    // Variant styles
-    const variantStyles = {
-      primary: [
-        'bg-primary-600',
-        'text-white',
-        'hover:bg-primary-700',
-        'focus:ring-primary-500',
-        'shadow-sm',
-        'hover:shadow-md',
-      ],
-      secondary: [
-        'bg-gray-600',
-        'text-white',
-        'hover:bg-gray-700',
-        'focus:ring-gray-500',
-        'shadow-sm',
-        'hover:shadow-md',
-      ],
-      outline: [
-        'bg-transparent',
-        'text-gray-700',
-        'border-gray-300',
-        'hover:bg-gray-50',
-        'focus:ring-primary-500',
-        'dark:text-gray-300',
-        'dark:border-gray-600',
-        'dark:hover:bg-gray-800',
-      ],
-      ghost: [
-        'bg-transparent',
-        'text-gray-700',
-        'hover:bg-gray-100',
-        'focus:ring-primary-500',
-        'dark:text-gray-300',
-        'dark:hover:bg-gray-800',
-      ],
-      danger: [
-        'bg-red-600',
-        'text-white',
-        'hover:bg-red-700',
-        'focus:ring-red-500',
-        'shadow-sm',
-        'hover:shadow-md',
-      ],
-    };
-
-    // Size styles
-    const sizeStyles = {
-      sm: ['px-3', 'py-1.5', 'text-sm'],
-      md: ['px-4', 'py-2', 'text-sm'],
-      lg: ['px-6', 'py-3', 'text-base'],
-    };
-
-    // Width styles
-    const widthStyles = fullWidth ? ['w-full'] : [];
-
-    // Combine all styles with memoization
-    const styles = useMemo(() => [
-      ...baseStyles,
-      ...variantStyles[variant],
-      ...sizeStyles[size],
-      ...widthStyles,
+    const classes = [
+      'btn',
+      VARIANT_CLASS[variant],
+      SIZE_CLASS[size],
+      fullWidth ? 'btn--full' : '',
       className,
-    ].join(' '), [variant, size, fullWidth, className]);
+    ]
+      .filter(Boolean)
+      .join(' ')
 
-    const isDisabled = disabled || loading;
+    const isDisabled = disabled || loading
 
     return (
       <Component
         ref={ref}
-        className={styles}
+        className={classes}
         disabled={isDisabled}
         to={to}
         {...props}
       >
-        {loading ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          leftIcon && <span className="flex-shrink-0">{leftIcon}</span>
-        )}
-
-        {children && <span>{children}</span>}
-
-        {!loading && rightIcon && (
-          <span className="flex-shrink-0">{rightIcon}</span>
-        )}
+        {leftIcon && !loading ? <span className="btn__icon">{leftIcon}</span> : null}
+        {loading ? <Loader2 className="btn__icon" style={{ width: '1.1rem', height: '1.1rem', animation: 'spin 1s linear infinite' }} /> : null}
+        {children ? <span>{children}</span> : null}
+        {rightIcon && !loading ? <span className="btn__icon">{rightIcon}</span> : null}
       </Component>
-    );
-  }
-);
+    )
+  },
+)
 
-Button.displayName = 'Button';
+Button.displayName = 'Button'
 
-export default React.memo(Button);
+export default React.memo(Button)

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,16 +1,14 @@
-import React, { forwardRef, InputHTMLAttributes, useMemo } from 'react';
+import React, { forwardRef, InputHTMLAttributes } from 'react'
 
-type NativeInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
+type NativeInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>
 
 interface InputProps extends NativeInputProps {
-  label?: string;
-  error?: string;
-  helperText?: string;
-  variant?: 'default' | 'filled' | 'outlined';
-  size?: 'sm' | 'md' | 'lg';
-  leftIcon?: React.ReactNode;
-  rightIcon?: React.ReactNode;
-  fullWidth?: boolean;
+  label?: string
+  error?: string
+  helperText?: string
+  leftIcon?: React.ReactNode
+  rightIcon?: React.ReactNode
+  fullWidth?: boolean
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -19,8 +17,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       label,
       error,
       helperText,
-      variant = 'default',
-      size = 'md',
       leftIcon,
       rightIcon,
       fullWidth = false,
@@ -28,145 +24,50 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       id,
       ...props
     },
-    ref
+    ref,
   ) => {
-    const inputId = id || `input-${Math.random().toString(36).substr(2, 9)}`;
+    const inputId = id || `input-${Math.random().toString(36).slice(2, 9)}`
+    const hasLeftIcon = Boolean(leftIcon)
+    const hasRightIcon = Boolean(rightIcon)
 
-    const baseStyles = [
-      'transition-all',
-      'duration-200',
-      'focus:outline-none',
-      'focus:ring-2',
-      'focus:ring-primary-500',
-      'disabled:opacity-50',
-      'disabled:cursor-not-allowed',
-    ];
-
-    const variantStyles = {
-      default: [
-        'border',
-        'border-gray-300',
-        'rounded-lg',
-        'bg-white',
-        'text-gray-900',
-        'placeholder-gray-400',
-        'focus:border-primary-500',
-        'dark:bg-gray-800',
-        'dark:border-gray-600',
-        'dark:text-white',
-        'dark:placeholder-gray-400',
-      ],
-      filled: [
-        'border-0',
-        'rounded-lg',
-        'bg-gray-100',
-        'text-gray-900',
-        'placeholder-gray-500',
-        'focus:bg-white',
-        'focus:ring-2',
-        'dark:bg-gray-700',
-        'dark:text-white',
-        'dark:placeholder-gray-400',
-        'dark:focus:bg-gray-800',
-      ],
-      outlined: [
-        'border-2',
-        'border-gray-300',
-        'rounded-lg',
-        'bg-transparent',
-        'text-gray-900',
-        'placeholder-gray-400',
-        'focus:border-primary-500',
-        'dark:border-gray-600',
-        'dark:text-white',
-        'dark:placeholder-gray-400',
-      ],
-    };
-
-    const sizeStyles = {
-      sm: ['px-3', 'py-1.5', 'text-sm'],
-      md: ['px-4', 'py-2', 'text-sm'],
-      lg: ['px-4', 'py-3', 'text-base'],
-    };
-
-    const iconPadding = {
-      sm: leftIcon ? 'pl-10' : rightIcon ? 'pr-10' : '',
-      md: leftIcon ? 'pl-10' : rightIcon ? 'pr-10' : '',
-      lg: leftIcon ? 'pl-12' : rightIcon ? 'pr-12' : '',
-    };
-
-    const widthStyles = fullWidth ? ['w-full'] : [];
-
-    const inputStyles = useMemo(() => [
-      ...baseStyles,
-      ...variantStyles[variant],
-      ...sizeStyles[size],
-      ...widthStyles,
-      iconPadding[size],
-      error ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : '',
+    const inputClasses = [
+      'form-control__input',
+      hasLeftIcon ? 'form-control__input--with-left-icon' : '',
+      hasRightIcon ? 'form-control__input--with-right-icon' : '',
+      error ? 'form-control__input--error' : '',
       className,
-    ].join(' '), [variant, size, fullWidth, leftIcon, rightIcon, error, className]);
-
-    const iconSize = {
-      sm: 'h-4 w-4',
-      md: 'h-5 w-5',
-      lg: 'h-6 w-6',
-    };
-
-    const iconPosition = {
-      sm: 'left-3',
-      md: 'left-3',
-      lg: 'left-3',
-    };
-
-    const rightIconPosition = {
-      sm: 'right-3',
-      md: 'right-3',
-      lg: 'right-3',
-    };
+    ]
+      .filter(Boolean)
+      .join(' ')
 
     return (
-      <div className={fullWidth ? 'w-full' : ''}>
-        {label && (
-          <label
-            htmlFor={inputId}
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-          >
+      <div className={fullWidth ? 'form-control form-control--full' : 'form-control'}>
+        {label ? (
+          <label htmlFor={inputId} className="form-control__label">
             {label}
           </label>
-        )}
+        ) : null}
 
-        <div className="relative">
-          {leftIcon && (
-            <div className={`absolute ${iconPosition[size]} top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500`}>
-              <span className={iconSize[size]}>{leftIcon}</span>
-            </div>
-          )}
-
-          <input
-            ref={ref}
-            id={inputId}
-            className={inputStyles}
-            {...props}
-          />
-
-          {rightIcon && (
-            <div className={`absolute ${rightIconPosition[size]} top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500`}>
-              <span className={iconSize[size]}>{rightIcon}</span>
-            </div>
-          )}
+        <div className="input-shell">
+          {hasLeftIcon ? (
+            <span className="input-shell__icon input-shell__icon--left">{leftIcon}</span>
+          ) : null}
+          <input ref={ref} id={inputId} className={inputClasses} {...props} />
+          {hasRightIcon ? (
+            <span className="input-shell__icon input-shell__icon--right">{rightIcon}</span>
+          ) : null}
         </div>
 
-        {(error || helperText) && (
-          <p className={`mt-1 text-xs ${error ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'}`}>
-            {error || helperText}
-          </p>
-        )}
+        {error ? (
+          <p className="form-control__helper form-control__helper--error">{error}</p>
+        ) : helperText ? (
+          <p className="form-control__helper">{helperText}</p>
+        ) : null}
       </div>
-    );
-  }
-);
+    )
+  },
+)
 
-Input.displayName = 'Input';
+Input.displayName = 'Input'
 
-export default React.memo(Input);
+export default React.memo(Input)

--- a/src/components/ui/LoadingSpinner.tsx
+++ b/src/components/ui/LoadingSpinner.tsx
@@ -1,11 +1,18 @@
-import React, { useMemo } from 'react';
-import { Loader2 } from 'lucide-react';
+import React from 'react'
+import { Loader2 } from 'lucide-react'
 
 interface LoadingSpinnerProps {
-  size?: 'sm' | 'md' | 'lg' | 'xl';
-  className?: string;
-  text?: string;
-  centered?: boolean;
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+  className?: string
+  text?: string
+  centered?: boolean
+}
+
+const SIZE_MAP: Record<NonNullable<LoadingSpinnerProps['size']>, string> = {
+  sm: '1.1rem',
+  md: '1.5rem',
+  lg: '2rem',
+  xl: '2.75rem',
 }
 
 const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
@@ -14,42 +21,19 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   text,
   centered = false,
 }) => {
-  const sizeStyles = {
-    sm: 'h-4 w-4',
-    md: 'h-6 w-6',
-    lg: 'h-8 w-8',
-    xl: 'h-12 w-12',
-  };
+  const iconStyle: React.CSSProperties = {
+    width: SIZE_MAP[size],
+    height: SIZE_MAP[size],
+  }
 
-  const textSizeStyles = {
-    sm: 'text-sm',
-    md: 'text-base',
-    lg: 'text-lg',
-    xl: 'text-xl',
-  };
-
-  const containerClasses = useMemo(() => centered
-    ? 'flex flex-col items-center justify-center min-h-32'
-    : 'flex items-center space-x-2', [centered]);
-
-  const spinnerClasses = useMemo(() => [
-    'animate-spin',
-    'text-primary-600',
-    'dark:text-primary-400',
-    sizeStyles[size],
-    className,
-  ].join(' '), [size, className]);
+  const containerClass = centered ? 'loading-spinner loading-spinner--centered' : 'loading-spinner'
 
   return (
-    <div className={containerClasses}>
-      <Loader2 className={spinnerClasses} />
-      {text && (
-        <span className={`text-gray-600 dark:text-gray-400 ${textSizeStyles[size]} ${centered ? 'mt-2' : ''}`}>
-          {text}
-        </span>
-      )}
+    <div className={`${containerClass} ${className}`.trim()}>
+      <Loader2 className="loading-spinner__icon" style={iconStyle} />
+      {text ? <span className="loading-spinner__text">{text}</span> : null}
     </div>
-  );
-};
+  )
+}
 
-export default React.memo(LoadingSpinner);
+export default React.memo(LoadingSpinner)

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,7 @@
 /* src/index.css */
 
+@import './styles/ui.css';
+
 /* CSS Reset */
 *, *::before, *::after {
   box-sizing: border-box;
@@ -2944,7 +2946,6 @@ input, textarea, select {
     right: 1.5rem;
     transform: none;
   }
-}
 
 /* Modal styles */
 .modal-overlay {

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -352,99 +352,96 @@ const DashboardPage: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
-        <LoadingSpinner size="lg" text="Loading your projects..." centered />
+      <div className="app-page">
+        <main
+          className="app-page__body"
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '60vh' }}
+        >
+          <LoadingSpinner size="lg" text="Loading your projects..." centered />
+        </main>
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-      <header className="border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-900/80 backdrop-blur">
-        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-start gap-4">
-            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-indigo-100 dark:bg-indigo-900/40">
-              <Folder className="h-6 w-6 text-indigo-600 dark:text-indigo-300" />
+    <div className="app-page">
+      <header className="app-page__header">
+        <div className="app-page__header-inner">
+          <div className="dashboard-hero">
+            <div className="dashboard-hero__icon">
+              <Folder width={28} height={28} />
             </div>
             <div>
-              <h1 className="text-2xl font-bold">Portfolio control centre</h1>
-              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              <h1 className="dashboard-hero__title">Portfolio control centre</h1>
+              <p className="section-subtitle">
                 Capture project details, manage files locally, and generate polished narratives.
               </p>
             </div>
           </div>
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="button-row">
             <ThemeToggle />
-            <Button as={Link} to="/portfolio" variant="outline" leftIcon={<Layers className="h-4 w-4" />}>
+            <Button as={Link} to="/portfolio" variant="outline" leftIcon={<Layers size={18} />}>
               View portfolio
             </Button>
-            <Button as={Link} to="/create" variant="primary" leftIcon={<Plus className="h-4 w-4" />}>
+            <Button as={Link} to="/create" variant="primary" leftIcon={<Plus size={18} />}>
               New project
             </Button>
           </div>
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl px-6 py-10 space-y-8">
-        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <article className="rounded-2xl border border-indigo-100 bg-indigo-50 p-6 shadow-sm dark:border-indigo-800/60 dark:bg-indigo-950/40">
-            <div className="flex items-start justify-between">
-              <div>
-                <p className="text-sm font-medium text-indigo-600 dark:text-indigo-300">Projects</p>
-                <p className="mt-2 text-3xl font-semibold">{stats.totalProjects}</p>
-              </div>
-              <div className="rounded-full bg-white/70 p-2 dark:bg-indigo-900/60">
-                <Folder className="h-5 w-5 text-indigo-600 dark:text-indigo-300" />
-              </div>
+      <main className="app-page__body">
+        <section className="stats-grid">
+          <article
+            className="stat-card surface"
+            style={{ background: 'linear-gradient(135deg, #eef2ff, #e0e7ff)' }}
+          >
+            <div className="stat-card__icon">
+              <Folder width={18} height={18} />
             </div>
-            <p className="mt-3 text-xs text-indigo-700/80 dark:text-indigo-200/80">
-              All projects are saved locally in your browser.
-            </p>
+            <span className="stat-card__label">Projects</span>
+            <span className="stat-card__value">{stats.totalProjects}</span>
+            <p className="stat-card__description">All projects are saved locally in your browser.</p>
           </article>
 
-          <article className="rounded-2xl border border-purple-100 bg-purple-50 p-6 shadow-sm dark:border-purple-900/50 dark:bg-purple-950/40">
-            <div className="flex items-start justify-between">
-              <div>
-                <p className="text-sm font-medium text-purple-600 dark:text-purple-300">Case studies ready</p>
-                <p className="mt-2 text-3xl font-semibold">{stats.caseStudiesReady}</p>
-              </div>
-              <div className="rounded-full bg-white/70 p-2 dark:bg-purple-900/60">
-                <FileText className="h-5 w-5 text-purple-600 dark:text-purple-300" />
-              </div>
+          <article
+            className="stat-card surface"
+            style={{ background: 'linear-gradient(135deg, #f3e8ff, #ede9fe)' }}
+          >
+            <div className="stat-card__icon">
+              <FileText width={18} height={18} />
             </div>
-            <p className="mt-3 text-xs text-purple-700/80 dark:text-purple-200/80">
+            <span className="stat-card__label">Case studies ready</span>
+            <span className="stat-card__value">{stats.caseStudiesReady}</span>
+            <p className="stat-card__description">
               AI-assisted narratives make these projects portfolio-ready.
             </p>
           </article>
 
-          <article className="rounded-2xl border border-sky-100 bg-sky-50 p-6 shadow-sm dark:border-sky-900/60 dark:bg-sky-950/40">
-            <div className="flex items-start justify-between">
-              <div>
-                <p className="text-sm font-medium text-sky-600 dark:text-sky-300">Assets</p>
-                <p className="mt-2 text-3xl font-semibold">{stats.totalAssets}</p>
-              </div>
-              <div className="rounded-full bg-white/70 p-2 dark:bg-sky-900/60">
-                <Upload className="h-5 w-5 text-sky-600 dark:text-sky-300" />
-              </div>
+          <article
+            className="stat-card surface"
+            style={{ background: 'linear-gradient(135deg, #e0f2fe, #bae6fd)' }}
+          >
+            <div className="stat-card__icon">
+              <Upload width={18} height={18} />
             </div>
-            <p className="mt-3 text-xs text-sky-700/80 dark:text-sky-200/80">
-              Upload images and files directly into each project.
-            </p>
+            <span className="stat-card__label">Assets</span>
+            <span className="stat-card__value">{stats.totalAssets}</span>
+            <p className="stat-card__description">Upload images and files directly into each project.</p>
           </article>
 
-          <article className="rounded-2xl border border-emerald-100 bg-emerald-50 p-6 shadow-sm dark:border-emerald-900/50 dark:bg-emerald-950/40">
-            <div className="flex items-start justify-between">
-              <div>
-                <p className="text-sm font-medium text-emerald-600 dark:text-emerald-300">Storage used</p>
-                <p className="mt-2 text-3xl font-semibold">
-                  {storageUsage ? `${storageUsage.used}MB` : '—'}
-                </p>
-              </div>
-              <div className="rounded-full bg-white/70 p-2 dark:bg-emerald-900/60">
-                <RefreshCw className="h-5 w-5 text-emerald-600 dark:text-emerald-300" />
-              </div>
+          <article
+            className="stat-card surface"
+            style={{ background: 'linear-gradient(135deg, #dcfce7, #bbf7d0)' }}
+          >
+            <div className="stat-card__icon">
+              <RefreshCw width={18} height={18} />
             </div>
-            <p className="mt-3 text-xs text-emerald-700/80 dark:text-emerald-200/80">
+            <span className="stat-card__label">Storage used</span>
+            <span className="stat-card__value">
+              {storageUsage ? `${storageUsage.used}MB` : '—'}
+            </span>
+            <p className="stat-card__description">
               {storageUsage
                 ? `Approx. ${storageUsage.percentage}% of ${storageUsage.available}MB local capacity`
                 : 'Storage usage unavailable'}
@@ -452,22 +449,34 @@ const DashboardPage: React.FC = () => {
           </article>
         </section>
 
-        <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-          <div className="flex flex-col gap-4 border-b border-gray-200 pb-6 dark:border-gray-800 md:flex-row md:items-center md:justify-between">
+        <section className="surface surface--raised">
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: '1.5rem',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              borderBottom: '1px solid var(--color-border)',
+              paddingBottom: '1.5rem',
+              marginBottom: '1.5rem',
+            }}
+          >
             <div>
-              <h2 className="text-lg font-semibold">Local projects</h2>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
-                Search, export, or jump straight into the case study editor.
-              </p>
+              <h2 className="section-title">Local projects</h2>
+              <p className="section-subtitle">Search, export, or jump straight into the case study editor.</p>
             </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <Input
-                placeholder="Search projects"
-                value={searchQuery}
-                onChange={event => setSearchQuery(event.target.value)}
-                leftIcon={<ArrowRightCircle className="h-4 w-4 rotate-45" />}
-              />
-              <div className="flex items-center gap-2">
+            <div className="dashboard-toolbar">
+              <div className="dashboard-toolbar__search">
+                <Input
+                  placeholder="Search projects"
+                  value={searchQuery}
+                  onChange={event => setSearchQuery(event.target.value)}
+                  leftIcon={<ArrowRightCircle width={16} height={16} />}
+                  fullWidth
+                />
+              </div>
+              <div className="dashboard-toolbar__actions">
                 <input
                   ref={fileInputRef}
                   type="file"
@@ -478,7 +487,7 @@ const DashboardPage: React.FC = () => {
                 <Button
                   variant="outline"
                   onClick={() => fileInputRef.current?.click()}
-                  leftIcon={<Upload className="h-4 w-4" />}
+                  leftIcon={<Upload width={16} height={16} />}
                   loading={isImporting}
                 >
                   Import
@@ -486,7 +495,7 @@ const DashboardPage: React.FC = () => {
                 <Button
                   variant="ghost"
                   onClick={() => downloadJson('portfolio-projects.json', projects)}
-                  leftIcon={<Download className="h-4 w-4" />}
+                  leftIcon={<Download width={16} height={16} />}
                   disabled={projects.length === 0}
                 >
                   Export all
@@ -496,56 +505,49 @@ const DashboardPage: React.FC = () => {
           </div>
 
           {filteredProjects.length === 0 ? (
-            <div className="flex h-48 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+            <div className="dashboard-empty">
               {projects.length === 0
                 ? 'No projects yet. Start by creating your first project intake.'
                 : 'No projects match your search.'}
             </div>
           ) : (
-            <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+            <ul className="dashboard-list">
               {filteredProjects.map(project => (
-                <li key={project.slug} className="flex flex-col gap-4 py-6 md:flex-row md:items-center md:justify-between">
-                  <div className="space-y-2">
-                    <div className="flex flex-wrap items-center gap-3">
-                      <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
-                        {project.title}
-                      </h3>
-                      <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                <li key={project.slug} className="dashboard-project">
+                  <div>
+                    <div className="button-row" style={{ justifyContent: 'flex-start' }}>
+                      <h3 style={{ margin: 0, fontSize: '1.05rem' }}>{project.title}</h3>
+                      <span className="status-pill">
                         {project.status === 'draft' ? 'Draft' : project.status === 'cast' ? 'In review' : 'Published'}
                       </span>
                     </div>
-                    {project.summary && (
-                      <p className="max-w-2xl text-sm text-gray-600 dark:text-gray-400">{project.summary}</p>
-                    )}
-                    <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500 dark:text-gray-500">
+                    {project.summary ? (
+                      <p className="section-subtitle" style={{ marginTop: '0.5rem' }}>
+                        {project.summary}
+                      </p>
+                    ) : null}
+                    <div className="dashboard-project__meta">
                       <span>{project.assets.length} assets</span>
                       <span>Updated {formatDate(project.updatedAt)}</span>
-                      <span>
-                        {project.caseStudyContent?.overview
-                          ? 'Narrative ready'
-                          : 'Needs narrative'}
-                      </span>
+                      <span>{project.caseStudyContent?.overview ? 'Narrative ready' : 'Needs narrative'}</span>
                     </div>
-                    {project.tags.length > 0 && (
-                      <div className="flex flex-wrap gap-2">
+                    {project.tags.length > 0 ? (
+                      <div className="dashboard-project__tags">
                         {project.tags.slice(0, 5).map(tag => (
-                          <span
-                            key={tag}
-                            className="rounded-full bg-indigo-50 px-2.5 py-1 text-xs text-indigo-600 dark:bg-indigo-900/50 dark:text-indigo-200"
-                          >
+                          <span key={tag} className="dashboard-project__tag">
                             #{tag}
                           </span>
                         ))}
                       </div>
-                    )}
+                    ) : null}
                   </div>
-                  <div className="flex flex-wrap items-center gap-2">
+                  <div className="button-row" style={{ justifyContent: 'flex-start' }}>
                     <Button
                       as={Link}
                       to={`/editor/${project.slug}`}
                       variant="primary"
                       size="sm"
-                      leftIcon={<FileText className="h-4 w-4" />}
+                      leftIcon={<FileText width={16} height={16} />}
                     >
                       Case study
                     </Button>
@@ -553,7 +555,7 @@ const DashboardPage: React.FC = () => {
                       onClick={() => handleExport(project)}
                       variant="outline"
                       size="sm"
-                      leftIcon={<Download className="h-4 w-4" />}
+                      leftIcon={<Download width={16} height={16} />}
                     >
                       Export
                     </Button>
@@ -561,7 +563,7 @@ const DashboardPage: React.FC = () => {
                       onClick={() => handleDelete(project.slug)}
                       variant="danger"
                       size="sm"
-                      leftIcon={<Trash2 className="h-4 w-4" />}
+                      leftIcon={<Trash2 width={16} height={16} />}
                     >
                       Delete
                     </Button>
@@ -572,9 +574,11 @@ const DashboardPage: React.FC = () => {
           )}
         </section>
 
-        <section className="rounded-3xl border border-indigo-200 bg-indigo-50/60 p-6 text-sm text-indigo-900 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/40 dark:text-indigo-100">
-          <h3 className="text-base font-semibold">Workflow tips</h3>
-          <ol className="mt-3 list-decimal space-y-2 pl-5">
+        <section className="dashboard-workflow">
+          <h3 className="section-title" style={{ marginBottom: '0.75rem' }}>
+            Workflow tips
+          </h3>
+          <ol>
             <li>Capture a project through the intake to gather narrative hooks and assets.</li>
             <li>Use the case study editor to refine copy, upload visuals, and generate AI narratives.</li>
             <li>Arrange your highlights in the portfolio editor before sharing or exporting.</li>

--- a/src/pages/NewEditorPage.tsx
+++ b/src/pages/NewEditorPage.tsx
@@ -4,13 +4,13 @@ import {
   ArrowLeft,
   CheckCircle2,
   Image,
-  Loader2,
   RefreshCw,
   Save,
   Sparkles,
   Trash2,
 } from 'lucide-react'
 import { Button, Input } from '../components/ui'
+import LoadingSpinner from '../components/ui/LoadingSpinner'
 import type { CaseStudyContent, ProjectAsset, ProjectMeta } from '../intake/schema'
 import { newProject } from '../intake/schema'
 import { loadProject, saveProject } from '../utils/storageManager'
@@ -277,17 +277,21 @@ const NewEditorPage: React.FC = () => {
 
   if (!project || !caseStudy) {
     return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center text-sm text-gray-500 dark:text-gray-400">
-        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-        Loading editor…
+      <div className="app-page">
+        <main
+          className="app-page__body"
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '60vh' }}
+        >
+          <LoadingSpinner size="lg" text="Loading editor…" centered />
+        </main>
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-      <header className="border-b border-gray-200 bg-white/80 backdrop-blur dark:border-gray-800 dark:bg-gray-900/80">
-        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
+    <div className="app-page editor-page">
+      <header className="app-page__header">
+        <div className="app-page__header-inner" style={{ alignItems: 'center', justifyContent: 'space-between' }}>
           <div className="flex items-center gap-3">
             <Button
               variant="outline"
@@ -297,14 +301,14 @@ const NewEditorPage: React.FC = () => {
               Dashboard
             </Button>
             <div>
-              <h1 className="text-xl font-semibold">Case study editor</h1>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <h1 className="section-title" style={{ marginBottom: '0.35rem' }}>Case study editor</h1>
+              <p className="section-subtitle">
                 Shape a concise narrative, manage assets, and preview the final layout.
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-500">Last updated {formatDate(project.updatedAt)}</p>
+              <p className="form-control__helper">Last updated {formatDate(project.updatedAt)}</p>
             </div>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="button-row">
             <Button
               variant="ghost"
               leftIcon={<RefreshCw className="h-4 w-4" />}
@@ -332,59 +336,59 @@ const NewEditorPage: React.FC = () => {
         </div>
       </header>
 
-      <main className="mx-auto grid max-w-6xl gap-8 px-6 py-8 lg:grid-cols-[1.1fr_0.9fr]">
-        <section className="space-y-6">
-          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Hero & summary</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Set the hook for the case study and tune the key metadata.</p>
+      <main className="app-page__body editor-layout">
+        <section className="editor-grid">
+          <article className="surface editor-card">
+            <h2 className="section-title">Hero & summary</h2>
+            <p className="section-subtitle">Set the hook for the case study and tune the key metadata.</p>
 
-            <div className="mt-6 space-y-4">
+            <div className="form-grid">
               <Input
                 label="Project title"
                 value={project.title}
                 onChange={event => setProject(previous => (previous ? { ...previous, title: event.target.value } : previous))}
                 fullWidth
               />
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Portfolio summary
+              <label className="form-control">
+                <span className="form-control__label">Portfolio summary</span>
                 <textarea
                   value={summary}
                   onChange={event => setSummary(event.target.value)}
                   rows={3}
                   placeholder="A concise one-liner to describe the project."
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Hero narrative
+              <label className="form-control">
+                <span className="form-control__label">Hero narrative</span>
                 <textarea
                   value={overview}
                   onChange={event => setOverview(event.target.value)}
                   rows={3}
                   placeholder="Set the tone for the story with a short paragraph."
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Tags
+              <label className="form-control">
+                <span className="form-control__label">Tags</span>
                 <textarea
                   value={tagsInput}
                   onChange={event => setTagsInput(event.target.value)}
                   rows={2}
                   placeholder="product strategy, data visualisation, design systems"
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
             </div>
           </article>
 
-          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Narrative detail</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">These sections drive the AI narrative and portfolio export.</p>
+          <article className="surface editor-card">
+            <h2 className="section-title">Narrative detail</h2>
+            <p className="section-subtitle">These sections drive the AI narrative and portfolio export.</p>
 
-            <div className="mt-6 space-y-5">
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Challenge
+            <div className="form-grid">
+              <label className="form-control">
+                <span className="form-control__label">Challenge</span>
                 <textarea
                   value={problem}
                   onChange={event => {
@@ -393,11 +397,11 @@ const NewEditorPage: React.FC = () => {
                   }}
                   rows={3}
                   placeholder="What was the problem or opportunity?"
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Approach (one point per line)
+              <label className="form-control">
+                <span className="form-control__label">Approach (one point per line)</span>
                 <textarea
                   value={approachText}
                   onChange={event => {
@@ -406,11 +410,11 @@ const NewEditorPage: React.FC = () => {
                   }}
                   rows={4}
                   placeholder={'Discovery workshops\nCustomer journey mapping\nIterative prototyping'}
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea editor-textarea"
                 />
               </label>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Impact (one metric or story per line)
+              <label className="form-control">
+                <span className="form-control__label">Impact (one metric or story per line)</span>
                 <textarea
                   value={resultsText}
                   onChange={event => {
@@ -419,31 +423,31 @@ const NewEditorPage: React.FC = () => {
                   }}
                   rows={4}
                   placeholder={'30% uplift in activation\nShipped cross-team design system'}
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea editor-textarea"
                 />
               </label>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Solution summary
+              <label className="form-control">
+                <span className="form-control__label">Solution summary</span>
                 <textarea
                   value={solution}
                   onChange={event => setSolution(event.target.value)}
                   rows={3}
                   placeholder="How did you design, build, or facilitate the outcome?"
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Outcomes & metrics
+              <label className="form-control">
+                <span className="form-control__label">Outcomes &amp; metrics</span>
                 <textarea
                   value={outcomes}
                   onChange={event => setOutcomes(event.target.value)}
                   rows={3}
                   placeholder="Key numbers, qualitative wins, or momentum unlocked."
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Learnings
+              <label className="form-control">
+                <span className="form-control__label">Learnings</span>
                 <textarea
                   value={learnings}
                   onChange={event => {
@@ -452,11 +456,11 @@ const NewEditorPage: React.FC = () => {
                   }}
                   rows={3}
                   placeholder="Key lessons or reflections to carry into the next project."
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Call to action
+              <label className="form-control">
+                <span className="form-control__label">Call to action</span>
                 <textarea
                   value={cta}
                   onChange={event => {
@@ -465,7 +469,7 @@ const NewEditorPage: React.FC = () => {
                   }}
                   rows={2}
                   placeholder="Let’s shape the next release together."
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
             </div>
@@ -473,31 +477,26 @@ const NewEditorPage: React.FC = () => {
 
         </section>
 
-        <aside className="space-y-6">
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Assets</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Select a hero image and keep supporting visuals close at hand.</p>
+        <aside className="editor-sidebar">
+          <section className="surface">
+            <h2 className="section-title">Assets</h2>
+            <p className="section-subtitle">Select a hero image and keep supporting visuals close at hand.</p>
 
-            <label className="mt-4 flex cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-600 transition hover:border-indigo-400 hover:text-indigo-500 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-400 dark:hover:border-indigo-500">
-              <input type="file" accept="image/*" multiple className="hidden" onChange={handleAssetUpload} />
+            <label className="upload-dropzone" style={{ marginTop: '1rem' }}>
+              <input type="file" accept="image/*" multiple className="sr-only" onChange={handleAssetUpload} />
               <Image className="h-6 w-6" />
-              <span>Drop imagery or <span className="underline">browse</span></span>
+              <span>Drop imagery or <strong>browse</strong></span>
             </label>
 
             {assets.length > 0 ? (
-              <ul className="mt-4 space-y-3 text-sm">
+              <ul className="asset-list" style={{ marginTop: '1rem' }}>
                 {assets.map(asset => (
-                  <li
-                    key={asset.id}
-                    className="flex items-center justify-between rounded-2xl border border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-800/70"
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate font-medium">{asset.name}</p>
-                      <p className="truncate text-xs text-gray-500">
-                        {asset.mimeType}
-                      </p>
+                  <li key={asset.id} className="asset-list__item">
+                    <div className="asset-list__meta">
+                      <span className="asset-list__name">{asset.name}</span>
+                      <span className="asset-list__type">{asset.mimeType}</span>
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="button-row">
                       <Button
                         variant={asset.isHeroImage ? 'primary' : 'outline'}
                         size="sm"
@@ -518,29 +517,26 @@ const NewEditorPage: React.FC = () => {
                 ))}
               </ul>
             ) : (
-              <p className="mt-4 text-xs text-gray-500 dark:text-gray-500">No assets yet. Upload hero imagery or screenshots to enhance the case study.</p>
+              <p className="form-control__helper" style={{ marginTop: '1rem' }}>
+                No assets yet. Upload hero imagery or screenshots to enhance the case study.
+              </p>
             )}
           </section>
 
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Live preview</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Updated as you type. Export-ready HTML & CSS are saved locally.</p>
-            <div className="mt-4 overflow-hidden rounded-2xl border border-gray-200 bg-gray-900/80 p-4 shadow-inner dark:border-gray-700">
-              <div
-                className="max-h-[420px] overflow-y-auto rounded-xl bg-black/60 text-sm"
-                dangerouslySetInnerHTML={{ __html: previewMarkup }}
-              />
+          <section className="surface preview-panel">
+            <h2 className="section-title">Live preview</h2>
+            <p className="section-subtitle">Updated as you type. Export-ready HTML &amp; CSS are saved locally.</p>
+            <div className="preview-panel__frame">
+              <div dangerouslySetInnerHTML={{ __html: previewMarkup }} />
             </div>
           </section>
 
-          {statusMessage && (
-            <section className="rounded-3xl border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-900 shadow-sm dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-100">
-              <p className="flex items-center gap-2">
-                <CheckCircle2 className="h-4 w-4" />
-                {statusMessage}
-              </p>
+          {statusMessage ? (
+            <section className="status-banner">
+              <CheckCircle2 width={16} height={16} />
+              {statusMessage}
             </section>
-          )}
+          ) : null}
         </aside>
       </main>
     </div>

--- a/src/pages/NewIntakePage.tsx
+++ b/src/pages/NewIntakePage.tsx
@@ -1,12 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import {
-  ArrowLeft,
-  CheckCircle2,
-  FolderPlus,
-  ImagePlus,
-  Sparkles,
-} from 'lucide-react'
+import { ArrowLeft, CheckCircle2, FolderPlus, ImagePlus, Sparkles } from 'lucide-react'
 import { Button, Input } from '../components/ui'
 import type { ProjectAsset, ProjectMeta } from '../intake/schema'
 import { newProject } from '../intake/schema'
@@ -39,7 +33,7 @@ const createAssetFromFile = (file: File): Promise<ProjectAsset> =>
 
 const normaliseListInput = (value: string): string[] =>
   value
-    .split(/[,\n]+/)
+    .split(/[\n,]+/)
     .map(entry => entry.trim())
     .filter(entry => entry.length > 0)
 
@@ -111,39 +105,33 @@ const NewIntakePage: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-      <header className="border-b border-gray-200 bg-white/80 backdrop-blur dark:border-gray-800 dark:bg-gray-900/80">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-6">
-          <div className="flex items-center gap-3">
-            <Link
-              to="/dashboard"
-              className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-600 transition hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-            >
-              <ArrowLeft className="h-4 w-4" />
+    <div className="app-page intake-page">
+      <header className="app-page__header">
+        <div className="app-page__header-inner intake-header">
+          <div className="intake-header__meta">
+            <Button as={Link} to="/dashboard" variant="outline" leftIcon={<ArrowLeft width={16} height={16} />}>
               Dashboard
-            </Link>
+            </Button>
             <div>
-              <h1 className="text-xl font-semibold">Project intake</h1>
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <h1 className="section-title">Project intake</h1>
+              <p className="section-subtitle">
                 Capture the essentials so your case study practically writes itself.
               </p>
             </div>
           </div>
-          <Button as={Link} to="/portfolio" variant="outline" leftIcon={<Sparkles className="h-4 w-4" />}>
+          <Button as={Link} to="/portfolio" variant="ghost" leftIcon={<Sparkles width={18} height={18} />}>
             Portfolio
           </Button>
         </div>
       </header>
 
-      <main className="mx-auto max-w-4xl px-6 py-10">
-        <form className="space-y-8" onSubmit={handleSubmit}>
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Project overview</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-              Give the project a name and a short framing statement.
-            </p>
+      <main className="app-page__body">
+        <form className="intake-body" onSubmit={handleSubmit}>
+          <section className="surface">
+            <h2 className="section-title">Project overview</h2>
+            <p className="section-subtitle">Give the project a name and a short framing statement.</p>
 
-            <div className="mt-6 space-y-4">
+            <div className="form-grid">
               <Input
                 label="Project title"
                 value={title}
@@ -152,127 +140,121 @@ const NewIntakePage: React.FC = () => {
                 required
                 fullWidth
               />
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Summary
+              <label className="form-control form-control--full">
+                <span className="form-control__label">Summary</span>
                 <textarea
                   value={summary}
                   onChange={event => setSummary(event.target.value)}
                   placeholder="One or two sentences that set the scene for the work."
                   rows={3}
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
             </div>
           </section>
 
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Narrative hooks</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-              These answers become the backbone of your AI generated case study.
-            </p>
+          <section className="surface">
+            <h2 className="section-title">Narrative hooks</h2>
+            <p className="section-subtitle">These answers become the backbone of your AI generated case study.</p>
 
-            <div className="mt-6 space-y-5">
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                What was the challenge?
+            <div className="form-grid">
+              <label className="form-control">
+                <span className="form-control__label">What was the challenge?</span>
                 <textarea
                   value={problem}
                   onChange={event => setProblem(event.target.value)}
                   rows={3}
-                  placeholder="Describe the friction, business goal, or customer problem."
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
                   required
+                  placeholder="Describe the friction, business goal, or customer problem."
+                  className="form-control__textarea"
                 />
               </label>
 
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                How did you approach it?
+              <label className="form-control">
+                <span className="form-control__label">How did you approach it?</span>
                 <textarea
                   value={solution}
                   onChange={event => setSolution(event.target.value)}
                   rows={3}
-                  placeholder="Outline key moves, collaboration patterns, or design decisions."
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
                   required
+                  placeholder="Outline key moves, collaboration patterns, or design decisions."
+                  className="form-control__textarea"
                 />
               </label>
 
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                What happened as a result?
+              <label className="form-control">
+                <span className="form-control__label">What happened as a result?</span>
                 <textarea
                   value={outcomes}
                   onChange={event => setOutcomes(event.target.value)}
                   rows={3}
-                  placeholder="Metrics, qualitative feedback, or momentum the project unlocked."
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
                   required
+                  placeholder="Metrics, qualitative feedback, or momentum the project unlocked."
+                  className="form-control__textarea"
                 />
               </label>
 
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Tags
+              <label className="form-control">
+                <span className="form-control__label">Tags</span>
                 <textarea
                   value={tags}
                   onChange={event => setTags(event.target.value)}
                   rows={2}
                   placeholder="Separate with commas or new lines – e.g. product strategy, analytics, design systems"
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
             </div>
           </section>
 
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Reference material</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          <section className="surface">
+            <h2 className="section-title">Reference material</h2>
+            <p className="section-subtitle">
               Upload hero images, process shots, or supporting files. You can manage these later in the case study editor.
             </p>
 
-            <div className="mt-6 space-y-4">
-              <label className="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-gray-300 bg-gray-50 px-6 py-10 text-center text-sm text-gray-600 transition hover:border-indigo-400 hover:text-indigo-500 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-400 dark:hover:border-indigo-500">
-                <input type="file" accept="image/*,.pdf,.doc,.docx" multiple className="hidden" onChange={handleAssetUpload} />
-                <ImagePlus className="h-6 w-6" />
-                <span>
-                  Drop files here or <span className="underline">browse</span>
-                </span>
+            <div className="form-grid">
+              <label className="upload-dropzone">
+                <input type="file" accept="image/*,.pdf,.doc,.docx" multiple className="sr-only" onChange={handleAssetUpload} />
+                <ImagePlus width={24} height={24} />
+                <span>Drop files here or <strong>browse</strong></span>
               </label>
 
-              {assets.length > 0 && (
-                <ul className="space-y-2 text-sm">
+              {assets.length > 0 ? (
+                <ul className="asset-list">
                   {assets.map(asset => (
-                    <li key={asset.id} className="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-800/80">
-                      <span className="truncate">
-                        {asset.name}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => handleRemoveAsset(asset.id)}
-                        className="text-xs text-rose-500 hover:text-rose-600"
-                      >
+                    <li key={asset.id} className="asset-list__item">
+                      <div className="asset-list__meta">
+                        <span className="asset-list__name">{asset.name}</span>
+                        <span className="asset-list__type">{asset.mimeType}</span>
+                      </div>
+                      <Button variant="ghost" size="sm" onClick={() => handleRemoveAsset(asset.id)}>
                         Remove
-                      </button>
+                      </Button>
                     </li>
                   ))}
                 </ul>
+              ) : (
+                <p className="form-control__helper">No assets yet. Add imagery or supporting files to enrich the case study.</p>
               )}
             </div>
           </section>
 
-          <section className="rounded-3xl border border-indigo-200 bg-indigo-50/80 p-6 shadow-sm dark:border-indigo-900/60 dark:bg-indigo-950/40">
-            <div className="flex items-start gap-3">
-              <div className="rounded-full bg-white p-2 shadow-sm dark:bg-indigo-900/80">
-                <Sparkles className="h-5 w-5 text-indigo-600 dark:text-indigo-300" />
+          <section className="surface surface--tinted">
+            <div style={{ display: 'flex', gap: '1rem', alignItems: 'flex-start' }}>
+              <div className="btn__icon" style={{ padding: '0.4rem', background: 'rgba(255,255,255,0.15)', borderRadius: '50%' }}>
+                <Sparkles width={20} height={20} />
               </div>
-              <div className="space-y-2">
-                <h2 className="text-lg font-semibold text-indigo-900 dark:text-indigo-100">AI narrative boost</h2>
-                <p className="text-sm text-indigo-800/80 dark:text-indigo-200/80">
+              <div style={{ display: 'grid', gap: '0.5rem' }}>
+                <h2 className="section-title" style={{ marginBottom: 0 }}>AI narrative boost</h2>
+                <p className="section-subtitle">
                   Keep this enabled to pre-fill the case study editor with an AI generated narrative.
                 </p>
-                <label className="inline-flex items-center gap-2 text-sm text-indigo-900 dark:text-indigo-100">
+                <label style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.95rem' }}>
                   <input
                     type="checkbox"
                     checked={autoNarrative}
                     onChange={event => setAutoNarrative(event.target.checked)}
-                    className="h-4 w-4 rounded border-indigo-400 text-indigo-600 focus:ring-indigo-500"
                   />
                   Auto-generate a narrative draft after saving
                 </label>
@@ -280,19 +262,18 @@ const NewIntakePage: React.FC = () => {
             </div>
           </section>
 
-          <footer className="flex flex-wrap items-center justify-between gap-4">
-            <p className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
-              <CheckCircle2 className="h-4 w-4 text-emerald-500" />
-              Data is stored locally in your browser. Export anytime from the dashboard.
+          <footer className="intake-actions">
+            <p className="intake-actions__note">
+              <CheckCircle2 width={16} height={16} /> Data is stored locally in your browser. Export anytime from the dashboard.
             </p>
-            <div className="flex items-center gap-2">
+            <div className="button-row">
               <Button as={Link} to="/dashboard" variant="ghost">
                 Cancel
               </Button>
               <Button
                 type="submit"
                 variant="primary"
-                leftIcon={<FolderPlus className="h-4 w-4" />}
+                leftIcon={<FolderPlus width={18} height={18} />}
                 disabled={!canSubmit}
                 loading={isSubmitting}
               >

--- a/src/pages/PortfolioEditorPage.tsx
+++ b/src/pages/PortfolioEditorPage.tsx
@@ -145,22 +145,22 @@ const PortfolioEditorPage: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-      <header className="border-b border-gray-200 bg-white/80 backdrop-blur dark:border-gray-800 dark:bg-gray-900/80">
-        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
+    <div className="app-page">
+      <header className="app-page__header">
+        <div className="app-page__header-inner" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
           <div className="flex items-center gap-3">
             <Button variant="outline" onClick={() => navigate('/dashboard')} leftIcon={<ArrowLeft className="h-4 w-4" />}>
               Dashboard
             </Button>
             <div>
-              <h1 className="text-xl font-semibold">Portfolio editor</h1>
-              <p className="text-sm text-gray-600 dark:text-gray-400">Curate your case studies into a publish-ready layout.</p>
+              <h1 className="section-title">Portfolio editor</h1>
+              <p className="section-subtitle">Curate your case studies into a publish-ready layout.</p>
               {lastSavedAt && (
-                <p className="text-xs text-gray-500 dark:text-gray-500">Last saved {new Date(lastSavedAt).toLocaleString()}</p>
+                <p className="form-control__helper">Last saved {new Date(lastSavedAt).toLocaleString()}</p>
               )}
             </div>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="button-row">
             <Button as={Link} to="/portfolio" variant="ghost" leftIcon={<Layers className="h-4 w-4" />}>
               View generated portfolio
             </Button>
@@ -171,13 +171,13 @@ const PortfolioEditorPage: React.FC = () => {
         </div>
       </header>
 
-      <main className="mx-auto grid max-w-6xl gap-8 px-6 py-8 lg:grid-cols-[1.05fr_0.95fr]">
-        <section className="space-y-6">
-          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Hero and framing</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Set the voice for the top of your portfolio.</p>
+      <main className="app-page__body portfolio-editor-grid">
+        <section className="editor-grid">
+          <article className="surface editor-card">
+            <h2 className="section-title">Hero and framing</h2>
+            <p className="section-subtitle">Set the voice for the top of your portfolio.</p>
 
-            <div className="mt-6 space-y-4">
+            <div className="form-grid">
               <Input
                 label="Portfolio title"
                 value={settings.title}
@@ -190,13 +190,13 @@ const PortfolioEditorPage: React.FC = () => {
                 onChange={event => handleUpdateSetting('subtitle', event.target.value)}
                 fullWidth
               />
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Introduction
+              <label className="form-control">
+                <span className="form-control__label">Introduction</span>
                 <textarea
                   value={settings.introduction}
                   onChange={event => handleUpdateSetting('introduction', event.target.value)}
                   rows={4}
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                 />
               </label>
               <Input
@@ -213,39 +213,36 @@ const PortfolioEditorPage: React.FC = () => {
                 placeholder="you@example.com"
                 fullWidth
               />
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Call to action
+              <label className="form-control">
+                <span className="form-control__label">Call to action</span>
                 <textarea
                   value={settings.callToAction ?? ''}
                   onChange={event => handleUpdateSetting('callToAction', event.target.value)}
                   rows={2}
-                  className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+                  className="form-control__textarea"
                   placeholder="Let’s collaborate on the next launch."
                 />
               </label>
             </div>
           </article>
 
-          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Selected case studies</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Reorder to control how projects appear.</p>
+          <article className="surface editor-card">
+            <h2 className="section-title">Selected case studies</h2>
+            <p className="section-subtitle">Reorder to control how projects appear.</p>
 
             {selectedProjects.length === 0 ? (
-              <p className="mt-6 text-sm text-gray-500 dark:text-gray-500">Pick a few projects from the list to build your showcase.</p>
+              <p className="form-control__helper">Pick a few projects from the list to build your showcase.</p>
             ) : (
-              <ul className="mt-4 space-y-3">
+              <ul className="project-selection__list" style={{ marginTop: '1rem' }}>
                 {selectedProjects.map(project => (
-                  <li
-                    key={project.slug}
-                    className="flex items-center justify-between gap-3 rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800/70"
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate font-medium">{project.title}</p>
-                      <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                  <li key={project.slug} className="project-selection__item">
+                    <div className="project-selection__meta" style={{ color: 'inherit' }}>
+                      <p style={{ margin: 0, fontWeight: 600 }}>{project.title}</p>
+                      <p className="project-selection__meta">
                         {project.summary || project.solution || project.problem || 'Add a summary in the case study editor.'}
                       </p>
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="project-selection__actions">
                       <Button
                         variant="outline"
                         size="sm"
@@ -262,11 +259,7 @@ const PortfolioEditorPage: React.FC = () => {
                       >
                         Down
                       </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleToggleProject(project.slug)}
-                      >
+                      <Button variant="ghost" size="sm" onClick={() => handleToggleProject(project.slug)}>
                         Remove
                       </Button>
                     </div>
@@ -276,25 +269,25 @@ const PortfolioEditorPage: React.FC = () => {
             )}
           </article>
 
-          <article className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Available projects</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          <article className="surface editor-card">
+            <h2 className="section-title">Available projects</h2>
+            <p className="section-subtitle">
               Tap any project to add it to the featured list. Already selected projects stay highlighted above.
             </p>
 
             {availableProjects.length === 0 ? (
-              <p className="mt-6 text-sm text-gray-500 dark:text-gray-500">All projects are already featured.</p>
+              <p className="form-control__helper">All projects are already featured.</p>
             ) : (
-              <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+              <ul className="project-selection__list" style={{ marginTop: '1rem' }}>
                 {availableProjects.map(project => (
                   <li key={project.slug}>
                     <button
                       type="button"
                       onClick={() => handleToggleProject(project.slug)}
-                      className="w-full rounded-2xl border border-gray-200 bg-white px-4 py-3 text-left text-sm shadow-sm transition hover:border-indigo-400 hover:shadow-md dark:border-gray-700 dark:bg-gray-800/70 dark:text-gray-100"
+                      className="project-selection__item"
                     >
-                      <p className="font-medium">{project.title}</p>
-                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      <p style={{ margin: 0, fontWeight: 600 }}>{project.title}</p>
+                      <p className="project-selection__meta">
                         {project.summary || project.solution || 'Craft the case study to add more context.'}
                       </p>
                     </button>
@@ -305,26 +298,21 @@ const PortfolioEditorPage: React.FC = () => {
           </article>
         </section>
 
-        <aside className="space-y-6">
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900/70">
-            <h2 className="text-lg font-semibold">Live preview</h2>
-            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Refresh to regenerate the layout from your current settings.</p>
-            <div className="mt-4 overflow-hidden rounded-2xl border border-gray-200 bg-slate-900/80 p-4 shadow-inner dark:border-gray-700">
-              <div
-                className="max-h-[520px] overflow-y-auto rounded-xl bg-black/50 text-sm"
-                dangerouslySetInnerHTML={{ __html: previewMarkup }}
-              />
+        <aside className="portfolio-editor-sidebar">
+          <section className="surface preview-panel">
+            <h2 className="section-title">Live preview</h2>
+            <p className="section-subtitle">Refresh to regenerate the layout from your current settings.</p>
+            <div className="preview-panel__frame">
+              <div dangerouslySetInnerHTML={{ __html: previewMarkup }} />
             </div>
           </section>
 
-          {statusMessage && (
-            <section className="rounded-3xl border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-900 shadow-sm dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-100">
-              <p className="flex items-center gap-2">
-                <CheckCircle2 className="h-4 w-4" />
-                {statusMessage}
-              </p>
+          {statusMessage ? (
+            <section className="status-banner">
+              <CheckCircle2 width={16} height={16} />
+              {statusMessage}
             </section>
-          )}
+          ) : null}
         </aside>
       </main>
     </div>

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { ArrowLeft, Loader2, Pencil } from 'lucide-react'
+import { ArrowLeft, Pencil } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
 import { buildPortfolioTemplate } from '../utils/portfolioTemplates'
 import { loadPortfolioDocument } from '../utils/portfolioStorage'
 import { listProjects } from '../utils/storageManager'
 import type { ProjectMeta } from '../intake/schema'
+import LoadingSpinner from '../components/ui/LoadingSpinner'
 
 type PortfolioViewDocument = { html: string; css: string }
 
@@ -50,58 +51,52 @@ const PortfolioPage: React.FC = () => {
   }, [document])
 
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <header className="border-b border-slate-800 bg-slate-950/80 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-6 lg:flex-row lg:items-center lg:justify-between">
+    <div className="portfolio-view">
+      <header className="portfolio-view__header">
+        <div className="portfolio-view__header-inner">
           <div className="flex items-center gap-4">
             <button
               type="button"
               onClick={() => navigate('/dashboard')}
-              className="inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-200 transition hover:bg-slate-800"
+              className="btn btn--outline"
             >
-              <ArrowLeft className="h-4 w-4" />
+              <ArrowLeft width={16} height={16} />
               Dashboard
             </button>
             <div>
-              <h1 className="text-xl font-semibold text-white">Portfolio</h1>
-              <p className="text-sm text-slate-400">A generated view of your saved projects and case studies.</p>
+              <h1 className="section-title" style={{ color: '#fff' }}>Portfolio</h1>
+              <p className="section-subtitle" style={{ color: 'rgba(226,232,240,0.7)' }}>
+                A generated view of your saved projects and case studies.
+              </p>
             </div>
           </div>
           <Link
             to="/portfolio/editor"
-            className="inline-flex items-center gap-2 rounded-lg bg-purple-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-purple-600"
+            className="btn btn--primary"
           >
-            <Pencil className="h-4 w-4" />
+            <Pencil width={16} height={16} />
             Edit portfolio
           </Link>
         </div>
       </header>
 
-      <main className="mx-auto max-w-6xl px-4 py-10">
+      <main className="portfolio-view__body">
         {isLoading ? (
-          <div className="flex h-[60vh] items-center justify-center rounded-2xl border border-dashed border-slate-700 bg-slate-900/40">
-            <div className="flex items-center gap-2 text-sm text-slate-400">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Preparing portfolio…
-            </div>
-          </div>
+          <LoadingSpinner size="lg" text="Preparing portfolio…" centered />
         ) : error ? (
-          <div className="rounded-2xl border border-red-400 bg-red-500/10 p-6 text-red-200">
+          <div className="portfolio-view__error">
             {error}
           </div>
         ) : document ? (
-          <div
-            className="portfolio-render rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-2xl"
-            dangerouslySetInnerHTML={{ __html: markup }}
-          />
+          <div className="portfolio-view__panel" dangerouslySetInnerHTML={{ __html: markup }} />
         ) : (
-          <div className="rounded-2xl border border-slate-800 bg-slate-900/40 p-6 text-sm text-slate-300">
+          <div className="portfolio-view__empty">
             No portfolio content yet. Create a project and craft a case study to populate this page.
           </div>
         )}
 
         {!isLoading && projects.length === 0 && (
-          <div className="mt-6 rounded-xl border border-slate-800 bg-slate-900/60 p-5 text-sm text-slate-300">
+          <div className="portfolio-view__empty" style={{ marginTop: '1.5rem' }}>
             Tip: Start by creating a project from the dashboard. The editor will generate a starter case study for you.
           </div>
         )}

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -1,0 +1,898 @@
+/* Shared UI styles for the redesigned front end */
+
+.app-page {
+  min-height: 100vh;
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-page__header {
+  border-bottom: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+.app-page__header-inner {
+  margin: 0 auto;
+  width: min(1160px, 100%);
+  padding: var(--spacing-lg) var(--spacing-lg);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-lg);
+}
+
+.app-page__body {
+  flex: 1;
+  width: min(1160px, 100%);
+  margin: 0 auto;
+  padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-2xl);
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.surface {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 24px;
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.surface--raised {
+  box-shadow: var(--shadow-lg);
+}
+
+.surface--tinted {
+  background: color-mix(in srgb, var(--color-primary-500) 8%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-primary-500) 20%, var(--color-border));
+}
+
+.section-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: var(--spacing-sm);
+}
+
+.section-subtitle {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.stats-grid {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+@media (min-width: 640px) {
+  .stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .stats-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.stat-card {
+  border-radius: 20px;
+  padding: var(--spacing-lg);
+  display: grid;
+  gap: var(--spacing-sm);
+  position: relative;
+  overflow: hidden;
+}
+
+.stat-card__icon {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  opacity: 0.85;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.stat-card__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.75;
+}
+
+.stat-card__value {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.stat-card__description {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.form-grid {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.form-grid--two-column {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.form-control {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.form-control--full {
+  width: 100%;
+}
+
+.form-control__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.form-control__helper {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.form-control__helper--error {
+  color: #dc2626;
+}
+
+.input-shell {
+  position: relative;
+}
+
+.input-shell__icon {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-secondary);
+  pointer-events: none;
+}
+
+.input-shell__icon--left {
+  left: 0.9rem;
+}
+
+.input-shell__icon--right {
+  right: 0.9rem;
+}
+
+.form-control__input,
+.form-control__textarea {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  color: var(--color-text-primary);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.form-control__input--error {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 1px rgba(220, 38, 38, 0.2);
+}
+
+.form-control__input--with-left-icon {
+  padding-left: 2.6rem;
+}
+
+.form-control__input--with-right-icon {
+  padding-right: 2.6rem;
+}
+
+.form-control__input:focus,
+.form-control__textarea:focus {
+  outline: none;
+  border-color: var(--color-primary-500);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.form-control__textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.upload-dropzone {
+  border: 2px dashed var(--color-border);
+  border-radius: 20px;
+  padding: var(--spacing-xl);
+  display: grid;
+  justify-items: center;
+  gap: var(--spacing-sm);
+  text-align: center;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.upload-dropzone:hover {
+  border-color: var(--color-primary-500);
+  transform: translateY(-2px);
+  color: var(--color-primary-500);
+}
+
+.asset-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.asset-list__item {
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-surface) 95%, transparent);
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.asset-list__meta {
+  min-width: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.asset-list__name {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-list__description,
+.asset-list__type {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.preview-frame {
+  border-radius: 24px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.8);
+  color: #f8fafc;
+  padding: var(--spacing-lg);
+  max-height: 460px;
+  overflow-y: auto;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.status-banner {
+  border-radius: 20px;
+  padding: var(--spacing-md);
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  background: rgba(16, 185, 129, 0.1);
+  color: #065f46;
+}
+
+.loading-spinner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.loading-spinner--centered {
+  min-height: 7rem;
+  width: 100%;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 0.75rem;
+}
+
+.loading-spinner__icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  animation: spin 1s linear infinite;
+  color: var(--color-primary-600);
+}
+
+.loading-spinner__text {
+  font-size: 0.95rem;
+}
+
+.dark .loading-spinner__icon {
+  color: var(--color-primary-400);
+}
+
+.toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: var(--z-modal);
+  display: grid;
+  gap: var(--spacing-sm);
+  width: min(320px, calc(100vw - 32px));
+}
+
+.toast {
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-md);
+  background: color-mix(in srgb, var(--color-surface) 96%, transparent);
+  box-shadow: var(--shadow-lg);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: start;
+  gap: var(--spacing-sm);
+}
+
+.toast__content {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.toast__message {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.toast__meta {
+  margin: 0;
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--color-text-secondary) 90%, #9ca3af);
+}
+
+.toast--success {
+  border-color: rgba(34, 197, 94, 0.35);
+  background: rgba(34, 197, 94, 0.12);
+  color: #166534;
+}
+
+.toast--error {
+  border-color: rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.12);
+  color: #7f1d1d;
+}
+
+.toast--warning {
+  border-color: rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.12);
+  color: #78350f;
+}
+
+.toast--info {
+  border-color: rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.6rem 1.1rem;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.btn--primary {
+  background: var(--color-primary-600);
+  color: white;
+  border-color: color-mix(in srgb, var(--color-primary-600) 80%, transparent);
+}
+
+.btn--primary:hover:not(:disabled) {
+  background: var(--color-primary-700);
+}
+
+.btn--outline {
+  background: transparent;
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
+}
+
+.btn--outline:hover:not(:disabled) {
+  border-color: var(--color-primary-500);
+  color: var(--color-primary-600);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--color-text-secondary);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  color: var(--color-primary-600);
+  background: color-mix(in srgb, var(--color-primary-500) 12%, transparent);
+}
+
+.btn--danger {
+  background: #dc2626;
+  color: white;
+  border-color: rgba(220, 38, 38, 0.75);
+}
+
+.btn--danger:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.btn--secondary {
+  background: var(--color-text-secondary);
+  color: white;
+}
+
+.btn--sm {
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--radius-md);
+}
+
+.btn--lg {
+  font-size: 1.05rem;
+  padding: 0.75rem 1.3rem;
+}
+
+.btn--full {
+  width: 100%;
+}
+
+.btn__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dark .btn--outline {
+  border-color: color-mix(in srgb, var(--color-border) 80%, transparent);
+  color: var(--color-text-primary);
+}
+
+.dark .btn--outline:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--color-primary-500) 55%, var(--color-border));
+}
+
+.dark .btn--ghost {
+  color: color-mix(in srgb, var(--color-text-secondary) 90%, #fff);
+}
+
+.dark .btn--ghost:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-surface) 70%, transparent);
+}
+
+.dark .app-page__header {
+  background: color-mix(in srgb, var(--color-surface) 60%, transparent);
+}
+
+.dark .surface,
+.dark .surface--raised {
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  border-color: color-mix(in srgb, var(--color-border) 80%, transparent);
+}
+
+.dark .surface--tinted {
+  background: color-mix(in srgb, var(--color-primary-500) 18%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-primary-500) 40%, var(--color-border));
+}
+
+.dark .upload-dropzone {
+  background: color-mix(in srgb, var(--color-surface) 80%, transparent);
+}
+
+.dark .asset-list__item {
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+}
+
+.dark .status-banner {
+  background: rgba(16, 185, 129, 0.18);
+  color: rgba(209, 250, 229, 0.95);
+  border-color: rgba(16, 185, 129, 0.45);
+}
+
+.dark .preview-frame {
+  background: rgba(15, 23, 42, 0.9);
+}
+
+@media (max-width: 720px) {
+  .app-page__header-inner {
+    padding: var(--spacing-lg);
+  }
+  .app-page__body {
+    padding: var(--spacing-lg);
+  }
+}
+
+/* Dashboard */
+.dashboard-hero {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.dashboard-hero__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  background: color-mix(in srgb, var(--color-primary-500) 16%, transparent);
+}
+
+.dashboard-hero__title {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.dashboard-list {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.dashboard-project {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.dashboard-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.dashboard-toolbar__search {
+  flex: 1 1 260px;
+  min-width: 220px;
+}
+
+.dashboard-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.dashboard-project__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.dashboard-project__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dashboard-project__tag {
+  font-size: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-primary-500) 12%, transparent);
+  color: color-mix(in srgb, var(--color-primary-600) 80%, var(--color-text-primary));
+  text-transform: lowercase;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: color-mix(in srgb, var(--color-text-secondary) 14%, transparent);
+  color: color-mix(in srgb, var(--color-text-secondary) 70%, var(--color-text-primary));
+}
+
+.dashboard-empty {
+  display: grid;
+  place-items: center;
+  min-height: 200px;
+  color: var(--color-text-secondary);
+}
+
+.dashboard-workflow {
+  border-radius: 24px;
+  padding: var(--spacing-lg);
+  background: color-mix(in srgb, var(--color-primary-500) 10%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-primary-500) 25%, var(--color-border));
+}
+
+.dashboard-workflow ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  color: color-mix(in srgb, var(--color-primary-900) 85%, var(--color-text-primary));
+}
+
+.dark .dashboard-workflow {
+  background: color-mix(in srgb, var(--color-primary-500) 18%, var(--color-surface));
+}
+
+/* Intake */
+.intake-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-lg);
+}
+
+.intake-header__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.intake-body {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.intake-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.intake-actions__note {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+/* Editor */
+.editor-layout {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+@media (min-width: 1024px) {
+  .editor-layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  }
+}
+
+.editor-card {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.editor-grid {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.editor-textarea {
+  min-height: 140px;
+}
+
+.editor-sidebar {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.editor-status {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+/* Portfolio view */
+.portfolio-view {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #0f172a, #020617);
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+}
+
+.portfolio-view__header {
+  border-bottom: 1px solid rgba(100, 116, 139, 0.4);
+  background: rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(12px);
+}
+
+.portfolio-view__header-inner {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-lg);
+}
+
+.portfolio-view__body {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-2xl);
+  flex: 1;
+}
+
+.portfolio-view__panel {
+  border-radius: 32px;
+  border: 1px solid rgba(100, 116, 139, 0.4);
+  background: rgba(15, 23, 42, 0.75);
+  padding: var(--spacing-xl);
+  box-shadow: 0 30px 60px -40px rgba(2, 6, 23, 0.85);
+}
+
+.portfolio-view__empty,
+.portfolio-view__error {
+  border-radius: 24px;
+  border: 1px solid rgba(100, 116, 139, 0.4);
+  padding: var(--spacing-lg);
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+/* Portfolio editor */
+.portfolio-editor-grid {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+@media (min-width: 1024px) {
+  .portfolio-editor-grid {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  }
+}
+
+.portfolio-editor-sidebar {
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.project-selection {
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.project-selection__list {
+  display: grid;
+  gap: var(--spacing-sm);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.project-selection__item {
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: var(--spacing-md);
+  display: grid;
+  gap: 0.5rem;
+  background: color-mix(in srgb, var(--color-surface) 95%, transparent);
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.project-selection__item:hover {
+  border-color: var(--color-primary-500);
+  transform: translateY(-1px);
+}
+
+.project-selection__meta {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.project-selection__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.preview-panel {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.preview-panel__frame {
+  border-radius: 24px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.85);
+  padding: var(--spacing-lg);
+  color: #e2e8f0;
+  max-height: 520px;
+  overflow: auto;
+}
+
+.dark .project-selection__item {
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+}
+
+.dark .preview-panel__frame {
+  background: rgba(15, 23, 42, 0.92);
+}
+
+/* Theme toggle */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  padding: 0.35rem 0.75rem;
+  background: color-mix(in srgb, var(--color-surface) 95%, transparent);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.dark .theme-toggle {
+  background: color-mix(in srgb, var(--color-surface) 85%, transparent);
+}


### PR DESCRIPTION
## Summary
- introduce a shared ui.css stylesheet that defines reusable page layouts, cards, form controls, and toast styling to support the refreshed look and feel
- rework dashboard, intake, editor, and portfolio pages to use the new design system classes and improved structural layout while preserving existing functionality
- update reusable components (buttons, inputs, spinners, notifications, theme toggle) to match the new styling primitives and ensure consistent interactions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceaab56344832f99ca78c2f2a9f675