### PR TITLE
Add vitest configs to monorepo and ready Fastify server

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -30,6 +30,8 @@ export const buildServer = async () => {
   await server.register(templatesRoute, { prefix: '/templates' });
   await server.register(exportRoute, { prefix: '/export' });
 
+  await server.ready();
+
   return server;
 };
 

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+const toPath = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+    },
+  },
+  resolve: {
+    alias: {
+      '@portfolioforge/schemas': toPath('../../packages/schemas/src'),
+      '@portfolioforge/ui': toPath('../../packages/ui/src'),
+    },
+  },
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+const toPath = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+    },
+  },
+  resolve: {
+    alias: {
+      '@portfolioforge/schemas': toPath('../../packages/schemas/src'),
+      '@portfolioforge/ui': toPath('../../packages/ui/src'),
+    },
+  },
+});

--- a/packages/schemas/vitest.config.ts
+++ b/packages/schemas/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+const toPath = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+    },
+  },
+  resolve: {
+    alias: {
+      '@portfolioforge/schemas': toPath('./src'),
+    },
+  },
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+const toPath = (path: string) => fileURLToPath(new URL(path, import.meta.url));
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+    },
+    passWithNoTests: true,
+  },
+  resolve: {
+    alias: {
+      '@portfolioforge/ui': toPath('./src'),
+      '@portfolioforge/schemas': toPath('../schemas/src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add dedicated Vitest configs for each workspace so tests use local path aliases without requiring unavailable Vite plugins
- ensure the Fastify API server waits for plugin registration to finish before handling requests, preventing flaky test startup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d009cdf320832f8d331ca0cd00cb0c