### PR TITLE
feat: refresh dashboard layout

### DIFF
--- a/src/pages/DashboardPage.css
+++ b/src/pages/DashboardPage.css
@@ -1,0 +1,1211 @@
+.dashboard-app-shell {
+  --color-navy: #1e3cff;
+  --color-sky: #55a3f4;
+  --color-teal: #00bfa5;
+  --color-magenta: #ff55f5;
+  --color-light: #ffffff;
+  --color-ink: #1b1d33;
+  --color-ink-soft: #46506d;
+  --color-ink-muted: #6e7696;
+  --color-background: #eef3ff;
+  --color-surface: rgba(255, 255, 255, 0.92);
+  --color-surface-muted: rgba(255, 255, 255, 0.75);
+  --shadow-soft: 0 20px 60px -32px rgba(30, 60, 255, 0.35);
+  --shadow-strong: 0 36px 80px -46px rgba(255, 85, 245, 0.35);
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --transition-base: 200ms ease;
+
+  min-height: 100vh;
+  display: flex;
+  color: var(--color-ink);
+  background:
+    linear-gradient(140deg, rgba(30, 60, 255, 0.08) 0%, rgba(85, 163, 244, 0.12) 45%, rgba(0, 191, 165, 0.08) 100%),
+    var(--color-background);
+}
+
+.dashboard-sidebar {
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 32px 28px;
+  background:
+    linear-gradient(185deg, rgba(30, 60, 255, 0.96) 0%, rgba(30, 60, 255, 0.92) 45%, rgba(0, 191, 165, 0.9) 100%);
+  color: var(--color-light);
+  border-right: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: var(--shadow-soft);
+  transition: transform 240ms ease, opacity 240ms ease;
+  transform: translateX(0);
+  opacity: 1;
+  z-index: 30;
+}
+
+.dashboard-sidebar--desktop {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.dashboard-sidebar--mobile {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: min(320px, 88vw);
+  transform: translateX(-100%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.dashboard-sidebar--mobile.dashboard-sidebar--open {
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.dashboard-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dashboard-sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.dashboard-sidebar__mark {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 85, 245, 0.4));
+  display: grid;
+  place-items: center;
+  color: var(--color-light);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.dashboard-sidebar__title {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.dashboard-sidebar__subtitle {
+  display: block;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dashboard-sidebar__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+}
+
+.dashboard-sidebar nav {
+  margin-top: 12px;
+}
+
+.dashboard-sidebar__nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.dashboard-sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  color: rgba(255, 255, 255, 0.78);
+  border-radius: 14px;
+  transition: background var(--transition-base), color var(--transition-base), transform var(--transition-base);
+}
+
+.dashboard-sidebar__link:hover,
+.dashboard-sidebar__link:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--color-light);
+  transform: translateX(4px);
+}
+
+.dashboard-sidebar__link.is-active {
+  background: linear-gradient(135deg, rgba(85, 163, 244, 0.3), rgba(0, 191, 165, 0.35));
+  color: var(--color-light);
+  box-shadow: 0 18px 42px -28px rgba(0, 0, 0, 0.45);
+}
+
+.dashboard-sidebar__footer {
+  margin-top: auto;
+  padding: 20px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  display: grid;
+  gap: 12px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.dashboard-sidebar__footer-heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  color: var(--color-light);
+}
+
+.dashboard-sidebar__footer-body {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.9rem;
+}
+
+.dashboard-sidebar__footer-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: var(--radius-sm);
+  border: none;
+  padding: 10px 14px;
+  font-weight: 500;
+  color: var(--color-light);
+  background: linear-gradient(135deg, rgba(255, 85, 245, 0.45), rgba(85, 163, 244, 0.45));
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.dashboard-sidebar__footer-action:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px -28px rgba(255, 255, 255, 0.6);
+}
+
+.dashboard-sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  border: none;
+  background: rgba(19, 25, 56, 0.55);
+  backdrop-filter: blur(3px);
+  z-index: 20;
+}
+
+.dashboard-workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.dashboard-topbar {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 24px clamp(16px, 4vw, 40px);
+  background: var(--color-surface);
+  border-bottom: 1px solid rgba(30, 60, 255, 0.08);
+  box-shadow: var(--shadow-soft);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.dashboard-topbar__menu {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(30, 60, 255, 0.18);
+  background: rgba(85, 163, 244, 0.12);
+  color: var(--color-navy);
+  cursor: pointer;
+  transition: background var(--transition-base), transform var(--transition-base);
+}
+
+.dashboard-topbar__menu:hover {
+  background: rgba(85, 163, 244, 0.2);
+  transform: translateY(-2px);
+}
+
+.dashboard-topbar__search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(30, 60, 255, 0.12);
+  padding: 10px 16px;
+  color: var(--color-ink-soft);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.dashboard-topbar__search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.dashboard-topbar__search input:focus-visible {
+  outline: none;
+}
+
+.dashboard-topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dashboard-icon-button {
+  width: 42px;
+  height: 42px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(30, 60, 255, 0.12);
+  background: rgba(85, 163, 244, 0.15);
+  color: var(--color-navy);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.dashboard-icon-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px -22px rgba(30, 60, 255, 0.4);
+}
+
+.dashboard-user-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(85, 163, 244, 0.18);
+  border-radius: 999px;
+  padding: 8px 18px;
+  border: 1px solid rgba(30, 60, 255, 0.18);
+  cursor: pointer;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.dashboard-user-pill:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px -28px rgba(30, 60, 255, 0.35);
+}
+
+.dashboard-user-pill__avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(85, 163, 244, 0.4), rgba(255, 85, 245, 0.4));
+  color: var(--color-light);
+}
+
+.dashboard-user-pill__meta {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.dashboard-user-pill__name {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.dashboard-user-pill__role {
+  font-size: 0.75rem;
+  color: var(--color-ink-muted);
+}
+
+.dashboard-workspace__content {
+  flex: 1;
+  padding: clamp(24px, 4vw, 48px);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  position: relative;
+  z-index: 1;
+}
+
+.dashboard-workspace__content::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top right, rgba(85, 163, 244, 0.18), transparent 55%),
+    radial-gradient(circle at 20% 30%, rgba(255, 85, 245, 0.18), transparent 60%);
+  z-index: -1;
+}
+
+.page-heading {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.dashboard-page-heading__eyebrow {
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  color: var(--color-ink-muted);
+}
+
+.dashboard-page-heading__title {
+  margin: 6px 0;
+  font-size: clamp(1.8rem, 2.8vw, 2.6rem);
+  color: var(--color-ink);
+}
+
+.dashboard-page-heading__description {
+  margin: 0;
+  max-width: 520px;
+  color: var(--color-ink-soft);
+  font-size: 0.95rem;
+}
+
+.dashboard-timeframe-toggle {
+  display: inline-flex;
+  gap: 8px;
+  background: var(--color-surface-muted);
+  padding: 8px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(30, 60, 255, 0.14);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.dashboard-timeframe-toggle__button {
+  border: none;
+  padding: 8px 18px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-ink-soft);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base), transform var(--transition-base);
+}
+
+.dashboard-timeframe-toggle__button.is-active {
+  background: linear-gradient(135deg, rgba(30, 60, 255, 0.18), rgba(85, 163, 244, 0.22));
+  color: var(--color-navy);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.dashboard-metrics-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.dashboard-metric-card {
+  padding: 22px;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid rgba(30, 60, 255, 0.08);
+  display: grid;
+  gap: 14px;
+  box-shadow: var(--shadow-soft);
+}
+
+.dashboard-metric-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dashboard-metric-card__title {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.dashboard-metric-card__trend {
+  font-size: 0.85rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(85, 163, 244, 0.15);
+  font-weight: 600;
+}
+
+.dashboard-metric-card__trend--positive {
+  color: var(--color-teal);
+}
+
+.dashboard-metric-card__trend--negative {
+  color: var(--color-magenta);
+}
+
+.dashboard-metric-card__value {
+  font-size: 1.9rem;
+  font-weight: 600;
+  color: var(--color-navy);
+}
+
+.dashboard-metric-card__description {
+  margin: 0;
+  color: var(--color-ink-muted);
+  font-size: 0.85rem;
+}
+
+.dashboard-primary-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+}
+
+.dashboard-secondary-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+}
+
+.dashboard-secondary-grid__column {
+  display: grid;
+  gap: 24px;
+}
+
+.dashboard-card {
+  padding: 26px;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid rgba(30, 60, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: var(--shadow-soft);
+}
+
+.dashboard-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.dashboard-card__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-ink);
+}
+
+.dashboard-card__subtitle {
+  margin: 4px 0 0;
+  color: var(--color-ink-muted);
+  font-size: 0.9rem;
+}
+
+.dashboard-card__trend,
+.dashboard-card__hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(85, 163, 244, 0.15);
+  border-radius: 999px;
+  padding: 6px 14px;
+  color: var(--color-navy);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.dashboard-revenue-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 18px;
+}
+
+.dashboard-revenue-summary__label {
+  display: block;
+  color: var(--color-ink-muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.dashboard-revenue-summary__value {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-navy);
+}
+
+.revenue-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  height: 200px;
+}
+
+.dashboard-revenue-chart__column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.dashboard-revenue-chart__bar {
+  width: 100%;
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.dashboard-revenue-chart__bar-total {
+  width: 70%;
+  border-radius: 999px 999px 16px 16px;
+  background: linear-gradient(180deg, rgba(85, 163, 244, 0.75), rgba(30, 60, 255, 0.35));
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.dashboard-revenue-chart__bar-profit {
+  width: 100%;
+  border-radius: inherit;
+  background: linear-gradient(180deg, rgba(0, 191, 165, 0.95), rgba(0, 191, 165, 0.35));
+}
+
+.dashboard-revenue-chart__label {
+  font-size: 0.85rem;
+  color: var(--color-ink-muted);
+}
+
+.dashboard-team-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 18px;
+}
+
+.dashboard-team-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 18px;
+  align-items: center;
+}
+
+.dashboard-team-list__avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: var(--color-light);
+  box-shadow: 0 14px 30px -24px rgba(0, 0, 0, 0.5);
+}
+
+.dashboard-team-list__content {
+  display: grid;
+  gap: 10px;
+}
+
+.dashboard-team-list__heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dashboard-team-list__name {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.dashboard-team-list__role {
+  color: var(--color-ink-muted);
+  font-size: 0.85rem;
+}
+
+.dashboard-team-list__focus {
+  margin: 0;
+  color: var(--color-ink-soft);
+  font-size: 0.85rem;
+}
+
+.dashboard-team-list__progress {
+  height: 6px;
+  background: rgba(85, 163, 244, 0.16);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.dashboard-team-list__progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(0, 191, 165, 0.9), rgba(85, 163, 244, 0.9));
+  border-radius: inherit;
+}
+
+.dashboard-team-list__metrics {
+  display: grid;
+  text-align: right;
+  gap: 6px;
+}
+
+.dashboard-team-list__metric-label {
+  font-size: 0.75rem;
+  color: var(--color-ink-muted);
+}
+
+.dashboard-team-list__metric-value {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.dashboard-table-scroll {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.dashboard-pipeline-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 680px;
+  font-size: 0.92rem;
+}
+
+.dashboard-pipeline-table th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0 0 12px;
+  color: var(--color-ink-soft);
+  border-bottom: 1px solid rgba(30, 60, 255, 0.1);
+}
+
+.dashboard-pipeline-table td {
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(30, 60, 255, 0.08);
+  color: var(--color-ink);
+}
+
+.dashboard-align-right {
+  text-align: right;
+}
+
+.dashboard-pipeline-project {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dashboard-pipeline-project__code {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(85, 163, 244, 0.18);
+  color: var(--color-navy);
+}
+
+.dashboard-pipeline-project__name {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.dashboard-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 0.78rem;
+  padding: 6px 12px;
+  border-radius: 999px;
+  letter-spacing: 0.02em;
+}
+
+.dashboard-status-badge--positive {
+  background: rgba(0, 191, 165, 0.18);
+  color: var(--color-teal);
+}
+
+.dashboard-status-badge--warning {
+  background: rgba(255, 85, 245, 0.18);
+  color: var(--color-magenta);
+}
+
+.dashboard-status-badge--danger {
+  background: rgba(255, 85, 245, 0.3);
+  color: var(--color-magenta);
+}
+
+.dashboard-status-badge--neutral {
+  background: rgba(30, 60, 255, 0.18);
+  color: var(--color-navy);
+}
+
+.dashboard-progress {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dashboard-progress__track {
+  position: relative;
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(85, 163, 244, 0.18);
+  overflow: hidden;
+}
+
+.dashboard-progress__bar {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(0, 191, 165, 0.9), rgba(85, 163, 244, 0.9));
+  transition: width var(--transition-base);
+}
+
+.dashboard-progress__value {
+  font-weight: 600;
+  color: var(--color-ink);
+  min-width: 3ch;
+}
+
+.dashboard-channel-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 14px;
+}
+
+.dashboard-channel-summary__label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--color-ink-muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.dashboard-channel-summary__value {
+  display: block;
+  margin-top: 4px;
+  font-weight: 600;
+  color: var(--color-navy);
+}
+
+.dashboard-channel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.dashboard-channel-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: baseline;
+  padding-bottom: 14px;
+  border-bottom: 1px solid rgba(30, 60, 255, 0.08);
+}
+
+.dashboard-channel-list__item:last-child {
+  border-bottom: none;
+}
+
+.dashboard-channel-list__name {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.dashboard-channel-list__details {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--color-ink-muted);
+  margin-top: 4px;
+}
+
+.dashboard-channel-list__metrics {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  font-weight: 600;
+}
+
+.dashboard-channel-list__rate {
+  color: var(--color-teal);
+}
+
+.dashboard-channel-list__trend {
+  color: var(--color-magenta);
+  font-size: 0.85rem;
+}
+
+.dashboard-announcement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 18px;
+}
+
+.dashboard-announcement-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.dashboard-announcement-list__icon {
+  width: 38px;
+  height: 38px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(135deg, rgba(255, 85, 245, 0.35), rgba(85, 163, 244, 0.35));
+  display: grid;
+  place-items: center;
+  color: var(--color-light);
+}
+
+.dashboard-announcement-list__heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.dashboard-announcement-list__title {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.dashboard-announcement-list__date {
+  color: var(--color-ink-muted);
+  font-size: 0.85rem;
+}
+
+.dashboard-announcement-list__message {
+  margin: 6px 0 0;
+  color: var(--color-ink-soft);
+  font-size: 0.9rem;
+}
+
+@media (min-width: 960px) {
+  .dashboard-sidebar__close {
+    display: none;
+  }
+
+  .dashboard-sidebar--desktop {
+    transform: none !important;
+    opacity: 1 !important;
+    pointer-events: auto !important;
+  }
+
+  .dashboard-topbar__menu {
+    display: none;
+  }
+}
+
+@media (max-width: 1200px) {
+  .dashboard-primary-grid,
+  .dashboard-secondary-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 1024px) {
+  .dashboard-secondary-grid__column {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dashboard-portfolio-card {
+  display: grid;
+  gap: 24px;
+}
+
+.dashboard-portfolio-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.dashboard-portfolio-stats {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.48);
+  box-shadow: inset 0 0 0 1px rgba(30, 60, 255, 0.12);
+}
+
+.dashboard-portfolio-stat-label {
+  display: block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(27, 29, 51, 0.55);
+  margin-bottom: 4px;
+}
+
+.dashboard-portfolio-stat-value {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: var(--color-ink);
+}
+
+.dashboard-portfolio-list {
+  display: grid;
+  gap: 18px;
+}
+
+.dashboard-portfolio-empty {
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  border-radius: var(--radius-md);
+  background: rgba(27, 29, 51, 0.05);
+  color: var(--color-ink-muted);
+  font-size: 0.95rem;
+}
+
+.dashboard-portfolio-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 18px;
+}
+
+.dashboard-portfolio-project {
+  display: grid;
+  gap: 14px;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(30, 60, 255, 0.12);
+}
+
+.dashboard-portfolio-project__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.dashboard-portfolio-project__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--color-ink);
+}
+
+.dashboard-portfolio-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(27, 29, 51, 0.7);
+  background: rgba(30, 60, 255, 0.1);
+}
+
+.dashboard-portfolio-summary {
+  margin: 0;
+  color: var(--color-ink-soft);
+  font-size: 0.95rem;
+}
+
+.dashboard-portfolio-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 0.85rem;
+  color: var(--color-ink-muted);
+}
+
+.dashboard-portfolio-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.dashboard-portfolio-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  background: rgba(30, 60, 255, 0.14);
+  color: rgba(27, 29, 51, 0.75);
+}
+
+.dashboard-portfolio-project__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.dark .dashboard-portfolio-stats {
+  background: rgba(0, 0, 0, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.dark .dashboard-portfolio-card {
+  color: var(--color-light);
+}
+
+.dark .dashboard-portfolio-summary {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.dark .dashboard-portfolio-meta {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.dark .dashboard-portfolio-tag {
+  background: rgba(85, 163, 244, 0.22);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+@media (max-width: 960px) {
+  .dashboard-app-shell {
+    flex-direction: column;
+  }
+
+  .dashboard-workspace {
+    min-height: 100vh;
+  }
+
+  .dashboard-topbar {
+    position: static;
+    border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  }
+
+  .dashboard-workspace__content {
+    padding-top: 24px;
+  }
+}
+
+@media (max-width: 780px) {
+  .dashboard-topbar {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .dashboard-topbar__actions {
+    margin-left: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-topbar {
+    gap: 16px;
+  }
+
+  .dashboard-topbar__search {
+    order: 3;
+    width: 100%;
+  }
+
+  .dashboard-topbar__actions {
+    order: 2;
+  }
+
+  .dashboard-timeframe-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .dashboard-metrics-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-table-scroll {
+    overflow-x: visible;
+  }
+
+  .dashboard-pipeline-table {
+    min-width: 0;
+  }
+
+  .dashboard-pipeline-table thead {
+    display: none;
+  }
+
+  .dashboard-pipeline-table tbody {
+    display: grid;
+    gap: 18px;
+  }
+
+  .dashboard-pipeline-table tr {
+    display: grid;
+    gap: 12px;
+    padding: 18px;
+    border: 1px solid rgba(30, 60, 255, 0.08);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-soft);
+  }
+
+  .dashboard-pipeline-table td {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 0;
+    border: none;
+  }
+
+  .dashboard-pipeline-table td::before {
+    content: attr(data-title);
+    font-weight: 600;
+    color: var(--color-ink-soft);
+  }
+
+  .dashboard-pipeline-table td.dashboard-align-right {
+    justify-content: space-between;
+    text-align: left;
+  }
+
+  .dashboard-progress {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .dashboard-progress__value {
+    align-self: flex-end;
+  }
+}
+
+@media (max-width: 520px) {
+  .dashboard-topbar__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .dashboard-user-pill {
+    flex: 1;
+    justify-content: space-between;
+  }
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,17 +1,30 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
-  ArrowRightCircle,
+  Activity,
+  ArrowUpRight,
+  BarChart3,
+  Bell,
+  CheckCircle2,
+  ChevronDown,
   Download,
   FileText,
-  Folder,
   Layers,
+  LayoutDashboard,
+  Menu,
   Plus,
-  RefreshCw,
+  Search,
+  Settings,
+  ShieldCheck,
+  Sparkles,
+  Target,
   Trash2,
+  TrendingUp,
   Upload,
+  Users,
+  X,
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
-import { Button, Input, LoadingSpinner } from '../components/ui'
+import { Button, LoadingSpinner } from '../components/ui'
 import { useApp } from '../contexts/AppContext'
 import {
   deleteProject,
@@ -21,6 +34,22 @@ import {
 } from '../utils/storageManager'
 import type { ProjectMeta } from '../intake/schema'
 import ThemeToggle from '../components/ThemeToggle'
+import {
+  DASHBOARD_TIMEFRAMES,
+  buildDashboardSnapshot,
+  defaultDashboardTimeframe,
+  formatCurrency,
+  formatNumber,
+  formatPercentage,
+  type Announcement,
+  type ChannelPerformance,
+  type DashboardSnapshot,
+  type DashboardTimeframe,
+  type Metric,
+  type PipelineItem,
+  type TeamMember,
+} from '../utils/dashboardData'
+import './DashboardPage.css'
 
 export type ApiAssetPreview = {
   id: string
@@ -216,7 +245,7 @@ export const DeliverablePreviewList: React.FC<{ deliverables: ApiDeliverablePrev
   </section>
 )
 
-const formatDate = (value?: string) => {
+const formatProjectDate = (value?: string) => {
   if (!value) {
     return 'Just created'
   }
@@ -244,6 +273,514 @@ const downloadJson = (filename: string, payload: unknown) => {
 const countCaseStudiesReady = (projects: ProjectMeta[]) =>
   projects.filter(project => Boolean(project.caseStudyContent?.overview || project.caseStudyHtml)).length
 
+const NAVIGATION_ITEMS: Array<{ label: string; icon: React.ComponentType<{ size?: number }> }> = [
+  { label: 'Overview', icon: LayoutDashboard },
+  { label: 'Analytics', icon: BarChart3 },
+  { label: 'Projects', icon: Activity },
+  { label: 'Team', icon: Users },
+  { label: 'Settings', icon: Settings },
+]
+
+const TIMEFRAME_LABELS: Record<DashboardTimeframe, string> = {
+  week: 'Weekly',
+  month: 'Monthly',
+  quarter: 'Quarterly',
+  year: 'Yearly',
+}
+
+const TIMEFRAME_DESCRIPTION: Record<DashboardTimeframe, string> = {
+  week: 'A real-time look at momentum across the current sprint.',
+  month: 'A strategic overview of performance across the current month.',
+  quarter: 'Quarterly health across pipeline, revenue, and delivery.',
+  year: 'An annual perspective on growth, retention, and utilisation.',
+}
+
+type MetricCardProps = {
+  metric: Metric
+}
+
+const MetricCard: React.FC<MetricCardProps> = ({ metric }) => {
+  const isPositive = metric.direction === 'up'
+  const formattedValue =
+    metric.unit === 'currency'
+      ? formatCurrency(metric.value)
+      : metric.unit === 'percentage'
+        ? formatPercentage(metric.value)
+        : formatNumber(metric.value)
+
+  return (
+    <article className="dashboard-metric-card" aria-label={`${metric.label} summary`}>
+      <header className="dashboard-metric-card__header">
+        <span className="dashboard-metric-card__title">{metric.label}</span>
+        <span
+          className={`dashboard-metric-card__trend dashboard-metric-card__trend--${isPositive ? 'positive' : 'negative'}`}
+          aria-label={`Change ${metric.direction === 'up' ? 'upward' : 'downward'} ${formatPercentage(metric.change)}`}
+        >
+          {isPositive ? '▲' : '▼'} {formatPercentage(metric.change)}
+        </span>
+      </header>
+      <p className="dashboard-metric-card__value">{formattedValue}</p>
+      <p className="dashboard-metric-card__description">{metric.description}</p>
+    </article>
+  )
+}
+
+type RevenuePanelProps = {
+  snapshot: DashboardSnapshot
+}
+
+const RevenuePanel: React.FC<RevenuePanelProps> = ({ snapshot }) => {
+  const revenueMetric = snapshot.metrics.find(candidate => candidate.id === 'revenue')
+  const trendLabel = revenueMetric
+    ? `${revenueMetric.direction === 'up' ? '+' : '−'}${formatPercentage(revenueMetric.change)}`
+    : 'Stable vs previous period'
+  const chartMax = snapshot.revenue.series.length > 0
+    ? Math.max(...snapshot.revenue.series.map(point => point.revenue), 1)
+    : 1
+
+  return (
+    <section className="dashboard-card dashboard-revenue-card" aria-labelledby="dashboard-revenue-heading">
+      <header className="dashboard-card__header">
+        <div>
+          <h2 id="dashboard-revenue-heading">Revenue overview</h2>
+          <p className="dashboard-card__subtitle">Revenue and profit trends for the selected timeframe.</p>
+        </div>
+        <div className="dashboard-card__trend">
+          <TrendingUp size={16} aria-hidden="true" />
+          <span>{trendLabel}</span>
+        </div>
+      </header>
+
+      <div className="dashboard-revenue-summary">
+        <div>
+          <span className="dashboard-revenue-summary__label">Total revenue</span>
+          <span className="dashboard-revenue-summary__value">{formatCurrency(snapshot.revenue.totalRevenue)}</span>
+        </div>
+        <div>
+          <span className="dashboard-revenue-summary__label">Net profit</span>
+          <span className="dashboard-revenue-summary__value">{formatCurrency(snapshot.revenue.totalProfit)}</span>
+        </div>
+        <div>
+          <span className="dashboard-revenue-summary__label">Average margin</span>
+          <span className="dashboard-revenue-summary__value">{formatPercentage(snapshot.revenue.averageMargin)}</span>
+        </div>
+      </div>
+
+      <div className="dashboard-revenue-chart" role="list" aria-label="Revenue trend chart">
+        {snapshot.revenue.series.map(point => {
+          const revenueHeight = chartMax === 0 ? 0 : Math.round((point.revenue / chartMax) * 100)
+          const profitHeight = point.revenue === 0 ? 0 : Math.round((point.profit / point.revenue) * 100)
+          return (
+            <div key={point.label} className="dashboard-revenue-chart__column" role="listitem">
+              <div className="dashboard-revenue-chart__bar" aria-hidden="true">
+                <span
+                  className="dashboard-revenue-chart__bar-total"
+                  style={{ height: `${revenueHeight}%` }}
+                >
+                  <span
+                    className="dashboard-revenue-chart__bar-profit"
+                    style={{ height: `${profitHeight}%` }}
+                  />
+                </span>
+              </div>
+              <span className="dashboard-revenue-chart__label">{point.label}</span>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+type PipelineTableProps = {
+  items: PipelineItem[]
+}
+
+const pipelineStatusTone: Record<PipelineItem['status'], 'positive' | 'warning' | 'danger' | 'neutral'> = {
+  Completed: 'positive',
+  'In review': 'warning',
+  'In progress': 'neutral',
+  'At risk': 'danger',
+}
+
+const PipelineTable: React.FC<PipelineTableProps> = ({ items }) => (
+  <section className="dashboard-card dashboard-pipeline-card" aria-labelledby="dashboard-pipeline-heading">
+    <header className="dashboard-card__header">
+      <div>
+        <h2 id="dashboard-pipeline-heading">Project pipeline</h2>
+        <p className="dashboard-card__subtitle">Active client engagements across discovery, delivery, and QA.</p>
+      </div>
+      <div className="dashboard-card__hint">
+        <CheckCircle2 size={16} aria-hidden="true" />
+        <span>{formatNumber(items.filter(item => item.status === 'Completed').length)} completed</span>
+      </div>
+    </header>
+
+    <div className="dashboard-table-scroll">
+      <table className="dashboard-pipeline-table">
+        <thead>
+          <tr>
+            <th scope="col">Project</th>
+            <th scope="col">Client</th>
+            <th scope="col">Status</th>
+            <th scope="col">Progress</th>
+            <th scope="col" className="dashboard-align-right">Budget</th>
+            <th scope="col">Due</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(item => (
+            <tr key={item.id}>
+              <td data-title="Project">
+                <div className="dashboard-pipeline-project">
+                  <span className="dashboard-pipeline-project__code">{item.id}</span>
+                  <span className="dashboard-pipeline-project__name">{item.project}</span>
+                </div>
+              </td>
+              <td data-title="Client">{item.client}</td>
+              <td data-title="Status">
+                <span className={`dashboard-status-badge dashboard-status-badge--${pipelineStatusTone[item.status]}`}>
+                  {item.status}
+                </span>
+              </td>
+              <td data-title="Progress">
+                <div className="dashboard-progress">
+                  <span className="dashboard-progress__track">
+                    <span className="dashboard-progress__bar" style={{ width: `${item.progress}%` }} />
+                  </span>
+                  <span className="dashboard-progress__value">{item.progress}%</span>
+                </div>
+              </td>
+              <td data-title="Budget" className="dashboard-align-right">{formatCurrency(item.amount)}</td>
+              <td data-title="Due">{formatShortDate(item.dueDate)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  </section>
+)
+
+type TeamListProps = {
+  members: TeamMember[]
+}
+
+const TeamList: React.FC<TeamListProps> = ({ members }) => {
+  const maxContribution = members.length > 0 ? Math.max(...members.map(member => member.contributions), 1) : 1
+
+  return (
+    <section className="dashboard-card dashboard-team-card" aria-labelledby="dashboard-team-heading">
+      <header className="dashboard-card__header">
+        <div>
+          <h2 id="dashboard-team-heading">Team focus</h2>
+          <p className="dashboard-card__subtitle">Allocation, contributions, and current focus areas.</p>
+        </div>
+        <div className="dashboard-card__hint">
+          <Users size={16} aria-hidden="true" />
+          <span>{formatNumber(members.length)} key contributors</span>
+        </div>
+      </header>
+      <ul className="dashboard-team-list">
+        {members.map(member => (
+          <li key={member.id} className="dashboard-team-list__item">
+            <span className="dashboard-team-list__avatar" style={{ backgroundColor: member.avatarColor }} aria-hidden="true">
+              {getInitials(member.name)}
+            </span>
+            <div className="dashboard-team-list__content">
+              <div className="dashboard-team-list__heading">
+                <span className="dashboard-team-list__name">{member.name}</span>
+                <span className="dashboard-team-list__role">{member.role}</span>
+              </div>
+              <p className="dashboard-team-list__focus">Current focus: {member.focus}</p>
+              <div className="dashboard-team-list__progress" aria-label={`${member.contributions} contributions`}>
+                <span
+                  className="dashboard-team-list__progress-bar"
+                  style={{ width: `${Math.round((member.contributions / maxContribution) * 100)}%` }}
+                />
+              </div>
+            </div>
+            <div className="dashboard-team-list__metrics">
+              <span className="dashboard-team-list__metric-label">Contributions</span>
+              <span className="dashboard-team-list__metric-value">{formatNumber(member.contributions)}</span>
+              <span className="dashboard-team-list__metric-label">Hours</span>
+              <span className="dashboard-team-list__metric-value">{formatNumber(member.hours)}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+type ChannelListProps = {
+  channels: ChannelPerformance[]
+  summary: DashboardSnapshot['channelSummary']
+}
+
+const ChannelList: React.FC<ChannelListProps> = ({ channels, summary }) => (
+  <section className="dashboard-card dashboard-channel-card" aria-labelledby="dashboard-channel-heading">
+    <header className="dashboard-card__header">
+      <div>
+        <h2 id="dashboard-channel-heading">Growth channels</h2>
+        <p className="dashboard-card__subtitle">Lead generation and conversion performance.</p>
+      </div>
+      <div className="dashboard-channel-summary">
+        <div>
+          <span className="dashboard-channel-summary__label">Leads</span>
+          <span className="dashboard-channel-summary__value">{formatNumber(summary.totalLeads)}</span>
+        </div>
+        <div>
+          <span className="dashboard-channel-summary__label">Top channel</span>
+          <span className="dashboard-channel-summary__value">{summary.strongestChannel.channel}</span>
+        </div>
+        <div>
+          <span className="dashboard-channel-summary__label">Avg. conversion</span>
+          <span className="dashboard-channel-summary__value">{formatPercentage(summary.averageConversion)}</span>
+        </div>
+      </div>
+    </header>
+    <ul className="dashboard-channel-list">
+      {channels.map(channel => (
+        <li key={channel.id} className="dashboard-channel-list__item">
+          <div>
+            <span className="dashboard-channel-list__name">{channel.channel}</span>
+            <span className="dashboard-channel-list__details">
+              {formatNumber(channel.leads)} leads • {formatNumber(channel.opportunities)} opportunities
+            </span>
+          </div>
+          <div className="dashboard-channel-list__metrics">
+            <span className="dashboard-channel-list__rate">{formatPercentage(channel.conversionRate)}</span>
+            <span className="dashboard-channel-list__trend">+{formatPercentage(channel.trend)}</span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  </section>
+)
+
+type AnnouncementListProps = {
+  items: Announcement[]
+}
+
+const AnnouncementList: React.FC<AnnouncementListProps> = ({ items }) => (
+  <section className="dashboard-card dashboard-announcement-card" aria-labelledby="dashboard-announcement-heading">
+    <header className="dashboard-card__header">
+      <div>
+        <h2 id="dashboard-announcement-heading">Updates</h2>
+        <p className="dashboard-card__subtitle">Operational updates and enablement highlights for the team.</p>
+      </div>
+    </header>
+    <ul className="dashboard-announcement-list">
+      {items.map(item => (
+        <li key={item.id} className="dashboard-announcement-list__item">
+          <div className="dashboard-announcement-list__icon" aria-hidden="true">
+            <Sparkles size={16} />
+          </div>
+          <div className="dashboard-announcement-list__content">
+            <div className="dashboard-announcement-list__heading">
+              <span className="dashboard-announcement-list__title">{item.title}</span>
+              <span className="dashboard-announcement-list__date">{formatShortDate(item.date)}</span>
+            </div>
+            <p className="dashboard-announcement-list__message">{item.message}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  </section>
+)
+
+const formatShortDate = (value: string): string => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return '—'
+  }
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+const getInitials = (name: string): string => {
+  const parts = name.split(' ').filter(Boolean)
+  if (parts.length === 0) {
+    return 'T'
+  }
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2).toUpperCase()
+  }
+  return `${parts[0]!.charAt(0)}${parts[parts.length - 1]!.charAt(0)}`.toUpperCase()
+}
+
+type PortfolioProjectsCardProps = {
+  projects: ProjectMeta[]
+  totalProjects: number
+  stats: { totalProjects: number; caseStudiesReady: number; totalAssets: number }
+  storageUsage: { used: number; available: number; percentage: number } | null
+  onImportClick: () => void
+  onExportAll: () => void
+  onExportProject: (project: ProjectMeta) => void
+  onDeleteProject: (slug: string) => void
+  fileInputRef: React.RefObject<HTMLInputElement>
+  onImportChange: React.ChangeEventHandler<HTMLInputElement>
+  isImporting: boolean
+  searchQuery: string
+  isLoading: boolean
+}
+
+const PortfolioProjectsCard: React.FC<PortfolioProjectsCardProps> = ({
+  projects,
+  totalProjects,
+  stats,
+  storageUsage,
+  onImportClick,
+  onExportAll,
+  onExportProject,
+  onDeleteProject,
+  fileInputRef,
+  onImportChange,
+  isImporting,
+  searchQuery,
+  isLoading,
+}) => {
+  const hasProjects = totalProjects > 0
+  const emptyMessage = hasProjects
+    ? searchQuery
+      ? `No projects match “${searchQuery}”.`
+      : 'No projects match your filters.'
+    : 'No projects yet. Start by creating your first project intake.'
+
+  return (
+    <section className="dashboard-card dashboard-portfolio-card" aria-labelledby="dashboard-portfolio-heading">
+      <header className="dashboard-card__header">
+        <div>
+          <h2 id="dashboard-portfolio-heading">Portfolio projects</h2>
+          <p className="dashboard-card__subtitle">
+            Manage local case studies, imports, and exports from your browser.
+          </p>
+        </div>
+        <div className="dashboard-portfolio-actions">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            hidden
+            onChange={onImportChange}
+          />
+          <Button
+            variant="outline"
+            onClick={onImportClick}
+            leftIcon={<Upload size={16} />}
+            loading={isImporting}
+          >
+            Import JSON
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={onExportAll}
+            leftIcon={<Download size={16} />}
+            disabled={!hasProjects}
+          >
+            Export all
+          </Button>
+        </div>
+      </header>
+
+      <div className="dashboard-portfolio-stats" role="list">
+        <div role="listitem">
+          <span className="dashboard-portfolio-stat-label">Projects</span>
+          <span className="dashboard-portfolio-stat-value">{stats.totalProjects}</span>
+        </div>
+        <div role="listitem">
+          <span className="dashboard-portfolio-stat-label">Case studies ready</span>
+          <span className="dashboard-portfolio-stat-value">{stats.caseStudiesReady}</span>
+        </div>
+        <div role="listitem">
+          <span className="dashboard-portfolio-stat-label">Assets</span>
+          <span className="dashboard-portfolio-stat-value">{stats.totalAssets}</span>
+        </div>
+        <div role="listitem">
+          <span className="dashboard-portfolio-stat-label">Storage</span>
+          <span className="dashboard-portfolio-stat-value">
+            {storageUsage
+              ? `${storageUsage.used}MB • ${storageUsage.percentage}% of ${storageUsage.available}MB`
+              : 'Unavailable'}
+          </span>
+        </div>
+      </div>
+
+      <div className="dashboard-portfolio-list">
+        {isLoading ? (
+          <div className="dashboard-portfolio-empty">
+            <LoadingSpinner size="md" text="Loading your projects..." />
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="dashboard-portfolio-empty">{emptyMessage}</div>
+        ) : (
+          <ul className="dashboard-portfolio-items">
+            {projects.map(project => (
+              <li key={project.slug} className="dashboard-portfolio-project">
+                <div className="dashboard-portfolio-project__header">
+                  <div>
+                    <h3 className="dashboard-portfolio-project__title">{project.title}</h3>
+                    <span className="dashboard-portfolio-status">
+                      {project.status === 'draft'
+                        ? 'Draft'
+                        : project.status === 'cast'
+                          ? 'In review'
+                          : 'Published'}
+                    </span>
+                  </div>
+                  <div className="dashboard-portfolio-project__actions button-row">
+                    <Button
+                      as={Link}
+                      to={`/editor/${project.slug}`}
+                      variant="primary"
+                      size="sm"
+                      leftIcon={<FileText size={16} />}
+                    >
+                      Case study
+                    </Button>
+                    <Button
+                      onClick={() => onExportProject(project)}
+                      variant="outline"
+                      size="sm"
+                      leftIcon={<Download size={16} />}
+                    >
+                      Export
+                    </Button>
+                    <Button
+                      onClick={() => onDeleteProject(project.slug)}
+                      variant="danger"
+                      size="sm"
+                      leftIcon={<Trash2 size={16} />}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+                {project.summary ? (
+                  <p className="dashboard-portfolio-summary">{project.summary}</p>
+                ) : null}
+                <div className="dashboard-portfolio-meta">
+                  <span>{project.assets.length} assets</span>
+                  <span>Updated {formatProjectDate(project.updatedAt)}</span>
+                  <span>{project.caseStudyContent?.overview ? 'Narrative ready' : 'Needs narrative'}</span>
+                </div>
+                {project.tags.length > 0 ? (
+                  <div className="dashboard-portfolio-tags">
+                    {project.tags.slice(0, 5).map(tag => (
+                      <span key={tag} className="dashboard-portfolio-tag">
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}
+
 const DashboardPage: React.FC = () => {
   const { addNotification } = useApp()
 
@@ -252,7 +789,12 @@ const DashboardPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [storageUsage, setStorageUsage] = useState<{ used: number; available: number; percentage: number } | null>(null)
   const [isImporting, setIsImporting] = useState(false)
+  const [isSidebarOpen, setSidebarOpen] = useState(false)
+  const [isDesktop, setIsDesktop] = useState(false)
+  const [timeframe, setTimeframe] = useState<DashboardTimeframe>(defaultDashboardTimeframe)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const snapshot = useMemo(() => buildDashboardSnapshot(timeframe), [timeframe])
 
   const refreshProjects = useCallback(async () => {
     setIsLoading(true)
@@ -274,6 +816,32 @@ const DashboardPage: React.FC = () => {
   useEffect(() => {
     void refreshProjects()
   }, [refreshProjects])
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 960px)')
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsDesktop(event.matches)
+      if (event.matches) {
+        setSidebarOpen(false)
+      }
+    }
+
+    setIsDesktop(mediaQuery.matches)
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange)
+    } else {
+      mediaQuery.addListener(handleChange)
+    }
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === 'function') {
+        mediaQuery.removeEventListener('change', handleChange)
+      } else {
+        mediaQuery.removeListener(handleChange)
+      }
+    }
+  }, [])
 
   const filteredProjects = useMemo(() => {
     if (!searchQuery) {
@@ -350,243 +918,201 @@ const DashboardPage: React.FC = () => {
     }
   }
 
-  if (isLoading) {
-    return (
-      <div className="app-page">
-        <main
-          className="app-page__body"
-          style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '60vh' }}
-        >
-          <LoadingSpinner size="lg" text="Loading your projects..." centered />
-        </main>
-      </div>
-    )
+  const toggleSidebar = () => {
+    if (isDesktop) {
+      return
+    }
+    setSidebarOpen(previous => !previous)
   }
 
+  const closeSidebar = () => {
+    if (!isDesktop) {
+      setSidebarOpen(false)
+    }
+  }
+
+  const handleNavigation = () => {
+    if (!isDesktop) {
+      setSidebarOpen(false)
+    }
+  }
+
+  const isSidebarVisible = isDesktop || isSidebarOpen
+
   return (
-    <div className="app-page">
-      <header className="app-page__header">
-        <div className="app-page__header-inner">
-          <div className="dashboard-hero">
-            <div className="dashboard-hero__icon">
-              <Folder width={28} height={28} />
+    <div className="dashboard-app-shell">
+      {!isDesktop && isSidebarOpen ? (
+        <button type="button" className="dashboard-sidebar-overlay" onClick={closeSidebar} aria-label="Close navigation" />
+      ) : null}
+      <aside
+        id="dashboard-primary-navigation"
+        className={[
+          'dashboard-sidebar',
+          isDesktop ? 'dashboard-sidebar--desktop' : 'dashboard-sidebar--mobile',
+          isSidebarVisible ? 'dashboard-sidebar--open' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        aria-label="Primary navigation"
+        aria-hidden={!isDesktop && !isSidebarOpen}
+      >
+        <div className="dashboard-sidebar__header">
+          <div className="dashboard-sidebar__brand">
+            <div className="dashboard-sidebar__mark" aria-hidden="true">
+              <ShieldCheck size={24} />
             </div>
             <div>
-              <h1 className="dashboard-hero__title">Portfolio control centre</h1>
-              <p className="section-subtitle">
-                Capture project details, manage files locally, and generate polished narratives.
-              </p>
+              <span className="dashboard-sidebar__title">PortfolioForge</span>
+              <span className="dashboard-sidebar__subtitle">Control centre</span>
             </div>
           </div>
-          <div className="button-row">
+          {!isDesktop && (
+            <button type="button" className="dashboard-sidebar__close" onClick={closeSidebar} aria-label="Close navigation">
+              <X size={18} />
+            </button>
+          )}
+        </div>
+        <nav>
+          <ul className="dashboard-sidebar__nav">
+            {NAVIGATION_ITEMS.map(item => (
+              <li key={item.label}>
+                <a
+                  className={`dashboard-sidebar__link${item.label === 'Overview' ? ' is-active' : ''}`}
+                  href="#"
+                  onClick={event => {
+                    event.preventDefault()
+                    handleNavigation()
+                  }}
+                >
+                  <item.icon size={16} aria-hidden="true" />
+                  <span>{item.label}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <div className="dashboard-sidebar__footer">
+          <div className="dashboard-sidebar__footer-heading">
+            <Target size={16} aria-hidden="true" />
+            <span>Quarterly target</span>
+          </div>
+          <p className="dashboard-sidebar__footer-body">
+            Tracking ahead of plan. Maintain inbound cadence and delivery velocity.
+          </p>
+          <button type="button" className="dashboard-sidebar__footer-action">
+            <ArrowUpRight size={16} aria-hidden="true" />
+            View playbook
+          </button>
+        </div>
+      </aside>
+
+      <div className="dashboard-workspace">
+        <header className="dashboard-topbar">
+          <button
+            type="button"
+            className="dashboard-topbar__menu"
+            aria-label="Toggle navigation"
+            aria-controls="dashboard-primary-navigation"
+            aria-expanded={isDesktop ? true : isSidebarOpen}
+            onClick={toggleSidebar}
+          >
+            <Menu size={18} />
+          </button>
+          <div className="dashboard-topbar__search">
+            <Search size={16} aria-hidden="true" />
+            <input
+              type="search"
+              placeholder="Search projects, clients, and docs"
+              aria-label="Search dashboard"
+              value={searchQuery}
+              onChange={event => setSearchQuery(event.target.value)}
+            />
+          </div>
+          <div className="dashboard-topbar__actions">
+            <button type="button" className="dashboard-icon-button" aria-label="Notifications">
+              <Bell size={18} />
+            </button>
             <ThemeToggle />
-            <Button as={Link} to="/portfolio" variant="outline" leftIcon={<Layers size={18} />}>
+            <div className="dashboard-user-pill" role="button" tabIndex={0} aria-label="Account menu">
+              <div className="dashboard-user-pill__avatar" aria-hidden="true">
+                <Users size={16} />
+              </div>
+              <div className="dashboard-user-pill__meta">
+                <span className="dashboard-user-pill__name">Nova Martinez</span>
+                <span className="dashboard-user-pill__role">Operations lead</span>
+              </div>
+              <ChevronDown size={16} aria-hidden="true" />
+            </div>
+            <Button as={Link} to="/portfolio" variant="outline" leftIcon={<Layers size={16} />}>
               View portfolio
             </Button>
-            <Button as={Link} to="/create" variant="primary" leftIcon={<Plus size={18} />}>
+            <Button as={Link} to="/create" variant="primary" leftIcon={<Plus size={16} />}>
               New project
             </Button>
           </div>
-        </div>
-      </header>
+        </header>
 
-      <main className="app-page__body">
-        <section className="stats-grid">
-          <article
-            className="stat-card surface"
-            style={{ background: 'linear-gradient(135deg, #eef2ff, #e0e7ff)' }}
-          >
-            <div className="stat-card__icon">
-              <Folder width={18} height={18} />
-            </div>
-            <span className="stat-card__label">Projects</span>
-            <span className="stat-card__value">{stats.totalProjects}</span>
-            <p className="stat-card__description">All projects are saved locally in your browser.</p>
-          </article>
-
-          <article
-            className="stat-card surface"
-            style={{ background: 'linear-gradient(135deg, #f3e8ff, #ede9fe)' }}
-          >
-            <div className="stat-card__icon">
-              <FileText width={18} height={18} />
-            </div>
-            <span className="stat-card__label">Case studies ready</span>
-            <span className="stat-card__value">{stats.caseStudiesReady}</span>
-            <p className="stat-card__description">
-              AI-assisted narratives make these projects portfolio-ready.
-            </p>
-          </article>
-
-          <article
-            className="stat-card surface"
-            style={{ background: 'linear-gradient(135deg, #e0f2fe, #bae6fd)' }}
-          >
-            <div className="stat-card__icon">
-              <Upload width={18} height={18} />
-            </div>
-            <span className="stat-card__label">Assets</span>
-            <span className="stat-card__value">{stats.totalAssets}</span>
-            <p className="stat-card__description">Upload images and files directly into each project.</p>
-          </article>
-
-          <article
-            className="stat-card surface"
-            style={{ background: 'linear-gradient(135deg, #dcfce7, #bbf7d0)' }}
-          >
-            <div className="stat-card__icon">
-              <RefreshCw width={18} height={18} />
-            </div>
-            <span className="stat-card__label">Storage used</span>
-            <span className="stat-card__value">
-              {storageUsage ? `${storageUsage.used}MB` : '—'}
-            </span>
-            <p className="stat-card__description">
-              {storageUsage
-                ? `Approx. ${storageUsage.percentage}% of ${storageUsage.available}MB local capacity`
-                : 'Storage usage unavailable'}
-            </p>
-          </article>
-        </section>
-
-        <section className="surface surface--raised">
-          <div
-            style={{
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: '1.5rem',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              borderBottom: '1px solid var(--color-border)',
-              paddingBottom: '1.5rem',
-              marginBottom: '1.5rem',
-            }}
-          >
+        <main className="dashboard-workspace__content">
+          <section className="dashboard-page-heading">
             <div>
-              <h2 className="section-title">Local projects</h2>
-              <p className="section-subtitle">Search, export, or jump straight into the case study editor.</p>
+              <span className="dashboard-page-heading__eyebrow">PortfolioForge</span>
+              <h1 className="dashboard-page-heading__title">Control centre</h1>
+              <p className="dashboard-page-heading__description">{TIMEFRAME_DESCRIPTION[timeframe]}</p>
             </div>
-            <div className="dashboard-toolbar">
-              <div className="dashboard-toolbar__search">
-                <Input
-                  placeholder="Search projects"
-                  value={searchQuery}
-                  onChange={event => setSearchQuery(event.target.value)}
-                  leftIcon={<ArrowRightCircle width={16} height={16} />}
-                  fullWidth
-                />
-              </div>
-              <div className="dashboard-toolbar__actions">
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="application/json"
-                  hidden
-                  onChange={handleImport}
-                />
-                <Button
-                  variant="outline"
-                  onClick={() => fileInputRef.current?.click()}
-                  leftIcon={<Upload width={16} height={16} />}
-                  loading={isImporting}
+            <div className="dashboard-timeframe-toggle" role="group" aria-label="Select timeframe">
+              {DASHBOARD_TIMEFRAMES.map(option => (
+                <button
+                  key={option}
+                  type="button"
+                  className={`dashboard-timeframe-toggle__button${option === timeframe ? ' is-active' : ''}`}
+                  onClick={() => setTimeframe(option)}
+                  aria-pressed={option === timeframe}
                 >
-                  Import
-                </Button>
-                <Button
-                  variant="ghost"
-                  onClick={() => downloadJson('portfolio-projects.json', projects)}
-                  leftIcon={<Download width={16} height={16} />}
-                  disabled={projects.length === 0}
-                >
-                  Export all
-                </Button>
-              </div>
+                  {TIMEFRAME_LABELS[option]}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="dashboard-metrics-grid">
+            {snapshot.metrics.map(metric => (
+              <MetricCard key={metric.id} metric={metric} />
+            ))}
+          </section>
+
+          <div className="dashboard-primary-grid">
+            <RevenuePanel snapshot={snapshot} />
+            <TeamList members={snapshot.team} />
+          </div>
+
+          <div className="dashboard-secondary-grid">
+            <PipelineTable items={snapshot.pipeline} />
+            <div className="dashboard-secondary-grid__column">
+              <ChannelList channels={snapshot.channels} summary={snapshot.channelSummary} />
+              <AnnouncementList items={snapshot.highlights} />
             </div>
           </div>
 
-          {filteredProjects.length === 0 ? (
-            <div className="dashboard-empty">
-              {projects.length === 0
-                ? 'No projects yet. Start by creating your first project intake.'
-                : 'No projects match your search.'}
-            </div>
-          ) : (
-            <ul className="dashboard-list">
-              {filteredProjects.map(project => (
-                <li key={project.slug} className="dashboard-project">
-                  <div>
-                    <div className="button-row" style={{ justifyContent: 'flex-start' }}>
-                      <h3 style={{ margin: 0, fontSize: '1.05rem' }}>{project.title}</h3>
-                      <span className="status-pill">
-                        {project.status === 'draft' ? 'Draft' : project.status === 'cast' ? 'In review' : 'Published'}
-                      </span>
-                    </div>
-                    {project.summary ? (
-                      <p className="section-subtitle" style={{ marginTop: '0.5rem' }}>
-                        {project.summary}
-                      </p>
-                    ) : null}
-                    <div className="dashboard-project__meta">
-                      <span>{project.assets.length} assets</span>
-                      <span>Updated {formatDate(project.updatedAt)}</span>
-                      <span>{project.caseStudyContent?.overview ? 'Narrative ready' : 'Needs narrative'}</span>
-                    </div>
-                    {project.tags.length > 0 ? (
-                      <div className="dashboard-project__tags">
-                        {project.tags.slice(0, 5).map(tag => (
-                          <span key={tag} className="dashboard-project__tag">
-                            #{tag}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-                  </div>
-                  <div className="button-row" style={{ justifyContent: 'flex-start' }}>
-                    <Button
-                      as={Link}
-                      to={`/editor/${project.slug}`}
-                      variant="primary"
-                      size="sm"
-                      leftIcon={<FileText width={16} height={16} />}
-                    >
-                      Case study
-                    </Button>
-                    <Button
-                      onClick={() => handleExport(project)}
-                      variant="outline"
-                      size="sm"
-                      leftIcon={<Download width={16} height={16} />}
-                    >
-                      Export
-                    </Button>
-                    <Button
-                      onClick={() => handleDelete(project.slug)}
-                      variant="danger"
-                      size="sm"
-                      leftIcon={<Trash2 width={16} height={16} />}
-                    >
-                      Delete
-                    </Button>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-
-        <section className="dashboard-workflow">
-          <h3 className="section-title" style={{ marginBottom: '0.75rem' }}>
-            Workflow tips
-          </h3>
-          <ol>
-            <li>Capture a project through the intake to gather narrative hooks and assets.</li>
-            <li>Use the case study editor to refine copy, upload visuals, and generate AI narratives.</li>
-            <li>Arrange your highlights in the portfolio editor before sharing or exporting.</li>
-          </ol>
-        </section>
-      </main>
+          <PortfolioProjectsCard
+            projects={filteredProjects}
+            totalProjects={projects.length}
+            stats={stats}
+            storageUsage={storageUsage}
+            onImportClick={() => fileInputRef.current?.click()}
+            onExportAll={() => downloadJson('portfolio-projects.json', projects)}
+            onExportProject={handleExport}
+            onDeleteProject={handleDelete}
+            fileInputRef={fileInputRef}
+            onImportChange={handleImport}
+            isImporting={isImporting}
+            searchQuery={searchQuery}
+            isLoading={isLoading}
+          />
+        </main>
+      </div>
     </div>
   )
 }
 
 export default DashboardPage
+

--- a/src/utils/dashboardData.ts
+++ b/src/utils/dashboardData.ts
@@ -1,0 +1,595 @@
+export type DashboardTimeframe = 'week' | 'month' | 'quarter' | 'year'
+
+type MetricUnit = 'currency' | 'count' | 'percentage'
+
+type Metric = {
+  id: string
+  label: string
+  value: number
+  unit: MetricUnit
+  change: number
+  direction: 'up' | 'down'
+  description: string
+}
+
+type RevenuePoint = {
+  label: string
+  revenue: number
+  profit: number
+}
+
+type OrderStatus = 'Completed' | 'In review' | 'In progress' | 'At risk'
+
+type PipelineItem = {
+  id: string
+  client: string
+  project: string
+  amount: number
+  status: OrderStatus
+  dueDate: string
+  progress: number
+}
+
+type TeamMember = {
+  id: string
+  name: string
+  role: string
+  avatarColor: string
+  contributions: number
+  focus: string
+  hours: number
+}
+
+type ChannelPerformance = {
+  id: string
+  channel: string
+  leads: number
+  opportunities: number
+  conversionRate: number
+  trend: number
+}
+
+type Announcement = {
+  id: string
+  title: string
+  message: string
+  date: string
+}
+
+export type DashboardSnapshot = {
+  timeframe: DashboardTimeframe
+  metrics: Metric[]
+  revenue: RevenueSummary
+  pipeline: PipelineItem[]
+  team: TeamMember[]
+  channels: ChannelPerformance[]
+  highlights: Announcement[]
+  channelSummary: ChannelSummary
+}
+
+type RevenueSummary = {
+  series: RevenuePoint[]
+  totalRevenue: number
+  totalProfit: number
+  averageMargin: number
+}
+
+type ChannelSummary = {
+  totalLeads: number
+  strongestChannel: ChannelPerformance
+  averageConversion: number
+}
+
+export const DASHBOARD_TIMEFRAMES: DashboardTimeframe[] = [
+  'week',
+  'month',
+  'quarter',
+  'year',
+]
+
+const DEFAULT_TIMEFRAME: DashboardTimeframe = 'month'
+
+const METRIC_DATA: Record<DashboardTimeframe, Metric[]> = {
+  week: [
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      value: 48250,
+      unit: 'currency',
+      change: 12.6,
+      direction: 'up',
+      description: 'vs last week',
+    },
+    {
+      id: 'active-clients',
+      label: 'Active clients',
+      value: 28,
+      unit: 'count',
+      change: 3.2,
+      direction: 'up',
+      description: '9 projects delivered on time',
+    },
+    {
+      id: 'conversion',
+      label: 'Proposal win rate',
+      value: 37.4,
+      unit: 'percentage',
+      change: 1.4,
+      direction: 'up',
+      description: 'Improved follow-up cadence',
+    },
+    {
+      id: 'utilisation',
+      label: 'Team utilisation',
+      value: 76,
+      unit: 'percentage',
+      change: 4.3,
+      direction: 'down',
+      description: 'Capacity available for rush work',
+    },
+  ],
+  month: [
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      value: 192400,
+      unit: 'currency',
+      change: 18.2,
+      direction: 'up',
+      description: 'vs last month',
+    },
+    {
+      id: 'active-clients',
+      label: 'Active clients',
+      value: 42,
+      unit: 'count',
+      change: 6.5,
+      direction: 'up',
+      description: '12 new retainers won',
+    },
+    {
+      id: 'conversion',
+      label: 'Proposal win rate',
+      value: 41.2,
+      unit: 'percentage',
+      change: 5.1,
+      direction: 'up',
+      description: 'Automation in outreach workflow',
+    },
+    {
+      id: 'utilisation',
+      label: 'Team utilisation',
+      value: 83,
+      unit: 'percentage',
+      change: 2.8,
+      direction: 'down',
+      description: 'Hiring pipeline opened',
+    },
+  ],
+  quarter: [
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      value: 562900,
+      unit: 'currency',
+      change: 11.4,
+      direction: 'up',
+      description: 'vs previous quarter',
+    },
+    {
+      id: 'active-clients',
+      label: 'Active clients',
+      value: 65,
+      unit: 'count',
+      change: 8.1,
+      direction: 'up',
+      description: 'Enterprise pipeline growth',
+    },
+    {
+      id: 'conversion',
+      label: 'Proposal win rate',
+      value: 44.3,
+      unit: 'percentage',
+      change: 3.9,
+      direction: 'up',
+      description: 'Improved discovery process',
+    },
+    {
+      id: 'utilisation',
+      label: 'Team utilisation',
+      value: 88,
+      unit: 'percentage',
+      change: 1.5,
+      direction: 'down',
+      description: 'Increased tooling efficiency',
+    },
+  ],
+  year: [
+    {
+      id: 'revenue',
+      label: 'Revenue',
+      value: 2104300,
+      unit: 'currency',
+      change: 24.7,
+      direction: 'up',
+      description: 'Year over year',
+    },
+    {
+      id: 'active-clients',
+      label: 'Active clients',
+      value: 112,
+      unit: 'count',
+      change: 15.4,
+      direction: 'up',
+      description: 'Portfolio diversification',
+    },
+    {
+      id: 'conversion',
+      label: 'Proposal win rate',
+      value: 46.1,
+      unit: 'percentage',
+      change: 6.2,
+      direction: 'up',
+      description: 'Advisory services introduced',
+    },
+    {
+      id: 'utilisation',
+      label: 'Team utilisation',
+      value: 86,
+      unit: 'percentage',
+      change: 3.7,
+      direction: 'down',
+      description: 'Scaled creative operations',
+    },
+  ],
+}
+
+const REVENUE_DATA: Record<DashboardTimeframe, RevenuePoint[]> = {
+  week: [
+    { label: 'Mon', revenue: 5800, profit: 2100 },
+    { label: 'Tue', revenue: 6400, profit: 2600 },
+    { label: 'Wed', revenue: 7200, profit: 2900 },
+    { label: 'Thu', revenue: 6900, profit: 2700 },
+    { label: 'Fri', revenue: 5400, profit: 2100 },
+    { label: 'Sat', revenue: 4300, profit: 1700 },
+    { label: 'Sun', revenue: 3650, profit: 1400 },
+  ],
+  month: [
+    { label: 'Week 1', revenue: 42000, profit: 16300 },
+    { label: 'Week 2', revenue: 45800, profit: 17200 },
+    { label: 'Week 3', revenue: 51800, profit: 19100 },
+    { label: 'Week 4', revenue: 52700, profit: 19800 },
+  ],
+  quarter: [
+    { label: 'Jan', revenue: 172000, profit: 61500 },
+    { label: 'Feb', revenue: 186500, profit: 67100 },
+    { label: 'Mar', revenue: 204400, profit: 74200 },
+  ],
+  year: [
+    { label: 'Q1', revenue: 552000, profit: 196200 },
+    { label: 'Q2', revenue: 512600, profit: 184300 },
+    { label: 'Q3', revenue: 516800, profit: 182900 },
+    { label: 'Q4', revenue: 524900, profit: 187600 },
+  ],
+}
+
+const PIPELINE_DATA: Record<DashboardTimeframe, PipelineItem[]> = {
+  week: [
+    {
+      id: 'PX-1024',
+      client: 'Atlas Fintech',
+      project: 'Mobile banking onboarding',
+      amount: 18200,
+      status: 'In progress',
+      dueDate: '2025-01-18',
+      progress: 64,
+    },
+    {
+      id: 'PX-1011',
+      client: 'Greenline Energy',
+      project: 'Analytics portal redesign',
+      amount: 26800,
+      status: 'In review',
+      dueDate: '2025-01-15',
+      progress: 82,
+    },
+    {
+      id: 'PX-1008',
+      client: 'Northwind Labs',
+      project: 'Product launch microsite',
+      amount: 9400,
+      status: 'In progress',
+      dueDate: '2025-01-22',
+      progress: 47,
+    },
+  ],
+  month: [
+    {
+      id: 'PX-1036',
+      client: 'Stellar Networks',
+      project: 'Enterprise dashboard system',
+      amount: 74200,
+      status: 'In progress',
+      dueDate: '2025-02-04',
+      progress: 58,
+    },
+    {
+      id: 'PX-1021',
+      client: 'Helix Bio',
+      project: 'Clinical research workspace',
+      amount: 52300,
+      status: 'In review',
+      dueDate: '2025-01-28',
+      progress: 76,
+    },
+    {
+      id: 'PX-1014',
+      client: 'Marble & Co.',
+      project: 'Immersive showroom experience',
+      amount: 38600,
+      status: 'Completed',
+      dueDate: '2024-12-19',
+      progress: 100,
+    },
+    {
+      id: 'PX-1009',
+      client: 'Nimbus Aviation',
+      project: 'Brand system expansion',
+      amount: 24800,
+      status: 'At risk',
+      dueDate: '2025-02-11',
+      progress: 35,
+    },
+  ],
+  quarter: [
+    {
+      id: 'PX-1055',
+      client: 'Silverline Logistics',
+      project: 'Operations control tower',
+      amount: 98200,
+      status: 'In progress',
+      dueDate: '2025-03-30',
+      progress: 44,
+    },
+    {
+      id: 'PX-1042',
+      client: 'Cardinal Health',
+      project: 'Supply planning suite',
+      amount: 117400,
+      status: 'In review',
+      dueDate: '2025-04-12',
+      progress: 61,
+    },
+    {
+      id: 'PX-1031',
+      client: 'Aurora Travel',
+      project: 'Omnichannel booking platform',
+      amount: 84600,
+      status: 'Completed',
+      dueDate: '2024-11-18',
+      progress: 100,
+    },
+    {
+      id: 'PX-1026',
+      client: 'Brightwave Retail',
+      project: 'Store analytics dashboard',
+      amount: 58600,
+      status: 'At risk',
+      dueDate: '2025-03-14',
+      progress: 28,
+    },
+  ],
+  year: [
+    {
+      id: 'PX-1108',
+      client: 'Blue Horizon',
+      project: 'Customer intelligence platform',
+      amount: 186400,
+      status: 'In progress',
+      dueDate: '2025-06-22',
+      progress: 31,
+    },
+    {
+      id: 'PX-1099',
+      client: 'Vector Manufacturing',
+      project: 'Predictive maintenance system',
+      amount: 164800,
+      status: 'In review',
+      dueDate: '2025-07-09',
+      progress: 48,
+    },
+    {
+      id: 'PX-1084',
+      client: 'Evergreen Foods',
+      project: 'Supply chain visualisation',
+      amount: 121900,
+      status: 'Completed',
+      dueDate: '2024-10-28',
+      progress: 100,
+    },
+    {
+      id: 'PX-1072',
+      client: 'Harbor Insurance',
+      project: 'Claims automation suite',
+      amount: 143200,
+      status: 'At risk',
+      dueDate: '2025-05-17',
+      progress: 39,
+    },
+  ],
+}
+
+const TEAM_MEMBERS: TeamMember[] = [
+  {
+    id: 'team-1',
+    name: 'Nova Martinez',
+    role: 'Design Lead',
+    avatarColor: '#6366f1',
+    contributions: 24,
+    focus: 'Research synthesis',
+    hours: 32,
+  },
+  {
+    id: 'team-2',
+    name: 'Mikael Chen',
+    role: 'Product Strategist',
+    avatarColor: '#ec4899',
+    contributions: 18,
+    focus: 'Roadmap planning',
+    hours: 29,
+  },
+  {
+    id: 'team-3',
+    name: 'Priya Patel',
+    role: 'Engineering Manager',
+    avatarColor: '#22d3ee',
+    contributions: 31,
+    focus: 'Platform acceleration',
+    hours: 36,
+  },
+  {
+    id: 'team-4',
+    name: 'Caleb Wright',
+    role: 'Delivery Partner',
+    avatarColor: '#f97316',
+    contributions: 15,
+    focus: 'Client onboarding',
+    hours: 21,
+  },
+]
+
+const CHANNEL_DATA: Record<DashboardTimeframe, ChannelPerformance[]> = {
+  week: [
+    { id: 'channel-1', channel: 'Referrals', leads: 28, opportunities: 14, conversionRate: 0.48, trend: 6.2 },
+    { id: 'channel-2', channel: 'Newsletter', leads: 32, opportunities: 12, conversionRate: 0.37, trend: 3.8 },
+    { id: 'channel-3', channel: 'LinkedIn', leads: 21, opportunities: 9, conversionRate: 0.42, trend: 4.9 },
+  ],
+  month: [
+    { id: 'channel-1', channel: 'Referrals', leads: 132, opportunities: 68, conversionRate: 0.52, trend: 7.4 },
+    { id: 'channel-2', channel: 'Webinars', leads: 96, opportunities: 42, conversionRate: 0.44, trend: 5.3 },
+    { id: 'channel-3', channel: 'LinkedIn', leads: 84, opportunities: 33, conversionRate: 0.39, trend: 4.8 },
+    { id: 'channel-4', channel: 'Newsletter', leads: 102, opportunities: 36, conversionRate: 0.35, trend: 3.6 },
+  ],
+  quarter: [
+    { id: 'channel-1', channel: 'Referrals', leads: 384, opportunities: 182, conversionRate: 0.47, trend: 6.9 },
+    { id: 'channel-2', channel: 'Enterprise events', leads: 266, opportunities: 121, conversionRate: 0.46, trend: 7.1 },
+    { id: 'channel-3', channel: 'LinkedIn', leads: 218, opportunities: 84, conversionRate: 0.39, trend: 4.3 },
+    { id: 'channel-4', channel: 'Advisory content', leads: 204, opportunities: 77, conversionRate: 0.38, trend: 4.9 },
+  ],
+  year: [
+    { id: 'channel-1', channel: 'Referrals', leads: 1340, opportunities: 612, conversionRate: 0.46, trend: 6.2 },
+    { id: 'channel-2', channel: 'Partnerships', leads: 986, opportunities: 418, conversionRate: 0.42, trend: 5.5 },
+    { id: 'channel-3', channel: 'Thought leadership', leads: 842, opportunities: 307, conversionRate: 0.36, trend: 4.3 },
+    { id: 'channel-4', channel: 'Paid media', leads: 764, opportunities: 268, conversionRate: 0.31, trend: 3.1 },
+  ],
+}
+
+const ANNOUNCEMENTS: Announcement[] = [
+  {
+    id: 'announce-1',
+    title: 'January reporting window',
+    message: 'Submit partner performance scorecards by 21 January. Templates are pre-filled with CRM metrics.',
+    date: '2025-01-12',
+  },
+  {
+    id: 'announce-2',
+    title: 'Growth playbook 2.1',
+    message: 'New discovery scripts and objection handling flows are now available in the enablement hub.',
+    date: '2025-01-10',
+  },
+  {
+    id: 'announce-3',
+    title: 'Design asset refresh',
+    message: 'Updated TailAdmin illustration set launched to marketing. Use v2 components for all paid channels.',
+    date: '2025-01-08',
+  },
+]
+
+const getValidTimeframe = (timeframe?: DashboardTimeframe | string | null): DashboardTimeframe => {
+  if (timeframe && DASHBOARD_TIMEFRAMES.includes(timeframe as DashboardTimeframe)) {
+    return timeframe as DashboardTimeframe
+  }
+  return DEFAULT_TIMEFRAME
+}
+
+const sumNumbers = (values: number[]): number =>
+  values.reduce((total, value) => total + value, 0)
+
+const computeRevenueSummary = (series: RevenuePoint[]): RevenueSummary => {
+  const totalRevenue = sumNumbers(series.map(point => point.revenue))
+  const totalProfit = sumNumbers(series.map(point => point.profit))
+  const averageMargin = series.length === 0 ? 0 : Math.round((totalProfit / totalRevenue) * 100)
+  return {
+    series,
+    totalRevenue,
+    totalProfit,
+    averageMargin: Number.isFinite(averageMargin) ? averageMargin : 0,
+  }
+}
+
+const computeChannelSummary = (channels: ChannelPerformance[]): ChannelSummary => {
+  if (channels.length === 0) {
+    return {
+      totalLeads: 0,
+      strongestChannel: {
+        id: 'channel-empty',
+        channel: 'No data',
+        leads: 0,
+        opportunities: 0,
+        conversionRate: 0,
+        trend: 0,
+      },
+      averageConversion: 0,
+    }
+  }
+
+  const totalLeads = sumNumbers(channels.map(channel => channel.leads))
+  const strongestChannel = [...channels].sort(
+    (a, b) => b.conversionRate * b.opportunities - a.conversionRate * a.opportunities,
+  )[0]
+  const averageConversion =
+    channels.reduce((total, channel) => total + channel.conversionRate, 0) / channels.length
+
+  return {
+    totalLeads,
+    strongestChannel,
+    averageConversion: Math.round(averageConversion * 1000) / 10,
+  }
+}
+
+export const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: value >= 1000 ? 0 : 2,
+  }).format(value)
+
+export const formatNumber = (value: number): string =>
+  new Intl.NumberFormat('en-US').format(value)
+
+export const formatPercentage = (value: number): string => {
+  const normalised = value > 1 ? value : value * 100
+  return `${Math.round(normalised * 10) / 10}%`
+}
+
+export const buildDashboardSnapshot = (timeframe?: DashboardTimeframe | string | null): DashboardSnapshot => {
+  const safeTimeframe = getValidTimeframe(timeframe)
+  const metrics = METRIC_DATA[safeTimeframe]
+  const revenueSeries = REVENUE_DATA[safeTimeframe]
+  const pipeline = PIPELINE_DATA[safeTimeframe]
+  const channels = CHANNEL_DATA[safeTimeframe]
+
+  return {
+    timeframe: safeTimeframe,
+    metrics,
+    revenue: computeRevenueSummary(revenueSeries),
+    pipeline,
+    team: TEAM_MEMBERS,
+    channels,
+    highlights: ANNOUNCEMENTS,
+    channelSummary: computeChannelSummary(channels),
+  }
+}
+
+export type { Metric, RevenuePoint, PipelineItem, TeamMember, ChannelPerformance, Announcement, RevenueSummary, ChannelSummary }
+export { DEFAULT_TIMEFRAME as defaultDashboardTimeframe, ANNOUNCEMENTS as dashboardAnnouncements }


### PR DESCRIPTION
## Summary
- rebuild the dashboard screen around the new navigation/topbar shell with timeframe controls, metrics, charts, and announcements
- add a portfolio projects card that integrates import/export actions and project stats into the refreshed layout
- source dashboard snapshot data and formatting helpers from a shared dashboardData utility and add dedicated styling for the new experience

## Testing
- npm run test *(fails: vitest binary missing in workspace images)*

------
https://chatgpt.com/codex/tasks/task_e_68cf06bb8c84832f9cc2f8b029707747