### PR TITLE
Fix startup scripts to use apps web frontend

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -2,9 +2,12 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-FRONTEND_DIR="$ROOT_DIR"
-if [[ -f "$ROOT_DIR/portfolio-intake/package.json" ]]; then
+if [[ -f "$ROOT_DIR/apps/web/package.json" ]]; then
+  FRONTEND_DIR="$ROOT_DIR/apps/web"
+elif [[ -f "$ROOT_DIR/portfolio-intake/package.json" ]]; then
   FRONTEND_DIR="$ROOT_DIR/portfolio-intake"
+else
+  FRONTEND_DIR="$ROOT_DIR"
 fi
 FRONTEND_NAME="$(basename "$FRONTEND_DIR")"
 FRONTEND_ONLY=0

--- a/start-macos.sh
+++ b/start-macos.sh
@@ -25,8 +25,15 @@ SPARKLES="✨"
 # Resolve project paths
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$SCRIPT_DIR"
-FRONTEND_DIR="$PROJECT_ROOT"
-# Use the main project root for frontend (not the portfolio-intake subdirectory)
+
+if [ -f "$PROJECT_ROOT/apps/web/package.json" ]; then
+    FRONTEND_DIR="$PROJECT_ROOT/apps/web"
+elif [ -f "$PROJECT_ROOT/portfolio-intake/package.json" ]; then
+    FRONTEND_DIR="$PROJECT_ROOT/portfolio-intake"
+else
+    FRONTEND_DIR="$PROJECT_ROOT"
+fi
+
 FRONTEND_NAME="$(basename "$FRONTEND_DIR")"
 
 cd "$PROJECT_ROOT"

--- a/start.ps1
+++ b/start.ps1
@@ -20,8 +20,14 @@ $Colors = @{
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 
+$WorkspaceFrontendPath = Join-Path $ScriptDir "apps/web"
 $PortfolioFrontendPath = Join-Path $ScriptDir "portfolio-intake"
-if (Test-Path (Join-Path $PortfolioFrontendPath "package.json")) {
+
+if (Test-Path (Join-Path $WorkspaceFrontendPath "package.json")) {
+    $FrontendPath = $WorkspaceFrontendPath
+    $FrontendName = Split-Path $FrontendPath -Leaf
+}
+elseif (Test-Path (Join-Path $PortfolioFrontendPath "package.json")) {
     $FrontendPath = $PortfolioFrontendPath
     $FrontendName = Split-Path $FrontendPath -Leaf
 }

--- a/start.sh
+++ b/start.sh
@@ -5,9 +5,13 @@
 
 # Resolve project paths
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FRONTEND_DIR="$PROJECT_ROOT"
-if [ -f "$PROJECT_ROOT/portfolio-intake/package.json" ]; then
+
+if [ -f "$PROJECT_ROOT/apps/web/package.json" ]; then
+    FRONTEND_DIR="$PROJECT_ROOT/apps/web"
+elif [ -f "$PROJECT_ROOT/portfolio-intake/package.json" ]; then
     FRONTEND_DIR="$PROJECT_ROOT/portfolio-intake"
+else
+    FRONTEND_DIR="$PROJECT_ROOT"
 fi
 FRONTEND_NAME="$(basename "$FRONTEND_DIR")"
 


### PR DESCRIPTION
## Summary
- update all startup scripts to prioritise the apps/web workspace when launching the frontend
- keep backwards compatibility by falling back to the legacy portfolio-intake and repository root when needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf06009aa8832fb7b9baf1cdf215ea